### PR TITLE
Create a new entry in user_password_history when a new user is created

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -42,6 +42,10 @@ $eventDispatcher->addListener(
 	[$handler, 'generatePassword']
 );
 $eventDispatcher->addListener(
+	'user.aftercreate',
+	[$handler, 'savePasswordForCreatedUser']
+);
+$eventDispatcher->addListener(
 	'user.aftersetpassword',
 	[$handler, 'saveOldPassword']
 );

--- a/lib/HooksHandler.php
+++ b/lib/HooksHandler.php
@@ -187,6 +187,19 @@ class HooksHandler {
 		$this->oldPasswordMapper->insert($oldPassword);
 	}
 
+	public function savePasswordForCreatedUser(GenericEvent $event) {
+		$this->fixDI();
+
+		$userid = $event->getArgument('uid');
+		$password = $event->getArgument('password');
+
+		$oldPassword = new OldPassword();
+		$oldPassword->setUid($userid);
+		$oldPassword->setPassword($this->hasher->hash($password));
+		$oldPassword->setChangeTime($this->timeFactory->getTime());
+		$this->oldPasswordMapper->insert($oldPassword);
+	}
+
 	/**
 	 * Flags the session to require a password change
 	 */

--- a/tests/HooksHandlerTest.php
+++ b/tests/HooksHandlerTest.php
@@ -182,6 +182,32 @@ class HooksHandlerTest extends TestCase {
 		$this->handler->saveOldPassword($event);
 	}
 
+	public function testSavePasswordForCreatedUser() {
+
+		$this->hasher->expects($this->once())
+			->method('hash')
+			->with('secret')
+			->willReturn('somehash');
+
+		$this->timeFactory->expects($this->once())
+			->method('getTime')
+			->willReturn(12345);
+
+		$this->oldPasswordMapper->expects($this->once())
+			->method('insert')
+			->with($this->callback(function(OldPassword $oldPassword){
+				return $oldPassword->getPassword() === 'somehash' &&
+					$oldPassword->getUid() === 'testuid' &&
+					$oldPassword->getChangeTime() === 12345;
+			}));
+
+		$event = new GenericEvent(null, [
+			'uid' => 'testuid',
+			'password' => 'secret'
+		]);
+		$this->handler->savePasswordForCreatedUser($event);
+	}
+
 	/**
 	 * @expectedException \UnexpectedValueException
 	 */


### PR DESCRIPTION
Fix https://github.com/owncloud/password_policy/issues/25 by creating a new entry when the user is created