### PR TITLE
Check password type based on event name + allow empty password for public links

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -31,11 +31,11 @@ OCP\Util::connectHook(
 $eventDispatcher = \OC::$server->getEventDispatcher();
 $eventDispatcher->addListener(
 	'OCP\User::validatePassword',
-	[$handler, 'verifyPassword']
+	[$handler, 'verifyUserPassword']
 );
 $eventDispatcher->addListener(
 	'OCP\Share::validatePassword',
-	[$handler, 'verifyPassword']
+	[$handler, 'verifyPublicPassword']
 );
 $eventDispatcher->addListener(
 	'OCP\User::createPassword',

--- a/lib/Engine.php
+++ b/lib/Engine.php
@@ -105,9 +105,10 @@ class Engine {
 	/**
 	 * @param string $password
 	 * @param string $uid
+	 * @param string $type
 	 * @throws PolicyException
 	 */
-	public function verifyPassword($password, $uid = null) {
+	public function verifyPassword($password, $uid = null, $type = 'user') {
 		if ($this->yes('spv_min_chars_checked')) {
 			$val = (int) $this->configValues['spv_min_chars_value'];
 			$r = new Length($this->l10n);

--- a/lib/Engine.php
+++ b/lib/Engine.php
@@ -109,6 +109,12 @@ class Engine {
 	 * @throws PolicyException
 	 */
 	public function verifyPassword($password, $uid = null, $type = 'user') {
+		// skip policy when no password is specified for public link
+		// enforcement of password existence is done on a different level
+		if ($type === 'public' && ($password === null || $password === '')) {
+			return;
+		}
+
 		if ($this->yes('spv_min_chars_checked')) {
 			$val = (int) $this->configValues['spv_min_chars_value'];
 			$r = new Length($this->l10n);

--- a/lib/HooksHandler.php
+++ b/lib/HooksHandler.php
@@ -129,7 +129,23 @@ class HooksHandler {
 	 * @param GenericEvent $event
 	 * @throws PolicyException
 	 */
-	public function verifyPassword(GenericEvent $event) {
+	public function verifyUserPassword(GenericEvent $event) {
+		$this->verifyPassword($event, 'user');
+	}
+
+	/**
+	 * @param GenericEvent $event
+	 * @throws PolicyException
+	 */
+	public function verifyPublicPassword(GenericEvent $event) {
+		$this->verifyPassword($event, 'public');
+	}
+
+	/**
+	 * @param GenericEvent $event
+	 * @throws PolicyException
+	 */
+	private function verifyPassword(GenericEvent $event, $type = 'user') {
 		$this->fixDI();
 		$password = $event->getArguments()['password'];
 		if ($event->hasArgument('uid')) {
@@ -137,7 +153,7 @@ class HooksHandler {
 		} else {
 			$uid = null;
 		}
-		$this->engine->verifyPassword($password, $uid);
+		$this->engine->verifyPassword($password, $uid, $type);
 	}
 
 	public function updateLinkExpiry($params) {

--- a/tests/EngineTest.php
+++ b/tests/EngineTest.php
@@ -131,6 +131,14 @@ class EngineTest extends TestCase {
 	}
 
 	/**
+	 * @dataProvider providesTypes
+	 */
+	public function testPolicyPassesEmptyPasswordTypePublic() {
+		$engine = $this->createEngine(['spv_min_chars_checked' => true]);
+		$engine->verifyPassword('', null, 'public');
+	}
+
+	/**
 	 * @dataProvider providesFailTestData
 	 * @param array $config
 	 * @param $password

--- a/tests/HooksHandlerTest.php
+++ b/tests/HooksHandlerTest.php
@@ -103,7 +103,7 @@ class HooksHandlerTest extends TestCase {
 			->with('secret', null);
 
 		$event = new GenericEvent(null, ['password' => 'secret']);
-		$this->handler->verifyPassword($event);
+		$this->handler->verifyUserPassword($event);
 	}
 
 	public function testVerifyPasswordWithPasswordAndUid() {
@@ -112,7 +112,25 @@ class HooksHandlerTest extends TestCase {
 			->with('secret', 'testuid');
 
 		$event = new GenericEvent(null, ['uid' => 'testuid', 'password' => 'secret']);
-		$this->handler->verifyPassword($event);
+		$this->handler->verifyUserPassword($event);
+	}
+
+	public function testVerifyUserPassword() {
+		$this->engine->expects($this->once())
+			->method('verifyPassword')
+			->with('secret', null, 'user');
+
+		$event = new GenericEvent(null, ['password' => 'secret']);
+		$this->handler->verifyUserPassword($event);
+	}
+
+	public function testVerifyPublicPassword() {
+		$this->engine->expects($this->once())
+			->method('verifyPassword')
+			->with('secret', null, 'public');
+
+		$event = new GenericEvent(null, ['password' => 'secret']);
+		$this->handler->verifyPublicPassword($event);
 	}
 
 	public function updateLinkExpiryProvider() {


### PR DESCRIPTION
- Pass along new password "type" argument which can be "user", "public" based from the namespace of the "validatePassword" event
- Allow empty public link passwords even when rules are set

No core changes required.
