### PR TITLE
send notification when passwords are about to expire

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -61,3 +61,16 @@ $eventDispatcher->addListener(
 	\OCP\IUser::class . '::firstLogin',
 	[$handler, 'checkForcePasswordChangeOnFirstLogin']
 );
+
+$app = new \OCA\PasswordPolicy\AppInfo\Application();
+$app->registerNotifier();
+
+// only load notification JS code in the logged in layout page (not public links not login page)
+$request = \OC::$server->getRequest();
+if (\OC::$server->getUserSession() !== null && \OC::$server->getUserSession()->getUser() !== null
+	&& substr($request->getScriptName(), 0 - strlen('/index.php')) === '/index.php'
+	&& substr($request->getPathInfo(), 0, strlen('/s/')) !== '/s/'
+	&& substr($request->getPathInfo(), 0, strlen('/login')) !== '/login') {
+
+	\OCP\Util::addScript('password_policy', 'notification');
+}

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,12 +12,12 @@ The definition of certain password rules support administrators in the task of e
 Password history and expiration policies are supplements that allow IT to establish a level of password security that can comply with corporate guidelines of all sorts. The provided tools enable administrators to granularly choose their desired security level. At this point it is important to keep in mind that high levels of security might sacrifice usability and come at the expense of user experience. For this reason it is highly recommended to check [best practices](https://pages.nist.gov/800-63-3/sp800-63b.html) and decide carefully on the hurdles that are put upon users in order to maintain and optimize user adoption and satisfaction.
 
 Administrators find the configuration options in the 'Security' section of the ownCloud administration settings panel. The respective policies are designed for local user accounts, not for user accounts imported from LDAP or other user backends as these provide their own mechanisms. For more information and recommendations when deploying policies in an existing ownCloud, please consult the [ownCloud Documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/security/password-policy.html).</description>
-	<version>2.0.0</version>
+	<version>2.0.1</version>
 	<documentation>
 		<admin>https://doc.owncloud.com/server/10.0/admin_manual/configuration/server/security/password_policy.html</admin>
 	</documentation>
 	<dependencies>
-		<owncloud min-version="10.0.5" max-version="10.1" />
+		<owncloud min-version="10.0.9" max-version="10.1" />
 	</dependencies>
 	<namespace>PasswordPolicy</namespace>
 	<settings>
@@ -30,6 +30,9 @@ Administrators find the configuration options in the 'Security' section of the o
 	<account-modules>
 		<module>OCA\PasswordPolicy\Authentication\AccountModule</module>
 	</account-modules>
+	<background-jobs>
+		<job>OCA\PasswordPolicy\Jobs\PasswordExpirationNotifierJob</job>
+	</background-jobs>
 
 	<screenshot>https://raw.githubusercontent.com/owncloud/screenshots/master/password_policy/owncloud-app-password_policy.jpg</screenshot>
 	<screenshot>https://raw.githubusercontent.com/owncloud/screenshots/master/password_policy/owncloud-app-password_policy2.jpg</screenshot>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,7 +12,7 @@ The definition of certain password rules support administrators in the task of e
 Password history and expiration policies are supplements that allow IT to establish a level of password security that can comply with corporate guidelines of all sorts. The provided tools enable administrators to granularly choose their desired security level. At this point it is important to keep in mind that high levels of security might sacrifice usability and come at the expense of user experience. For this reason it is highly recommended to check [best practices](https://pages.nist.gov/800-63-3/sp800-63b.html) and decide carefully on the hurdles that are put upon users in order to maintain and optimize user adoption and satisfaction.
 
 Administrators find the configuration options in the 'Security' section of the ownCloud administration settings panel. The respective policies are designed for local user accounts, not for user accounts imported from LDAP or other user backends as these provide their own mechanisms. For more information and recommendations when deploying policies in an existing ownCloud, please consult the [ownCloud Documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/security/password-policy.html).</description>
-	<version>2.0.1</version>
+	<version>2.0.0</version>
 	<documentation>
 		<admin>https://doc.owncloud.com/server/10.0/admin_manual/configuration/server/security/password_policy.html</admin>
 	</documentation>

--- a/js/notification.js
+++ b/js/notification.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2018 Vincent Petry <pvince81@owncloud.com>
+ *
+ * This file is licensed under the Affero General Public License version 3
+ * or later.
+ *
+ * See the COPYING-README file.
+ *
+ */
+(function () {
+
+	$(document).ready(function() {
+		// convert action URL to redirect
+		$('body').on('OCA.Notification.Action', function(e) {
+			if (e.notification.app === 'password_policy'
+				&& (e.notification.object_type === 'about_to_expire' || e.notification.object_type === 'expired')
+				&& e.action.type === 'GET'
+			) {
+				OC.redirect(e.notification.link);
+				return false;
+			}
+		});
+	});
+})();
+

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -21,6 +21,8 @@
 namespace OCA\PasswordPolicy\AppInfo;
 
 use OCP\AppFramework\App;
+use OCP\Notification\Events\RegisterNotifierEvent;
+use OCA\PasswordPolicy\Notifier;
 
 class Application extends App {
 
@@ -28,4 +30,15 @@ class Application extends App {
 		parent::__construct('password_policy', $urlParams);
 	}
 
+	/**
+	 * Registers the notifier
+	 */
+	public function registerNotifier() {
+		$container = $this->getContainer();
+		$dispatcher = $container->getServer()->getEventDispatcher();
+		$dispatcher->addListener(RegisterNotifierEvent::NAME, function (RegisterNotifierEvent $event) use ($container) {
+			$l10n = $container->getServer()->getL10N('password_policy');
+			$event->registerNotifier($container->query(Notifier::class), 'password_policy', $l10n->t('Password Policy'));
+		});
+	}
 }

--- a/lib/Controller/PasswordController.php
+++ b/lib/Controller/PasswordController.php
@@ -141,7 +141,7 @@ class PasswordController extends Controller implements IAccountModuleController 
 		if ($new_password !== $confirm_password) {
 			return $this->createPasswordTemplateResponse(
 				$redirect_url,
-				$this->l10n->t('New passwords are not the same.')
+				$this->l10n->t('Password confirmation does not match the password.')
 			);
 		}
 
@@ -150,7 +150,7 @@ class PasswordController extends Controller implements IAccountModuleController 
 		if(!$this->userManager->checkPassword($user->getUID(), $current_password)) {
 			return $this->createPasswordTemplateResponse(
 				$redirect_url,
-				$this->l10n->t('Incorrect current password supplied.')
+				$this->l10n->t('The current password is incorrect.')
 			);
 		}
 

--- a/lib/Db/OldPasswordMapper.php
+++ b/lib/Db/OldPasswordMapper.php
@@ -87,7 +87,7 @@ class OldPasswordMapper extends Mapper {
 			$info = \json_encode($stmt->erroInfo());
 			$message = "Cannot get the passwords that are about to expire. Error: {$info}";
 			\OCP\Util::writeLog('password_policy', $message, \OCP\Util::ERROR);
-			return false;
+			return;
 		}
 
 		while ($row = $stmt->fetch()) {

--- a/lib/Db/OldPasswordMapper.php
+++ b/lib/Db/OldPasswordMapper.php
@@ -63,4 +63,39 @@ class OldPasswordMapper extends Mapper {
 		}
 		return $passwords[0];
 	}
+
+	/**
+	 * Get the passwords that are about to expire or already expired.
+	 * Last passwords which have been changed before the timestamp are the ones
+	 * selectable. Previous stored passwords won't be included
+	 * In addition, passwords from multiple users are expected
+	 * @param int $maxTimestamp timestamp marker, last passwords changed before
+	 * the timestamp will be selected
+	 * @return OldPassword[] the selected passwords
+	 */
+	public function getPasswordsAboutToExpire($maxTimestamp) {
+		$oldPasswords = [];
+
+		$query = "SELECT `f`.`id`, `f`.`uid`, `f`.`password`, `f`.`change_time` FROM (";
+		$query .= "SELECT `uid`, max(`change_time`) AS `maxtime` FROM `*PREFIX*user_password_history` GROUP BY `uid`";
+		$query .= ") AS `x` INNER JOIN `*PREFIX*user_password_history` AS `f` ON `f`.`uid` = `x`.`uid` AND `f`.`change_time` = `x`.`maxtime`";
+		$query .= " WHERE `f`.`change_time` < ?";
+
+		$stmt = $this->db->prepare($query);
+		$stmt->bindValue(1, $maxTimestamp);
+		$result = $stmt->execute();
+
+		if ($result === false) {
+			$info = \json_encode($stmt->erroInfo());
+			$message = "Cannot get the passwords that are about to expire. Error: {$info}";
+			\OCP\Util::writeLog('password_policy', $message, \OCP\Util::ERROR);
+			return false;
+		}
+
+		while ($row = $stmt->fetch()) {
+			$oldPasswords[] = OldPassword::fromRow($row);
+		}
+		$stmt->closeCursor();
+		return $oldPasswords;
+	}
 }

--- a/lib/Db/OldPasswordMapper.php
+++ b/lib/Db/OldPasswordMapper.php
@@ -71,11 +71,9 @@ class OldPasswordMapper extends Mapper {
 	 * In addition, passwords from multiple users are expected
 	 * @param int $maxTimestamp timestamp marker, last passwords changed before
 	 * the timestamp will be selected
-	 * @return OldPassword[] the selected passwords
+	 * @return Generator to traverse the selected passwords
 	 */
 	public function getPasswordsAboutToExpire($maxTimestamp) {
-		$oldPasswords = [];
-
 		$query = "SELECT `f`.`id`, `f`.`uid`, `f`.`password`, `f`.`change_time` FROM (";
 		$query .= "SELECT `uid`, max(`change_time`) AS `maxtime` FROM `*PREFIX*user_password_history` GROUP BY `uid`";
 		$query .= ") AS `x` INNER JOIN `*PREFIX*user_password_history` AS `f` ON `f`.`uid` = `x`.`uid` AND `f`.`change_time` = `x`.`maxtime`";
@@ -93,9 +91,8 @@ class OldPasswordMapper extends Mapper {
 		}
 
 		while ($row = $stmt->fetch()) {
-			$oldPasswords[] = OldPassword::fromRow($row);
+			yield OldPassword::fromRow($row);
 		}
 		$stmt->closeCursor();
-		return $oldPasswords;
 	}
 }

--- a/lib/Jobs/PasswordExpirationNotifierJob.php
+++ b/lib/Jobs/PasswordExpirationNotifierJob.php
@@ -107,6 +107,15 @@ class PasswordExpirationNotifierJob extends TimedJob {
 		}
 	}
 
