### PR TITLE
Tidy password messages

### DIFF
--- a/lib/Controller/PasswordController.php
+++ b/lib/Controller/PasswordController.php
@@ -150,7 +150,7 @@ class PasswordController extends Controller implements IAccountModuleController 
 		if(!$this->userManager->checkPassword($user->getUID(), $current_password)) {
 			return $this->createPasswordTemplateResponse(
 				$redirect_url,
-				$this->l10n->t('Incorrect password supplied.')
+				$this->l10n->t('Incorrect current password supplied.')
 			);
 		}
 

--- a/lib/Engine.php
+++ b/lib/Engine.php
@@ -130,7 +130,7 @@ class Engine {
 		}
 		if ($this->yes('spv_special_chars_checked')) {
 			$val = $this->configValues['spv_special_chars_value'];
-			$chars = [];
+			$chars = '';
 			if ($this->yes('spv_def_special_chars_checked')) {
 				$chars = $this->configValues['spv_def_special_chars_value'];
 			}

--- a/lib/Engine.php
+++ b/lib/Engine.php
@@ -109,27 +109,27 @@ class Engine {
 	 */
 	public function verifyPassword($password, $uid = null) {
 		if ($this->yes('spv_min_chars_checked')) {
-			$val = $this->configValues['spv_min_chars_value'];
+			$val = (int) $this->configValues['spv_min_chars_value'];
 			$r = new Length($this->l10n);
 			$r->verify($password, $val);
 		}
 		if ($this->yes('spv_lowercase_checked')) {
-			$val = $this->configValues['spv_lowercase_value'];
+			$val = (int) $this->configValues['spv_lowercase_value'];
 			$r = new Lowercase($this->l10n);
 			$r->verify($password, $val);
 		}
 		if ($this->yes('spv_uppercase_checked')) {
-			$val = $this->configValues['spv_uppercase_value'];
+			$val = (int) $this->configValues['spv_uppercase_value'];
 			$r = new Uppercase($this->l10n);
 			$r->verify($password, $val);
 		}
 		if ($this->yes('spv_numbers_checked')) {
-			$val = $this->configValues['spv_numbers_value'];
+			$val = (int) $this->configValues['spv_numbers_value'];
 			$r = new Numbers($this->l10n);
 			$r->verify($password, $val);
 		}
 		if ($this->yes('spv_special_chars_checked')) {
-			$val = $this->configValues['spv_special_chars_value'];
+			$val = (int) $this->configValues['spv_special_chars_value'];
 			$chars = '';
 			if ($this->yes('spv_def_special_chars_checked')) {
 				$chars = $this->configValues['spv_def_special_chars_value'];
@@ -138,7 +138,7 @@ class Engine {
 			$r->verify($password, $val, $chars);
 		}
 		if ($uid !== null && $this->yes('spv_password_history_checked')) {
-			$val = $this->configValues['spv_password_history_value'];
+			$val = (int) $this->configValues['spv_password_history_value'];
 			$dbMapper = new OldPasswordMapper($this->db);
 			$r = new PasswordHistory($this->l10n, $dbMapper, $this->hasher);
 			$r->verify($password, $val, $uid);

--- a/lib/Rules/Length.php
+++ b/lib/Rules/Length.php
@@ -24,8 +24,8 @@ namespace OCA\PasswordPolicy\Rules;
 class Length extends Base {
 
 	/**
-	 * @param $password
-	 * @param $val
+	 * @param string $password
+	 * @param int $val
 	 * @throws PolicyException
 	 */
 	public function verify($password, $val) {

--- a/lib/Rules/Lowercase.php
+++ b/lib/Rules/Lowercase.php
@@ -24,14 +24,19 @@ namespace OCA\PasswordPolicy\Rules;
 class Lowercase extends Base {
 
 	/**
-	 * @param $password
-	 * @param $val
+	 * @param string $password
+	 * @param int $val
 	 * @throws PolicyException
 	 */
 	public function verify($password, $val) {
 		if ($this->countLowercase($password) < $val) {
 			throw new PolicyException(
-				$this->l10n->t('The password contains too few lowercase characters. At least %d lowercase characters are required.', [$val]));
+				$this->l10n->n(
+					'The password contains too few lowercase letters. At least one lowercase letter is required.',
+					'The password contains too few lowercase letters. At least %n lowercase letters are required.',
+					$val
+				)
+			);
 		}
 	}
 

--- a/lib/Rules/Numbers.php
+++ b/lib/Rules/Numbers.php
@@ -24,14 +24,19 @@ namespace OCA\PasswordPolicy\Rules;
 class Numbers extends Base {
 
 	/**
-	 * @param $password
-	 * @param $val
+	 * @param string $password
+	 * @param int $val
 	 * @throws PolicyException
 	 */
 	public function verify($password, $val) {
 		if ($this->countDigits($password) < $val) {
 			throw new PolicyException(
-				$this->l10n->t('The password contains too few numbers. At least %d numbers are required.', [$val]));
+				$this->l10n->n(
+					'The password contains too few numbers. At least one number is required.',
+					'The password contains too few numbers. At least %n numbers are required.',
+					$val
+				)
+			);
 		}
 	}
 

--- a/lib/Rules/Special.php
+++ b/lib/Rules/Special.php
@@ -25,7 +25,7 @@ class Special extends Base {
 
 	/**
 	 * @param string $password
-	 * @param string $val
+	 * @param int $val
 	 * @param string $allowedSpecialChars
 	 * @throws PolicyException
 	 */
@@ -42,8 +42,24 @@ class Special extends Base {
 			}
 		}
 		if (\strlen($special) < $val) {
-			throw new PolicyException(
-				$this->l10n->t('The password contains too few special characters. A minimum of %d special characters are required.', [$val]));
+			if (!empty($allowedSpecialChars)) {
+				throw new PolicyException(
+					$this->l10n->n(
+						'The password contains too few special characters. At least one special character (%s) is required.',
+						'The password contains too few special characters. At least %n special characters (%s) are required.',
+						$val,
+						[$allowedSpecialChars]
+					)
+				);
+			} else {
+				throw new PolicyException(
+					$this->l10n->n(
+						'The password contains too few special characters. At least one special character is required.',
+						'The password contains too few special characters. At least %n special characters are required.',
+						$val
+					)
+				);
+			}
 		}
 	}
 

--- a/lib/Rules/Uppercase.php
+++ b/lib/Rules/Uppercase.php
@@ -24,18 +24,23 @@ namespace OCA\PasswordPolicy\Rules;
 class Uppercase extends Base {
 
 	/**
-	 * @param $password
-	 * @param $val
+	 * @param string $password
+	 * @param int $val
 	 * @throws PolicyException
 	 */
 	public function verify($password, $val) {
-		if ($this->countCapitals($password) < $val) {
+		if ($this->countUppercase($password) < $val) {
 			throw new PolicyException(
-				$this->l10n->t('The password contains too few uppercase characters. A minimum of %d uppercase characters are required.', [$val]));
+				$this->l10n->n(
+					'The password contains too few uppercase letters. At least one uppercase letter is required.',
+					'The password contains too few uppercase letters. At least %n uppercase letters are required.',
+					$val
+				)
+			);
 		}
 	}
 
-	private function countCapitals($s) {
+	private function countUppercase($s) {
 		$split = \preg_split('//u', $s, -1, PREG_SPLIT_NO_EMPTY);
 
 		$count = 0;

--- a/tests/Controller/PasswordControllerTest.php
+++ b/tests/Controller/PasswordControllerTest.php
@@ -170,7 +170,7 @@ class PasswordControllerTest extends TestCase {
 		$redirect_url = 'redirect/target';
 		$this->c->expects($this->once())
 			->method('createPasswordTemplateResponse')
-			->with($redirect_url, 'Incorrect password supplied.');
+			->with($redirect_url, 'Incorrect current password supplied.');
 
 		$user
 			->expects($this->never())

--- a/tests/Rules/LowercaseTest.php
+++ b/tests/Rules/LowercaseTest.php
@@ -41,13 +41,30 @@ class LowercaseTest extends TestCase {
 			->will($this->returnCallback(function($text, $parameters = array()) {
 				return vsprintf($text, $parameters);
 			}));
+		$l10n
+			->method('n')
+			->will($this->returnCallback(function($text_singular, $text_plural, $count, $parameters = array()) {
+				if ($count === 1) {
+					return (string) vsprintf(str_replace('%n', $count, $text_singular), $parameters);
+				} else {
+					return (string) vsprintf(str_replace('%n', $count, $text_plural), $parameters);
+				}
+			}));
 
 		$this->r = new Lowercase($l10n);
 	}
 
 	/**
 	 * @expectedException \OCA\PasswordPolicy\Rules\PolicyException
-	 * @expectedExceptionMessage The password contains too few lowercase characters. At least 4 lowercase characters are required.
+	 * @expectedExceptionMessage The password contains too few lowercase letters. At least one lowercase letter is required.
+	 */
+	public function testNoLowercase() {
+		$this->r->verify('AB', 1);
+	}
+
+	/**
+	 * @expectedException \OCA\PasswordPolicy\Rules\PolicyException
+	 * @expectedExceptionMessage The password contains too few lowercase letters. At least 4 lowercase letters are required.
 	 */
 	public function testTooShort() {
 		$this->r->verify('ab', 4);
@@ -62,7 +79,7 @@ class LowercaseTest extends TestCase {
 
 	/**
 	 * @expectedException \OCA\PasswordPolicy\Rules\PolicyException
-	 * @expectedExceptionMessage The password contains too few lowercase characters. At least 5 lowercase characters are required.
+	 * @expectedExceptionMessage The password contains too few lowercase letters. At least 5 lowercase letters are required.
 	 */
 	public function testSpecialLowerCaseTooShort() {
 		$this->r->verify('ÑÑÑÑÑÑÑÑÑñ', 5);
@@ -77,7 +94,7 @@ class LowercaseTest extends TestCase {
 
 	/**
 	 * @expectedException \OCA\PasswordPolicy\Rules\PolicyException
-	 * @expectedExceptionMessage The password contains too few lowercase characters. At least 5 lowercase characters are required.
+	 * @expectedExceptionMessage The password contains too few lowercase letters. At least 5 lowercase letters are required.
 	 */
 	public function testNumericOnlyTooShort() {
 		$this->r->verify('11111111', 5);
@@ -85,7 +102,7 @@ class LowercaseTest extends TestCase {
 
 	/**
 	 * @expectedException \OCA\PasswordPolicy\Rules\PolicyException
-	 * @expectedExceptionMessage The password contains too few lowercase characters. At least 5 lowercase characters are required.
+	 * @expectedExceptionMessage The password contains too few lowercase letters. At least 5 lowercase letters are required.
 	 */
 	public function testSpecialOnlyTooShort() {
 		$this->r->verify('#+?@#+?@', 5);

--- a/tests/Rules/NumbersTest.php
+++ b/tests/Rules/NumbersTest.php
@@ -40,8 +40,25 @@ class NumbersTest extends \Test\TestCase {
 			->will($this->returnCallback(function($text, $parameters = array()) {
 				return vsprintf($text, $parameters);
 			}));
+		$l10n
+			->method('n')
+			->will($this->returnCallback(function($text_singular, $text_plural, $count, $parameters = array()) {
+				if ($count === 1) {
+					return (string) vsprintf(str_replace('%n', $count, $text_singular), $parameters);
+				} else {
+					return (string) vsprintf(str_replace('%n', $count, $text_plural), $parameters);
+				}
+			}));
 
 		$this->r = new Numbers($l10n);
+	}
+
+	/**
+	 * @expectedException \OCA\PasswordPolicy\Rules\PolicyException
+	 * @expectedExceptionMessage The password contains too few numbers. At least one number is required.
+	 */
+	public function testNoNumbers() {
+		$this->r->verify('ab', 1);
 	}
 
 	/**
@@ -49,7 +66,7 @@ class NumbersTest extends \Test\TestCase {
 	 * @expectedExceptionMessage The password contains too few numbers. At least 4 numbers are required.
 	 */
 	public function testTooShort() {
-		$this->r->verify('ab', 4);
+		$this->r->verify('ab123', 4);
 	}
 
 	/**

--- a/tests/Rules/UppercaseTest.php
+++ b/tests/Rules/UppercaseTest.php
@@ -41,16 +41,33 @@ class UppercaseTest extends TestCase {
 			->will($this->returnCallback(function($text, $parameters = array()) {
 				return vsprintf($text, $parameters);
 			}));
+		$l10n
+			->method('n')
+			->will($this->returnCallback(function($text_singular, $text_plural, $count, $parameters = array()) {
+				if ($count === 1) {
+					return (string) vsprintf(str_replace('%n', $count, $text_singular), $parameters);
+				} else {
+					return (string) vsprintf(str_replace('%n', $count, $text_plural), $parameters);
+				}
+			}));
 
 		$this->r = new Uppercase($l10n);
 	}
 
 	/**
 	 * @expectedException \OCA\PasswordPolicy\Rules\PolicyException
-	 * @expectedExceptionMessage The password contains too few uppercase characters. A minimum of 4 uppercase characters are required.
+	 * @expectedExceptionMessage The password contains too few uppercase letters. At least one uppercase letter is required.
+	 */
+	public function testNoUppercase() {
+		$this->r->verify('ab', 1);
+	}
+
+	/**
+	 * @expectedException \OCA\PasswordPolicy\Rules\PolicyException
+	 * @expectedExceptionMessage The password contains too few uppercase letters. At least 4 uppercase letters are required.
 	 */
 	public function testTooShort() {
-		$this->r->verify('ab', 4);
+		$this->r->verify('AB', 4);
 	}
 
 	/**
@@ -62,7 +79,7 @@ class UppercaseTest extends TestCase {
 
 	/**
 	 * @expectedException \OCA\PasswordPolicy\Rules\PolicyException
-	 * @expectedExceptionMessage The password contains too few uppercase characters. A minimum of 5 uppercase characters are required.
+	 * @expectedExceptionMessage The password contains too few uppercase letters. At least 5 uppercase letters are required.
 	 */
 	public function testSpecialUpperCaseTooShort() {
 		$this->r->verify('Ññññññññññ', 5);
@@ -77,7 +94,7 @@ class UppercaseTest extends TestCase {
 
 	/**
 	 * @expectedException \OCA\PasswordPolicy\Rules\PolicyException
-	 * @expectedExceptionMessage The password contains too few uppercase characters. A minimum of 5 uppercase characters are required.
+	 * @expectedExceptionMessage The password contains too few uppercase letters. At least 5 uppercase letters are required.
 	 */
 	public function testNumericOnlyTooShort() {
 		$this->r->verify('11111111', 5);
@@ -85,7 +102,7 @@ class UppercaseTest extends TestCase {
 
 	/**
 	 * @expectedException \OCA\PasswordPolicy\Rules\PolicyException
-	 * @expectedExceptionMessage The password contains too few uppercase characters. A minimum of 5 uppercase characters are required.
+	 * @expectedExceptionMessage The password contains too few uppercase letters. At least 5 uppercase letters are required.
 	 */
 	public function testSpecialOnlyTooShort() {
 		$this->r->verify('#+?@#+?@', 5);


### PR DESCRIPTION
Fixes issue #20 

1) ``Engine.php`` was passing an empty array instead of empty string when the required special chars are not enabled - fix it.
2) When the user inputs the current password wrong, the message is "Incorrect password supplied". Be more explicit and say "Incorrect current password supplied".
3) Change "A minimum of..." to "At least..." in password error messages, making them all consistent.
4) Handle singular and plural for when only 1 or many of a character category are required.
5) When particular special characters are required, put those in the message so the user has some clue which special characters they have to use.