### PR TITLE
New password must not match current one when resetting

### DIFF
--- a/lib/Controller/PasswordController.php
+++ b/lib/Controller/PasswordController.php
@@ -145,6 +145,13 @@ class PasswordController extends Controller implements IAccountModuleController 
 			);
 		}
 
+		if ($new_password === $current_password) {
+			return $this->createPasswordTemplateResponse(
+				$redirect_url,
+				$this->l10n->t('Password must be different than the old password.')
+			);
+		}
+
 		$user = $this->userSession->getUser();
 
 		if(!$this->userManager->checkPassword($user->getUID(), $current_password)) {

--- a/tests/Controller/PasswordControllerTest.php
+++ b/tests/Controller/PasswordControllerTest.php
@@ -151,6 +151,26 @@ class PasswordControllerTest extends TestCase {
 		$this->c->update(null, 'newsecret', 'different', $redirect_url);
 	}
 
+	public function testUpdatePasswordsMatchesCurrent() {
+		$redirect_url = 'redirect/target';
+		$this->c->expects($this->once())
+			->method('createPasswordTemplateResponse')
+			->with($redirect_url, 'Password must be different than the old password.');
+
+		$this->userSession
+			->expects($this->never())
+			->method('getUser');
+
+		$this->session
+			->expects($this->never())
+			->method('remove');
+		$this->config
+			->expects($this->never())
+			->method('deleteUserValue');
+
+		$this->c->update('oldsecret', 'oldsecret', 'oldsecret', $redirect_url);
+	}
+
 	public function testUpdateWrongPassword() {
 		$user = $this->createMock(IUser::class);
 		$user


### PR DESCRIPTION
When forcing existing users to change their password and no entry exists
in the history table, we must still prevent the user to set the password
to the same as the current one.

Found this bug and fixed it directly.