+	/**
+	 * Send an "about to expire" notification using the password information
+	 * in $passInfo. The password should expire after $expirationTime (90 days
+	 * by default). This information will also be used in the notification
+	 * @param OldPassword $passInfo the password information used to send the
+	 * notification
+	 * @param int $expirationTime the time to expire the password in seconds
+	 * (for example, 90 days - in seconds)
+	 */
 	private function sendAboutToExpireNotification(OldPassword $passInfo, $expirationTime) {
 		if ($this->unConfigHandler->isSentAboutToExpireNotification($passInfo)) {
 			return;  // notification already sent
@@ -134,6 +143,15 @@ class PasswordExpirationNotifierJob extends TimedJob {
 		$this->unConfigHandler->markAboutToExpireNotificationSentFor($passInfo);
 	}
 
+	/**
+	 * Send an "expired" notification using the password information
+	 * in $passInfo. The password should expire after $expirationTime (90 days
+	 * by default). This information will also be used in the notification
+	 * @param OldPassword $passInfo the password information used to send the
+	 * notification
+	 * @param int $expirationTime the time to expire the password in seconds
+	 * (for example, 90 days - in seconds)
+	 */
 	private function sendPassExpiredNotification(OldPassword $passInfo, $expirationTime) {
 		if ($this->unConfigHandler->isSentExpiredNotification($passInfo)) {
 			return;  // notification already sent

--- a/lib/Jobs/PasswordExpirationNotifierJob.php
+++ b/lib/Jobs/PasswordExpirationNotifierJob.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ *
+ * @author Juan Pablo Villafáñez <jvillafanez@solidgear.es>
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license GPL-2.0
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\PasswordPolicy\Jobs;
+
+use OC\BackgroundJob\TimedJob;
+use OCP\Notification\IManager;
+use OCP\IURLGenerator;
+use OCP\ILogger;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCA\PasswordPolicy\Db\OldPasswordMapper;
+use OCA\PasswordPolicy\Db\OldPassword;
+use OCA\PasswordPolicy\UserNotificationConfigHandler;
+
+class PasswordExpirationNotifierJob extends TimedJob {
+	/** @var OldPasswordMapper */
+	private $mapper;
+
+	/** @var $manager */
+	private $manager;
+
+	/** @var UserNotificationConfigHandler */
+	private $unConfigHandler;
+
+	/** @var ITimeFactory */
+	private $timeFactory;
+
+	/** @var IURLGenerator */
+	private $urlGenerator;
+
+	/** @var ILogger */
+	private $logger;
+
+	public function __construct(
+		OldPasswordMapper $mapper,
+		IManager $manager,
+		UserNotificationConfigHandler $unConfigHandler,
+		ITimeFactory $timeFactory,
+		IURLGenerator $urlGenerator,
+		ILogger $logger
+	) {
+		$this->mapper = $mapper;
+		$this->manager = $manager;
+		$this->unConfigHandler = $unConfigHandler;
+		$this->timeFactory = $timeFactory;
+		$this->urlGenerator = $urlGenerator;
+		$this->logger = $logger;
+
+		$this->setInterval(12 * 60 * 60);
+	}
+
+	protected function run($arguments) {
+		$expirationTime = $this->unConfigHandler->getExpirationTime();
+		if ($expirationTime === null) {
+			return;  // expiration not configured
+		}
+
+		$expirationTimeNotification = $this->unConfigHandler->getExpirationTimeForNormalNotification();
+		if ($expirationTimeNotification === null) {
+			$expirationTimeNotification = 0;
+		}
+
+		// ensure ranges are correct
+		if ($expirationTime <= $expirationTimeNotification) {
+			$message = "wrong expiration range: normal ($expirationTimeNotification) < expired ($expirationTime)";
+			$this->logger->warning($message, ['app' => 'password_policy']);
+			return;
+		}
+
+		$notifyAfter = $expirationTime - $expirationTimeNotification;
+
+		$currentTime = $this->timeFactory->getTime();
+
+		$maxTimestamp = $currentTime - $notifyAfter;
+		// passwords changed before $maxTimestamp are expired or about to be expired
+		// according to the expiration time range
+
+		$oldPasswordsAboutToExpire = $this->mapper->getPasswordsAboutToExpire($maxTimestamp);
+		foreach ($oldPasswordsAboutToExpire as $passInfo) {
+			$elapsedTime = $currentTime - $passInfo->getChangeTime();
+			if ($elapsedTime >= $expirationTime) {
+				$this->logger->debug("password timestamp for {$passInfo->getUid()}: {$passInfo->getChangeTime()}; elapsed time: {$elapsedTime} -> EXPIRED", ['app' => 'password_policy']);
+				$this->sendPassExpiredNotification($passInfo, $expirationTime);
+			} elseif ($elapsedTime >= $notifyAfter) {
+				$this->logger->debug("password timestamp for {$passInfo->getUid()}: {$passInfo->getChangeTime()}; elapsed time: {$elapsedTime} -> NOTIFY", ['app' => 'password_policy']);
+				$this->sendAboutToExpireNotification($passInfo, $expirationTime);
+			}
+		}
+	}
+
+	private function sendAboutToExpireNotification(OldPassword $passInfo, $expirationTime) {
+		if ($this->unConfigHandler->isSentAboutToExpireNotification($passInfo)) {
+			return;  // notification already sent
+		}
+
+		$notificationTimestamp = $this->timeFactory->getTime();
+
+		// we'll use the id of the passInfo as object id and marker
+		$notification = $this->manager->createNotification();
+		$notification->setApp('password_policy')
+			->setUser($passInfo->getUid())
+			->setDateTime(new \DateTime("@{$notificationTimestamp}"))
+			->setObject('about_to_expire', $passInfo->getId())
+			->setSubject('about_to_expire', [$passInfo->getChangeTime(), $expirationTime])
+			->setMessage('about_to_expire', [$passInfo->getChangeTime(), $expirationTime])
+			->setLink($this->getNotificationLink());
+
+		$linkAction = $notification->createAction();
+		$linkAction->setLabel('Change password')
+			->setLink($this->getNotificationLink(), 'GET');
+		$notification->addAction($linkAction);
+
+		$this->manager->notify($notification);
+
+		$this->unConfigHandler->markAboutToExpireNotificationSentFor($passInfo);
+	}
+
+	private function sendPassExpiredNotification(OldPassword $passInfo, $expirationTime) {
+		if ($this->unConfigHandler->isSentExpiredNotification($passInfo)) {
+			return;  // notification already sent
+		}
+
+		$notificationTimestamp = $this->timeFactory->getTime();
+
+		// we'll use the id of the passInfo as object id and marker
+		$notification = $this->manager->createNotification();
+		$notification->setApp('password_policy')
+			->setUser($passInfo->getUid())
+			->setDateTime(new \DateTime("@{$notificationTimestamp}"))
+			->setObject('expired', $passInfo->getId())
+			->setSubject('expired', [$passInfo->getChangeTime(), $expirationTime])
+			->setMessage('expired', [$passInfo->getChangeTime(), $expirationTime])
+			->setLink($this->getNotificationLink());
+
+		$linkAction = $notification->createAction();
+		$linkAction->setLabel('Change password')
+			->setLink($this->getNotificationLink(), 'GET');
+		$notification->addAction($linkAction);
+
+		$this->manager->notify($notification);
+
+		$this->unConfigHandler->markExpiredNotificationSentFor($passInfo);
+	}
+
+	private function getNotificationLink() {
+		return $this->urlGenerator->linkToRouteAbsolute(
+			'settings.SettingsPage.getPersonal',
+			['sectionid' => 'general']
+		);
+	}
+}

--- a/lib/Notifier.php
+++ b/lib/Notifier.php
@@ -24,7 +24,7 @@ use OCP\Notification\INotifier;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\L10N\IFactory;
-use OC\L10N\L10N;
+use OCP\IL10N;
 
 class Notifier implements INotifier {
 	/** @var IFactory */
@@ -63,7 +63,7 @@ class Notifier implements INotifier {
 		}
 	}
 
-	private function formatAboutToExpire(INotification $notification, L10N $l) {
+	private function formatAboutToExpire(INotification $notification, IL10N $l) {
 		$params = $notification->getSubjectParameters();
 		$notification->setParsedSubject(
 			(string) $l->t('Password expiration notice', $params)
@@ -103,7 +103,7 @@ class Notifier implements INotifier {
 		return $notification;
 	}
 
-	private function formatExpired(INotification $notification, L10N $l) {
+	private function formatExpired(INotification $notification, IL10N $l) {
 		$params = $notification->getSubjectParameters();
 		$notification->setParsedSubject(
 			(string) $l->t('Your password has expired', $params)

--- a/lib/Notifier.php
+++ b/lib/Notifier.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * @author Juan Pablo Villafáñez <jvillafanez@solidgear.es>
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license GPL-2.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\PasswordPolicy;
+
+use OCP\Notification\INotification;
+use OCP\Notification\INotifier;
+use OCP\Notification\IManager as INotificationManager;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\L10N\IFactory;
+use OC\L10N\L10N;
+
+class Notifier implements INotifier {
+	/** @var IFactory */
+	protected $factory;
+
+	/** @var ITimeFactory */
+	protected $timeFactory;
+	/**
+	 * @param \OCP\L10N\IFactory $factory
+	 */
+	public function __construct(
+		IFactory $factory,
+		ITimeFactory $timeFactory
+	) {
+		$this->factory = $factory;
+		$this->timeFactory = $timeFactory;
+	}
+	/**
+	 * @param INotification $notification
+	 * @param string $languageCode The code of the language that should be used to prepare the notification
+	 * @return INotification
+	 */
+	public function prepare(INotification $notification, $languageCode) {
+		if ($notification->getApp() !== 'password_policy') {
+			throw new \InvalidArgumentException();
+		}
+		// Read the language from the notification
+		$l = $this->factory->get('password_policy', $languageCode);
+		switch ($notification->getObjectType()) {
+			case 'about_to_expire':
+				return $this->formatAboutToExpire($notification, $l);
+			case 'expired':
+				return $this->formatExpired($notification, $l);
+			default:
+				throw new \InvalidArgumentException();
+		}
+	}
+
+	private function formatAboutToExpire(INotification $notification, L10N $l) {
+		$params = $notification->getSubjectParameters();
+		$notification->setParsedSubject(
+			(string) $l->t('Password expiration notice', $params)
+		);
+
+		$messageParams = $notification->getMessageParameters();
+		$currentTime = $this->timeFactory->getTime();
+		$currentDateTime = new \DateTime("@{$currentTime}");
+		$passwordTime = $messageParams[0];
+		$expirationTime = $messageParams[1];
+		$targetExpirationTime = $passwordTime + $expirationTime;
+		$expirationDateTime = new \DateTime("@{$targetExpirationTime}");
+		$interval = $currentDateTime->diff($expirationDateTime);
+
+		if ($interval->invert) {
+			$notification->setParsedMessage(
+				(string) $l->t('Your password expired %1$s days ago', [$interval->days])
+			);
+		} else {
+			$notification->setParsedMessage(
+				(string) $l->t('You have %1$s days to change your password', [$interval->days])
+			);
+		}
+
+		foreach ($notification->getActions() as $action) {
+			switch ($action->getLabel()) {
+				case 'Change password':
+					$action->setParsedLabel(
+						(string) $l->t('Change Password')
+					);
+					break;
+			}
+
+			$notification->addParsedAction($action);
+		}
+
+		return $notification;
+	}
+
+	private function formatExpired(INotification $notification, L10N $l) {
+		$params = $notification->getSubjectParameters();
+		$notification->setParsedSubject(
+			(string) $l->t('Your password has expired', $params)
+		);
+
+		$messageParams = $notification->getMessageParameters();
+
+		$notification->setParsedMessage(
+			(string) $l->t('Please change your password to gain back access to your account', $messageParams)
+		);
+
+		foreach ($notification->getActions() as $action) {
+			switch ($action->getLabel()) {
+				case 'Change password':
+					$action->setParsedLabel(
+						(string) $l->t('Change Password')
+					);
+					break;
+			}
+
+			$notification->addParsedAction($action);
+		}
+
+		return $notification;
+	}
+}

--- a/lib/Rules/PasswordHistory.php
+++ b/lib/Rules/PasswordHistory.php
@@ -65,7 +65,7 @@ class PasswordHistory extends Base {
 		foreach($oldPasswords as $oldPassword) {
 			if ($this->hasher->verify($password, $oldPassword->getPassword())) {
 				throw new PolicyException(
-					$this->l10n->t('The password must be different to your previous %d passwords.', [$val]));
+					$this->l10n->t('The password must be different than your previous %d passwords.', [$val]));
 			}
 		}
 	}

--- a/lib/UserNotificationConfigHandler.php
+++ b/lib/UserNotificationConfigHandler.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ *
+ * @author Juan Pablo Villafáñez <jvillafanez@solidgear.es>
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license GPL-2.0
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\PasswordPolicy;
+
+use OCP\IConfig;
+use OCA\PasswordPolicy\Db\OldPassword;
+
+class UserNotificationConfigHandler {
+	const DEFAULT_EXPIRATION_FOR_NORMAL_NOTIFICATION = 30 * 24 * 60 * 60;  // 30 days
+
+	/** @var IConfig */
+	private $config;
+
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+	}
+
+	/**
+	 * Return the number of seconds until the passwords should expire or
+	 * null if it isn't set (or disabled) or has a non parseable value
+	 * @return int|null seconds
+	 */
+	public function getExpirationTime() {
+		$isChecked = $this->config->getAppValue(
+			'password_policy',
+			'spv_user_password_expiration_checked',
+			false
+		);
+		if (!\filter_var($isChecked, FILTER_VALIDATE_BOOLEAN)) {
+			return null;
+		}
+
+		$expirationTime = $this->config->getAppValue(
+			'password_policy',
+			'spv_user_password_expiration_value',
+			null
+		);
+		if ($expirationTime === null || !\is_numeric($expirationTime)) {
+			return null;  // passwords don't expire or have weird value
+		}
+		// the expiration time is currently stored in days, so we need to convert
+		// it to seconds.
+		return \intval($expirationTime) * 24 * 60 * 60;
+	}
+
+	/**
+	 * Return the number of seconds until a user should receive a notification
+	 * that his password is about to expire. This _should_ be less than the value
+	 * returned by the getExpirationTime function (you'll need to verify it outside)
+	 * It will return null if the value isn't set (or disabled) or it has a
+	 * non-parseable value
+	 * @return int|null seconds
+	 */
+	public function getExpirationTimeForNormalNotification() {
+		$isChecked = $this->config->getAppValue(
+			'password_policy',
+			'spv_user_password_expiration_notification_checked',
+			false
+		);
+		if (!\filter_var($isChecked, FILTER_VALIDATE_BOOLEAN)) {
+			return null;
+		}
+
+		$expirationTime = $this->config->getAppValue(
+			'password_policy',
+			'spv_user_password_expiration_notification_value',
+			self::DEFAULT_EXPIRATION_FOR_NORMAL_NOTIFICATION);
+		if ($expirationTime === null || !\is_numeric($expirationTime)) {
+			return null;  // passwords don't expire or have weird value
+		}
+		return \intval($expirationTime);
+	}
+
+	/**
+	 * Mark that a "password about to expire" notification has been sent.
+	 * Note that we're using the id of the passInfo as marker, but this might change
+	 * @param OldPassword $passInfo the information about the password. It has
+	 * to include the userid owning the password and an id for the password
+	 */
+	public function markAboutToExpireNotificationSentFor(OldPassword $passInfo) {
+		$this->config->setUserValue($passInfo->getUid(), 'password_policy', 'aboutToExpireSent', $passInfo->getId());
+	}
+
+	/**
+	 * Mark that a "password expired" notification has been sent.
+	 * Note that we're using the id of the passInfo as marker, but this might change
+	 * @param OldPassword $passInfo the information about the password. It has
+	 * to include the userid owning the password and an id for the password
+	 */
+	public function markExpiredNotificationSentFor(OldPassword $passInfo) {
+		$this->config->setUserValue($passInfo->getUid(), 'password_policy', 'expiredSent', $passInfo->getId());
+	}
+
+	/**
+	 * Get the mark set with markAboutToExpireNotificationSentFor for the specified user
+	 * @param string $userid the user id to get the mark from
+	 * @return string|null the mark or null if there is no mark
+	 */
+	public function getMarkAboutToExpireNotificationSentFor($userid) {
+		return $this->config->getUserValue($userid, 'password_policy', 'aboutToExpireSent', null);
+	}
+
+	/**
+	 * Get the mark set with markExpiredNotificationSentFor for the specified user
+	 * @param string $userid the user id to get the mark from
+	 * @return string|null the mark or null if there is no mark
+	 */
+	public function getMarkExpiredNotificationSentFor($userid) {
+		return $this->config->getUserValue($userid, 'password_policy', 'expiredSent', null);
+	}
+
+	/**
+	 * Check if a "password about to expire" notification has been sent for that
+	 * password
+	 * @param OldPassword $passInfo the password information to be checked
+	 * @return bool true if the notification has been sent already, false otherwise.
+	 * Note that we'll check only with the last password id sent
+	 */
+	public function isSentAboutToExpireNotification(OldPassword $passInfo) {
+		$storedId = $this->config->getUserValue($passInfo->getUid(), 'password_policy', 'aboutToExpireSent', null);
+		if ($storedId === null) {
+			return false;  // notification not sent
+		} elseif (\intval($storedId) !== $passInfo->getId()) {
+			// if the password id doesn't match the one stored, the notification hasn't been sent
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Check if a "password expired" notification has been sent for that
+	 * password
+	 * @param OldPassword $passInfo the password information to be checked
+	 * @return bool true if the notification has been sent already, false otherwise.
+	 * Note that we'll check only with the last password id sent
+	 */
+	public function isSentExpiredNotification(OldPassword $passInfo) {
+		$storedId = $this->config->getUserValue($passInfo->getUid(), 'password_policy', 'expiredSent', null);
+		if ($storedId === null) {
+			return false;  // notification not sent
+		} elseif (\intval($storedId) !== $passInfo->getId()) {
+			// if the password id doesn't match the one stored, the notification hasn't been sent
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Reset the marks created with markAboutToExpireNotificationSentFor and
+	 * markExpiredNotificationSentFor functions. This function should be call
+	 * once the password for the user has been changed
+	 * @param string $uid the id if the user that has changed his password
+	 */
+	public function resetExpirationMarks($uid) {
+		$targetKeys = [
+			'aboutToExpireSent',
+			'expiredSent',
+		];
+		foreach ($targetKeys as $targetKey) {
+			$this->config->deleteUserValue($uid, 'password_policy', $targetKey);
+		}
+	}
+}

--- a/lib/UserNotificationConfigHandler.php
+++ b/lib/UserNotificationConfigHandler.php
@@ -55,7 +55,7 @@ class UserNotificationConfigHandler {
 			'spv_user_password_expiration_value',
 			null
 		);
-		if ($expirationTime === null || !\is_numeric($expirationTime)) {
+		if ($expirationTime === null || !\is_numeric($expirationTime) || $expirationTime < 0) {
 			return null;  // passwords don't expire or have weird value
 		}
 		// the expiration time is currently stored in days, so we need to convert
@@ -65,7 +65,7 @@ class UserNotificationConfigHandler {
 
 	/**
 	 * Return the number of seconds until a user should receive a notification
-	 * that his password is about to expire. This _should_ be less than the value
+	 * that their password is about to expire. This _should_ be less than the value
 	 * returned by the getExpirationTime function (you'll need to verify it outside)
 	 * It will return null if the value isn't set (or disabled) or it has a
 	 * non-parseable value
@@ -85,7 +85,7 @@ class UserNotificationConfigHandler {
 			'password_policy',
 			'spv_user_password_expiration_notification_value',
 			self::DEFAULT_EXPIRATION_FOR_NORMAL_NOTIFICATION);
-		if ($expirationTime === null || !\is_numeric($expirationTime)) {
+		if ($expirationTime === null || !\is_numeric($expirationTime) || $expirationTime < 0) {
 			return null;  // passwords don't expire or have weird value
 		}
 		return \intval($expirationTime);

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -80,7 +80,7 @@ script('password_policy', 'ajax');
 		</ul>
 		<input type="hidden" name="app" value="oca-password-policy" />
 		<p class="margin-add-top">
-			<?php p($l->t('User Password policies:'));?>
+			<?php p($l->t('User password policies:'));?>
 		</p>
 		<ul>
 			<li>
@@ -92,8 +92,15 @@ script('password_policy', 'ajax');
 			</li>
 			<li>
 				<label>
+					<input type="checkbox" name="spv_user_password_expiration_notification_checked" <?php if ($_['spv_user_password_expiration_notification_checked']): ?> checked="checked"<?php endif; ?>/>
+					<input type="number" name="spv_user_password_expiration_notification_value"  min="0" value="<?php p($_['spv_user_password_expiration_notification_value']) ?>" placeholder="30"/>
+					<span><?php p($l->t('days before password expires, users will receive a reminder notification'));?></span>
+				</label>
+			</li>
+			<li>
+				<label>
 					<input type="checkbox" name="spv_user_password_force_change_on_first_login_checked" <?php if ($_['spv_user_password_force_change_on_first_login_checked']): ?> checked="checked"<?php endif; ?>/>
-					<span><?php p($l->t('force change on first login'));?></span>
+					<span><?php p($l->t('Force users to change their password on first login'));?></span>
 				</label>
 			</li>
 		</ul>

--- a/templates/password.php
+++ b/templates/password.php
@@ -33,23 +33,24 @@ style('password_policy', 'styles');
 <form id="password_policy" method="post">
 	<fieldset>
 		<h1 class="warning">
-			<?php p($l->t('Password changed required'));?>
+			<div><?php p($l->t('Your password has expired.')); ?></div>
+			<div><?php p($l->t('Please choose a new password.')); ?></div>
 		</h1>
 		<?php if (isset($_['error'])) { ?><div id="error" class="warning"><?php p($_['error']) ?></div> <?php } ?>
 		<input type="hidden" name="redirect_url" value="<?php p($_['redirect_url']) ?>" />
 		<input type="hidden" name="app" value="oca-password-policy" />
 		<input type="hidden" name="requesttoken" value="<?php p($_['requesttoken']) ?>" id="requesttoken">
 
-		<label for="current_password" class="infield"><?php p($l->t('current password'));?></label>
-		<input type="password" id="current_password" name="current_password" value="" autofocus placeholder="<?php p($l->t('current password'));?>"/>
+		<label for="current_password" class="infield"><?php p($l->t('Current password'));?></label>
+		<input type="password" id="current_password" name="current_password" value="" autofocus placeholder="<?php p($l->t('Current password'));?>"/>
 
 		<div class="grouptop">
-			<label for="new_password" class="infield"><?php p($l->t('new password'));?></label>
-			<input type="password" id="new_password" name="new_password" value="" placeholder="<?php p($l->t('new password'));?>"/>
+			<label for="new_password" class="infield"><?php p($l->t('New password'));?></label>
+			<input type="password" id="new_password" name="new_password" value="" placeholder="<?php p($l->t('New password'));?>"/>
 		</div>
 		<div class="groupbottom">
-			<label for="confirm_password" class="infield"><?php p($l->t('confirm new password'));?></label>
-			<input type="password" id="confirm_password" name="confirm_password" value="" placeholder="<?php p($l->t('confirm new password'));?>"/>
+			<label for="confirm_password" class="infield"><?php p($l->t('Confirm new password'));?></label>
+			<input type="password" id="confirm_password" name="confirm_password" value="" placeholder="<?php p($l->t('Confirm new password'));?>"/>
 		</div>
 		<button id="submit" type="submit"><?php p($l->t('Save'));?></button>
 	</fieldset>

--- a/tests/Controller/PasswordControllerTest.php
+++ b/tests/Controller/PasswordControllerTest.php
@@ -135,7 +135,7 @@ class PasswordControllerTest extends TestCase {
 		$redirect_url = 'redirect/target';
 		$this->c->expects($this->once())
 			->method('createPasswordTemplateResponse')
-			->with($redirect_url, 'New passwords are not the same.');
+			->with($redirect_url, 'Password confirmation does not match the password.');
 
 		$this->userSession
 			->expects($this->never())
@@ -170,7 +170,7 @@ class PasswordControllerTest extends TestCase {
 		$redirect_url = 'redirect/target';
 		$this->c->expects($this->once())
 			->method('createPasswordTemplateResponse')
-			->with($redirect_url, 'Incorrect current password supplied.');
+			->with($redirect_url, 'The current password is incorrect.');
 
 		$user
 			->expects($this->never())

--- a/tests/Db/OldPasswordMapperTest.php
+++ b/tests/Db/OldPasswordMapperTest.php
@@ -122,6 +122,7 @@ class OldPasswordMapperTest extends TestCase {
 
 
 		$passwordList = $this->mapper->getPasswordsAboutToExpire($baseTime + 44);
+		$passwordList = \iterator_to_array($passwordList);  // convert to array
 		// last password change before the timestamp
 		$this->assertCount(2, $passwordList);
 
@@ -144,6 +145,7 @@ class OldPasswordMapperTest extends TestCase {
 
 
 		$passwordList = $this->mapper->getPasswordsAboutToExpire($baseTime + 130);
+		$passwordList = \iterator_to_array($passwordList);  // convert to array
 		// last password change before the timestamp
 		$this->assertCount(3, $passwordList);
 

--- a/tests/Db/OldPasswordMapperTest.php
+++ b/tests/Db/OldPasswordMapperTest.php
@@ -26,6 +26,7 @@ namespace OCA\PasswordPolicy\Tests\Db;
 use OCA\PasswordPolicy\Db\OldPassword;
 use OCA\PasswordPolicy\Db\OldPasswordMapper;
 use OCP\IDBConnection;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use Test\TestCase;
 
 /**
@@ -38,11 +39,12 @@ class OldPasswordMapperTest extends TestCase {
 	private $mapper;
 	/** @var string */
 	private $testUID = 'test1';
+	private $testUIDs = ['test1', 'test2', 'test3'];
 
 	private function resetDB() {
 		$qb = $this->db->getQueryBuilder();
 		$qb->delete($this->mapper->getTableName())
-			->where($qb->expr()->eq('uid', $qb->createNamedParameter($this->testUID)));
+			->where($qb->expr()->in('uid', $qb->createNamedParameter($this->testUIDs, IQueryBuilder::PARAM_STR_ARRAY)));
 		$qb->execute();
 	}
 	protected function setUp() {
@@ -57,46 +59,110 @@ class OldPasswordMapperTest extends TestCase {
 		$this->resetDB();
 	}
 
-	public function addInitialTestEntries() {
+	public function addInitialTestEntries($baseTime) {
 		//add an initial entries
-		$oldPassword = new OldPassword();
-		$oldPassword->setUid($this->testUID);
-		$oldPassword->setPassword('testpass1');
-		$oldPassword->setChangeTime(\OC::$server->getTimeFactory()->getTime());
-		$this->mapper->insert($oldPassword);
+		foreach ($this->testUIDs as $index => $uid) {
+			$oldPassword = new OldPassword();
+			$oldPassword->setUid($uid);
+			$oldPassword->setPassword("{$uid}testpass1");
+			$oldPassword->setChangeTime($baseTime);
+			$this->mapper->insert($oldPassword);
 
-		$oldPassword = new OldPassword();
-		$oldPassword->setUid($this->testUID);
-		$oldPassword->setPassword('testpass2');
-		$oldPassword->setChangeTime(\OC::$server->getTimeFactory()->getTime()+1);
-		$this->mapper->insert($oldPassword);
+			$oldPassword = new OldPassword();
+			$oldPassword->setUid($uid);
+			$oldPassword->setPassword("{$uid}testpass2");
+			$oldPassword->setChangeTime($baseTime + (10 * ($index + 1)));
+			$this->mapper->insert($oldPassword);
 
-		$oldPassword = new OldPassword();
-		$oldPassword->setUid($this->testUID);
-		$oldPassword->setPassword('testpass3');
-		$oldPassword->setChangeTime(\OC::$server->getTimeFactory()->getTime()+2);
-		$this->mapper->insert($oldPassword);
+			$oldPassword = new OldPassword();
+			$oldPassword->setUid($uid);
+			$oldPassword->setPassword("{$uid}testpass3");
+			$oldPassword->setChangeTime($baseTime + (20 * ($index + 1)));
+			$this->mapper->insert($oldPassword);
+		}
 	}
 
 	public function testGetOldPasswords() {
-		$this->assertCount(0, $this->mapper->getOldPasswords($this->testUID,3));
-		$this->addInitialTestEntries();
+		$uid = $this->testUIDs[0];
+		$this->assertCount(0, $this->mapper->getOldPasswords($uid, 3));
+		$this->addInitialTestEntries(\time());
 
-		$oldPasswords = $this->mapper->getOldPasswords($this->testUID,2);
+		$oldPasswords = $this->mapper->getOldPasswords($uid, 2);
 
 		$this->assertCount(2, $oldPasswords);
-		$this->assertNotSame("testpass1", $oldPasswords[0]->getPassword());
-		$this->assertNotSame("testpass1", $oldPasswords[1]->getPassword());
+		$this->assertNotSame("{$uid}testpass1", $oldPasswords[0]->getPassword());
+		$this->assertNotSame("{$uid}testpass1", $oldPasswords[1]->getPassword());
 
-		$this->assertCount(3, $this->mapper->getOldPasswords($this->testUID,3));
+		$this->assertCount(3, $this->mapper->getOldPasswords($uid, 3));
 	}
 
 	public function testLatestPassword() {
-		$this->assertNull($this->mapper->getLatestPassword($this->testUID));
-		$this->addInitialTestEntries();
+		$uid = $this->testUIDs[0];
+		$this->assertNull($this->mapper->getLatestPassword($uid));
+		$this->addInitialTestEntries(\time());
 
-		$latestPassword = $this->mapper->getLatestPassword($this->testUID);
+		$latestPassword = $this->mapper->getLatestPassword($uid);
 
-		$this->assertSame("testpass3", $latestPassword->getPassword());
+		$this->assertSame("{$uid}testpass3", $latestPassword->getPassword());
+	}
+
+	public function testGetPasswordsAboutToExpireAllOk() {
+		$baseTime = \time();
+		$this->addInitialTestEntries($baseTime);
+
+
+		$passwordList = $this->mapper->getPasswordsAboutToExpire($baseTime + 14);
+		// last password change after the timestamp, so we shouldn't get any result
+		$this->assertCount(0, $passwordList);
+	}
+
+	public function testGetPasswordsAboutToExpireSomePassMarked() {
+		$baseTime = \time();
+		$this->addInitialTestEntries($baseTime);
+
+
+		$passwordList = $this->mapper->getPasswordsAboutToExpire($baseTime + 44);
+		// last password change before the timestamp
+		$this->assertCount(2, $passwordList);
+
+		$uid = $this->testUIDs[0];
+		$latestPassword = $passwordList[0];
+		$this->assertSame("{$uid}testpass3", $latestPassword->getPassword());
+		$this->assertSame($uid, $latestPassword->getUid());
+		$this->assertLessThan($baseTime + 44, $latestPassword->getChangeTime());
+
+		$uid = $this->testUIDs[1];
+		$latestPassword = $passwordList[1];
+		$this->assertSame("{$uid}testpass3", $latestPassword->getPassword());
+		$this->assertSame($uid, $latestPassword->getUid());
+		$this->assertLessThan($baseTime + 44, $latestPassword->getChangeTime());
+	}
+
+	public function testGetPasswordsAboutToExpireAllMarked() {
+		$baseTime = \time();
+		$this->addInitialTestEntries($baseTime);
+
+
+		$passwordList = $this->mapper->getPasswordsAboutToExpire($baseTime + 130);
+		// last password change before the timestamp
+		$this->assertCount(3, $passwordList);
+
+		$uid = $this->testUIDs[0];
+		$latestPassword = $passwordList[0];
+		$this->assertSame("{$uid}testpass3", $latestPassword->getPassword());
+		$this->assertSame($uid, $latestPassword->getUid());
+		$this->assertLessThan($baseTime + 130, $latestPassword->getChangeTime());
+
+		$uid = $this->testUIDs[1];
+		$latestPassword = $passwordList[1];
+		$this->assertSame("{$uid}testpass3", $latestPassword->getPassword());
+		$this->assertSame($uid, $latestPassword->getUid());
+		$this->assertLessThan($baseTime +130, $latestPassword->getChangeTime());
+
+		$uid = $this->testUIDs[2];
+		$latestPassword = $passwordList[2];
+		$this->assertSame("{$uid}testpass3", $latestPassword->getPassword());
+		$this->assertSame($uid, $latestPassword->getUid());
+		$this->assertLessThan($baseTime + 130, $latestPassword->getChangeTime());
 	}
 }

--- a/tests/NotifierTest.php
+++ b/tests/NotifierTest.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ *
+ * @author Juan Pablo Villafáñez <jvillafanez@solidgear.es>
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license GPL-2.0
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\PasswordPolicy\Tests;
+
+use OCA\PasswordPolicy\Notifier;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\L10N\IFactory;
+use OCP\Notification\INotification;
+use OCP\Notification\IAction;
+use OC\L10N\L10N;
+use Test\TestCase;
+
+class NotifierTest extends TestCase {
+	/** @var IFactory */
+	private $factory;
+
+	/** @var ITimeFactory */
+	private $timeFactory;
+
+	/** @var Notifier */
+	private $notifier;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->factory = $this->getMockBuilder(IFactory::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$this->timeFactory = $this->getMockBuilder(ITimeFactory::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$l10n = $this->getMockBuilder(L10N::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$l10n->method('t')
+			->will($this->returnCallback(function ($text, $parameters = []) {
+				return \vsprintf($text, $parameters);
+			}));
+
+		$this->factory->method('get')->willReturn($l10n);
+
+		$this->notifier = new Notifier($this->factory, $this->timeFactory);
+	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 */
+	public function testPrepareInvalidApp() {
+		$notification = $this->createMock(INotification::class);
+		$notification->method('getApp')->willReturn('another');
+		$notification->method('getObjectType')->willReturn('local_share');
+		$this->notifier->prepare($notification, 'en_US');
+	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 */
+	public function testPrepareInvalidUnknownObjectType() {
+		$notification = $this->createMock(INotification::class);
+		$notification->method('getApp')->willReturn('password_policy');
+		$notification->method('getObjectType')->willReturn('local_share');
+		$this->notifier->prepare($notification, 'en_US');
+	}
+
+	public function testPrepareAboutToExpire() {
+		$initialTime = 1531232050;
+		$expireIn = 10 * 24 * 60 * 60;  // 10 days;
+		$notification = $this->createMock(INotification::class);
+		$notification->method('getApp')->willReturn('password_policy');
+		$notification->method('getObjectType')->willReturn('about_to_expire');
+		$notification->method('getSubjectParameters')->willReturn([$initialTime, $expireIn]);
+		// first parameter is the password change time and the second is the
+		// expiration time starting from the password change time
+		$notification->method('getMessageParameters')->willReturn([$initialTime, $expireIn]);
+
+		$notification->method('getActions')->willReturn([]);  // FIXME: to recheck if we include actions
+
+		$this->timeFactory->method('getTime')->willReturn($initialTime + (7 * 24 * 60 * 60));
+
+		$notification->expects($this->once())
+			->method('setParsedSubject')
+			->with('Your password is about to expire!');
+
+		$notification->expects($this->once())
+			->method('setParsedMessage')
+			->with('You have 3 days to change your password');
+
+		$this->notifier->prepare($notification, 'en_US');
+	}
+
+	public function testPrepareAboutToExpireWithAction() {
+		$initialTime = 1531232050;
+		$expireIn = 10 * 24 * 60 * 60;  // 10 days;
+		$notification = $this->createMock(INotification::class);
+		$notification->method('getApp')->willReturn('password_policy');
+		$notification->method('getObjectType')->willReturn('about_to_expire');
+		$notification->method('getSubjectParameters')->willReturn([$initialTime, $expireIn]);
+		// first parameter is the password change time and the second is the
+		// expiration time starting from the password change time
+		$notification->method('getMessageParameters')->willReturn([$initialTime, $expireIn]);
+
+		$action = $this->createMock(IAction::class);
+		$action->method('getLabel')->willReturn('Change password');
+		$action->method('getLink')->willReturn('http://my.server/link/link');
+		$action->method('getRequestType')->willReturn('GET');
+
+		$notification->method('getActions')->willReturn([$action]);
+
+		$this->timeFactory->method('getTime')->willReturn($initialTime + (7 * 24 * 60 * 60));
+
+		$notification->expects($this->once())
+			->method('setParsedSubject')
+			->with('Your password is about to expire!');
+
+		$notification->expects($this->once())
+			->method('setParsedMessage')
+			->with('You have 3 days to change your password');
+
+		$notification->expects($this->once())
+			->method('addParsedAction')
+			->with($action);
+
+		$this->notifier->prepare($notification, 'en_US');
+	}
+
+	public function testPrepareAboutToExpirePassDate() {
+		$initialTime = 1531232050;
+		$expireIn = 10 * 24 * 60 * 60;  // 10 days;
+		$notification = $this->createMock(INotification::class);
+		$notification->method('getApp')->willReturn('password_policy');
+		$notification->method('getObjectType')->willReturn('about_to_expire');
+		$notification->method('getSubjectParameters')->willReturn([$initialTime, $expireIn]);
+		// first parameter is the password change time and the second is the
+		// expiration time starting from the password change time
+		$notification->method('getMessageParameters')->willReturn([$initialTime, $expireIn]);
+
+		$notification->method('getActions')->willReturn([]);  // FIXME: to recheck if we include actions
+
+		$this->timeFactory->method('getTime')->willReturn($initialTime + (12 * 24 * 60 * 60));
+
+		$notification->expects($this->once())
+			->method('setParsedSubject')
+			->with('Your password is about to expire!');
+
+		$notification->expects($this->once())
+			->method('setParsedMessage')
+			->with('Your password expired 2 days ago');
+
+		$this->notifier->prepare($notification, 'en_US');
+	}
+
+	public function testPrepareExpired() {
+		$initialTime = 1531232050;
+		$expireIn = 10 * 24 * 60 * 60;  // 10 days;
+		$notification = $this->createMock(INotification::class);
+		$notification->method('getApp')->willReturn('password_policy');
+		$notification->method('getObjectType')->willReturn('expired');
+		$notification->method('getSubjectParameters')->willReturn([$initialTime, $expireIn]);
+		// first parameter is the password change time and the second is the
+		// expiration time starting from the password change time
+		$notification->method('getMessageParameters')->willReturn([$initialTime, $expireIn]);
+
+		$action = $this->createMock(IAction::class);
+		$action->method('getLabel')->willReturn('Change password');
+		$action->method('getLink')->willReturn('http://my.server/link/link');
+		$action->method('getRequestType')->willReturn('GET');
+
+		$notification->method('getActions')->willReturn([$action]);  // FIXME: to recheck if we include actions
+
+		$this->timeFactory->method('getTime')->willReturn($initialTime + (12 * 24 * 60 * 60));
+
+		$notification->expects($this->once())
+			->method('setParsedSubject')
+			->with('Your password has expired');
+
+		$notification->expects($this->once())
+			->method('setParsedMessage')
+			->with('You have to change your password before you can access again');
+
+		$notification->expects($this->once())
+			->method('addParsedAction')
+			->with($action);
+
+		$this->notifier->prepare($notification, 'en_US');
+	}
+}

--- a/tests/NotifierTest.php
+++ b/tests/NotifierTest.php
@@ -99,7 +99,7 @@ class NotifierTest extends TestCase {
 
 		$notification->expects($this->once())
 			->method('setParsedSubject')
-			->with('Your password is about to expire!');
+			->with('Password expiration notice');
 
 		$notification->expects($this->once())
 			->method('setParsedMessage')
@@ -130,7 +130,7 @@ class NotifierTest extends TestCase {
 
 		$notification->expects($this->once())
 			->method('setParsedSubject')
-			->with('Your password is about to expire!');
+			->with('Password expiration notice');
 
 		$notification->expects($this->once())
 			->method('setParsedMessage')
@@ -160,7 +160,7 @@ class NotifierTest extends TestCase {
 
 		$notification->expects($this->once())
 			->method('setParsedSubject')
-			->with('Your password is about to expire!');
+			->with('Password expiration notice');
 
 		$notification->expects($this->once())
 			->method('setParsedMessage')
@@ -195,7 +195,7 @@ class NotifierTest extends TestCase {
 
 		$notification->expects($this->once())
 			->method('setParsedMessage')
-			->with('You have to change your password before you can access again');
+			->with('Please change your password to gain back access to your account');
 
 		$notification->expects($this->once())
 			->method('addParsedAction')

--- a/tests/Rules/PasswordHistoryTest.php
+++ b/tests/Rules/PasswordHistoryTest.php
@@ -74,7 +74,7 @@ class PasswordHistoryTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider failDataProvider
 	 * @param string $password
 	 * @expectedException \OCA\PasswordPolicy\Rules\PolicyException
-	 * @expectedExceptionMessage The password must be different to your previous 2 passwords.
+	 * @expectedExceptionMessage The password must be different than your previous 2 passwords.
 	 */
 	public function testWithOldPassword($password) {
 		$this->r->verify($password, 2, 'testuser');

--- a/tests/UserNotificationConfigHandlerTest.php
+++ b/tests/UserNotificationConfigHandlerTest.php
@@ -1,0 +1,269 @@
+<?php
+/**
+ *
+ * @author Juan Pablo Villafáñez <jvillafanez@solidgear.es>
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license GPL-2.0
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\PasswordPolicy\Tests;
+
+use OCP\IConfig;
+use OCA\PasswordPolicy\UserNotificationConfigHandler;
+use OCA\PasswordPolicy\Db\OldPassword;
+use Test\TestCase;
+
+class UserNotificationConfigHandlerTest extends TestCase {
+	/** @var IConfig */
+	private $config;
+
+	/** @var UserNotificationConfigHandler */
+	private $unConfigHandler;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->config = $this->getMockBuilder(IConfig::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->unConfigHandler = new UserNotificationConfigHandler($this->config);
+	}
+
+	public function falseyValueProvider() {
+		return [
+			[false],
+			['off'],
+			['no'],
+			['0'],
+			['false'],
+		];
+	}
+
+	/**
+	 * @dataProvider falseyValueProvider
+	 */
+	public function testExpirationTimeNotChecked($falseyValue) {
+		$this->config->method('getAppValue')
+			->will($this->returnValueMap([
+				['password_policy', 'spv_user_password_expiration_checked', false, $falseyValue]
+			]));
+		$this->assertNull($this->unConfigHandler->getExpirationTime());
+	}
+
+	public function testExpirationTimeWeirdValue() {
+		$this->config->method('getAppValue')
+			->will($this->returnValueMap([
+				['password_policy', 'spv_user_password_expiration_checked', false, true],
+				['password_policy', 'spv_user_password_expiration_value', null, 'wwwww']
+			]));
+		$this->assertNull($this->unConfigHandler->getExpirationTime());
+	}
+
+	public function testExpirationTime() {
+		$this->config->method('getAppValue')
+			->will($this->returnValueMap([
+				['password_policy', 'spv_user_password_expiration_checked', false, true],
+				['password_policy', 'spv_user_password_expiration_value', null, '90']
+			]));
+		// TODO: expiration time is currently stored in days,
+		// but the function returns seconds
+		$this->assertEquals(90*24*60*60, $this->unConfigHandler->getExpirationTime());
+	}
+
+	/**
+	 * @dataProvider falseyValueProvider
+	 */
+	public function testExpirationTimeForNotificationNotChecked($falseyValue) {
+		$this->config->method('getAppValue')
+			->will($this->returnValueMap([
+				['password_policy', 'spv_user_password_expiration_notification_checked', false, $falseyValue]
+			]));
+		$this->assertNull($this->unConfigHandler->getExpirationTimeForNormalNotification());
+	}
+
+	public function testExpirationTimeForNotificationWeirdValue() {
+		$expectedDefault = UserNotificationConfigHandler::DEFAULT_EXPIRATION_FOR_NORMAL_NOTIFICATION;
+		$this->config->method('getAppValue')
+			->will($this->returnValueMap([
+				['password_policy', 'spv_user_password_expiration_notification_checked', false, true],
+				['password_policy', 'spv_user_password_expiration_notification_value', $expectedDefault, 'wwwww']
+			]));
+		$this->assertNull($this->unConfigHandler->getExpirationTimeForNormalNotification());
+	}
+
+	public function testExpirationTimeForNotification() {
+		$expectedDefault = UserNotificationConfigHandler::DEFAULT_EXPIRATION_FOR_NORMAL_NOTIFICATION;
+		$this->config->method('getAppValue')
+			->will($this->returnValueMap([
+				['password_policy', 'spv_user_password_expiration_notification_checked', false, true],
+				['password_policy', 'spv_user_password_expiration_notification_value', $expectedDefault, '12234']
+			]));
+		$this->assertEquals(12234, $this->unConfigHandler->getExpirationTimeForNormalNotification());
+	}
+
+	public function testMarkAboutToExpireNotificationSentFor() {
+		$passData = [
+			'id' => 34,
+			'uid' => 'usertest1',
+			'password' => 'password',
+			'changeTime' => 1002030,
+		];
+		$oldPass = OldPassword::fromRow($passData);
+
+		$this->config->expects($this->once())
+			->method('setUserValue')
+			->with('usertest1', 'password_policy', 'aboutToExpireSent', 34);
+
+		$this->unConfigHandler->markAboutToExpireNotificationSentFor($oldPass);
+	}
+
+	public function testMarkExpiredNotificationSentFor() {
+		$passData = [
+			'id' => 34,
+			'uid' => 'usertest1',
+			'password' => 'password',
+			'changeTime' => 1002030,
+		];
+		$oldPass = OldPassword::fromRow($passData);
+
+		$this->config->expects($this->once())
+			->method('setUserValue')
+			->with('usertest1', 'password_policy', 'expiredSent', 34);
+
+		$this->unConfigHandler->markExpiredNotificationSentFor($oldPass);
+	}
+
+	public function testGetMarkAboutToExpireNotificationSentFor() {
+		$this->config->expects($this->once())
+			->method('getUserValue')
+			->with('usertest1', 'password_policy', 'aboutToExpireSent', null)
+			->willReturn('333');
+		$this->assertEquals('333', $this->unConfigHandler->getMarkAboutToExpireNotificationSentFor('usertest1'));
+	}
+
+	public function testGetMarkExpiredNotificationSentFor() {
+		$this->config->expects($this->once())
+			->method('getUserValue')
+			->with('usertest1', 'password_policy', 'expiredSent', null)
+			->willReturn('4444');
+		$this->assertEquals('4444', $this->unConfigHandler->getMarkExpiredNotificationSentFor('usertest1'));
+	}
+
+	public function testIsSentAboutToExpireNotificationNotSent() {
+		$passData = [
+			'id' => 34,
+			'uid' => 'usertest1',
+			'password' => 'password',
+			'changeTime' => 1002030,
+		];
+		$oldPass = OldPassword::fromRow($passData);
+		$this->config->method('getUserValue')
+			->will($this->returnValueMap([
+				['usertest1', 'password_policy', 'aboutToExpireSent', null, null],
+			]));
+		$this->assertFalse($this->unConfigHandler->isSentAboutToExpireNotification($oldPass));
+	}
+
+	public function testIsSentAboutToExpireNotificationDifferentId() {
+		$passData = [
+			'id' => 34,
+			'uid' => 'usertest1',
+			'password' => 'password',
+			'changeTime' => 1002030,
+		];
+		$oldPass = OldPassword::fromRow($passData);
+		$this->config->method('getUserValue')
+			->will($this->returnValueMap([
+				['usertest1', 'password_policy', 'aboutToExpireSent', null, 20],
+			]));
+		$this->assertFalse($this->unConfigHandler->isSentAboutToExpireNotification($oldPass));
+	}
+
+	public function testIsSentAboutToExpireNotificationAlreadySent() {
+		$passData = [
+			'id' => 34,
+			'uid' => 'usertest1',
+			'password' => 'password',
+			'changeTime' => 1002030,
+		];
+		$oldPass = OldPassword::fromRow($passData);
+		$this->config->method('getUserValue')
+			->will($this->returnValueMap([
+				['usertest1', 'password_policy', 'aboutToExpireSent', null, 34],
+			]));
+		$this->assertTrue($this->unConfigHandler->isSentAboutToExpireNotification($oldPass));
+	}
+
+	public function testIsSentExpiredNotificationNotSent() {
+		$passData = [
+			'id' => 34,
+			'uid' => 'usertest1',
+			'password' => 'password',
+			'changeTime' => 1002030,
+		];
+		$oldPass = OldPassword::fromRow($passData);
+		$this->config->method('getUserValue')
+			->will($this->returnValueMap([
+				['usertest1', 'password_policy', 'expiredSent', null, null],
+			]));
+		$this->assertFalse($this->unConfigHandler->isSentExpiredNotification($oldPass));
+	}
+
+	public function testIsSentExpiredNotificationDifferentId() {
+		$passData = [
+			'id' => 34,
+			'uid' => 'usertest1',
+			'password' => 'password',
+			'changeTime' => 1002030,
+		];
+		$oldPass = OldPassword::fromRow($passData);
+		$this->config->method('getUserValue')
+			->will($this->returnValueMap([
+				['usertest1', 'password_policy', 'expiredSent', null, 20],
+			]));
+		$this->assertFalse($this->unConfigHandler->isSentExpiredNotification($oldPass));
+	}
+
+	public function testIsSentExpiredNotificationAlreadySent() {
+		$passData = [
+			'id' => 34,
+			'uid' => 'usertest1',
+			'password' => 'password',
+			'changeTime' => 1002030,
+		];
+		$oldPass = OldPassword::fromRow($passData);
+		$this->config->method('getUserValue')
+			->will($this->returnValueMap([
+				['usertest1', 'password_policy', 'expiredSent', null, 34],
+			]));
+		$this->assertTrue($this->unConfigHandler->isSentExpiredNotification($oldPass));
+	}
+
+	public function testResetExpirationMarks() {
+		$targetKeys = [
+			'aboutToExpireSent',
+			'expiredSent',
+		];
+		$this->config->expects($this->exactly(\count($targetKeys)))
+			->method('deleteUserValue')
+			->withConsecutive(
+				[$this->equalTo('usertest1'), $this->equalTo('password_policy'), $this->equalTo($targetKeys[0])],
+				[$this->equalTo('usertest1'), $this->equalTo('password_policy'), $this->equalTo($targetKeys[1])]
+			);
+		$this->unConfigHandler->resetExpirationMarks('usertest1');
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/owncloud/password_policy/issues/18

### Open tasks
- [x] better SQL query
- [x] agree whether the JS hack is ok and/or whether we want to hide the "Change Password" button and exploit hack, see https://github.com/owncloud/password_policy/pull/27#issuecomment-403951044
- [x] delete related notifications after password was changed
- [x] solve confusing settings in page (PVince81 was confused)
- [x] adjust wording based on @pmaier1 feedback https://github.com/owncloud/password_policy/issues/18#issuecomment-403439985
- [x] unit tests
- [x] ~JS tests~