### PR TITLE
Check password type + allow empty public password

### DIFF
--- a/lib/Engine.php
+++ b/lib/Engine.php
@@ -105,9 +105,10 @@ class Engine {
 	/**
 	 * @param string $password
 	 * @param string $uid
+	 * @param string $type
 	 * @throws PolicyException
 	 */
-	public function verifyPassword($password, $uid = null) {
+	public function verifyPassword($password, $uid = null, $type = 'user') {
 		if ($this->yes('spv_min_chars_checked')) {
 			$val = (int) $this->configValues['spv_min_chars_value'];
 			$r = new Length($this->l10n);

--- a/lib/Engine.php
+++ b/lib/Engine.php
@@ -109,6 +109,12 @@ class Engine {
 	 * @throws PolicyException
 	 */
 	public function verifyPassword($password, $uid = null, $type = 'user') {
+		// skip policy when no password is specified
+		// enforcement of password existence is done on a different level
+		if ($type === 'public' && ($password === null || $password === '')) {
+			return;
+		}
+
 		if ($this->yes('spv_min_chars_checked')) {
 			$val = (int) $this->configValues['spv_min_chars_value'];
 			$r = new Length($this->l10n);

--- a/lib/HooksHandler.php
+++ b/lib/HooksHandler.php
@@ -137,7 +137,12 @@ class HooksHandler {
 		} else {
 			$uid = null;
 		}
-		$this->engine->verifyPassword($password, $uid);
+		if ($event->hasArgument('type')) {
+			$type = $event->getArgument('type');
+		} else {
+			$type = 'user';
+		}
+		$this->engine->verifyPassword($password, $uid, $type);
 	}
 
 	public function updateLinkExpiry($params) {

--- a/tests/EngineTest.php
+++ b/tests/EngineTest.php
@@ -131,6 +131,14 @@ class EngineTest extends TestCase {
 	}
 
 	/**
+	 * @dataProvider providesTypes
+	 */
+	public function testPolicyPassesEmptyPasswordTypePublic() {
+		$engine = $this->createEngine(['spv_min_chars_checked' => true]);
+		$engine->verifyPassword('', null, 'public');
+	}
+
+	/**
 	 * @dataProvider providesFailTestData
 	 * @param array $config
 	 * @param $password

--- a/tests/HooksHandlerTest.php
+++ b/tests/HooksHandlerTest.php
@@ -115,6 +115,15 @@ class HooksHandlerTest extends TestCase {
 		$this->handler->verifyPassword($event);
 	}
 
+	public function testVerifyPasswordWithPasswordAndType() {
+		$this->engine->expects($this->once())
+			->method('verifyPassword')
+			->with('secret', null, 'guest');
+
+		$event = new GenericEvent(null, ['password' => 'secret', 'type' => 'guest']);
+		$this->handler->verifyPassword($event);
+	}
+
 	public function updateLinkExpiryProvider() {
 		$tomorrow = new \DateTime();
 		$tomorrow->setTime(0,0,0);


### PR DESCRIPTION
- Pass along new password "type" argument which can be "user", "guest" or "public" from "validatePassword" event.
- Allow empty public link passwords even when rules are set

In the future this will allow easier splitting of rules between "user password" and "public link password".

The PR as is will not do anything and requires the following core changes to work:
- [ ] TODO: core PR
