### PR TITLE
Report correct expire date for expire-password command

### DIFF
--- a/lib/Command/ExpirePassword.php
+++ b/lib/Command/ExpirePassword.php
@@ -110,14 +110,19 @@ class ExpirePassword extends Command {
 			return 1;
 		}
 
-		$date = new \DateTime();
-		$date->setTimezone(new \DateTimeZone('UTC'));
-		$date->setTimestamp($this->timeFactory->getTime());
-		$date->modify($input->getArgument('expiredate'));
+		$expireDate = new \DateTime();
+		$expireDate->setTimezone(new \DateTimeZone('UTC'));
+		$expireDate->setTimestamp($this->timeFactory->getTime());
+		$expireDate->modify($input->getArgument('expiredate'));
+
+		$oldDate = new \DateTime();
+		$oldDate->setTimezone(new \DateTimeZone('UTC'));
+		$oldDate->setTimestamp($this->timeFactory->getTime());
+		$oldDate->modify($input->getArgument('expiredate'));
 
 		if ($this->config->getAppValue('password_policy', 'spv_user_password_expiration_checked', false) === 'on') {
 			$delta = $this->config->getAppValue('password_policy', 'spv_user_password_expiration_value', 90);
-			$date->modify("-$delta days");
+			$oldDate->modify("-$delta days");
 		}
 
 		$this->config->deleteUserValue(
@@ -131,12 +136,12 @@ class ExpirePassword extends Command {
 		$oldPassword = new OldPassword();
 		$oldPassword->setUid($uid);
 		$oldPassword->setPassword(OldPassword::EXPIRED);
-		$oldPassword->setChangeTime($date->getTimestamp());
+		$oldPassword->setChangeTime($oldDate->getTimestamp());
 		$this->mapper->insert($oldPassword);
 
 		// show expire date if it was given
 		if ($input->hasArgument('expiredate')) {
-			$output->writeln("The password for $uid is set to expire on ". $date->format('Y-m-d H:i:s T').'.');
+			$output->writeln("The password for $uid is set to expire on ". $expireDate->format('Y-m-d H:i:s T').'.');
 		}
 		return 0;
 	}

--- a/lib/Command/ExpirePassword.php
+++ b/lib/Command/ExpirePassword.php
@@ -40,6 +40,9 @@ class ExpirePassword extends Command {
 	/** @var \OCP\IUserManager */
 	protected $userManager;
 
+	/** @var ITimeFactory */
+	private $timeFactory;
+
 	/** @var OldPasswordMapper */
 	private $mapper;
 
@@ -58,8 +61,8 @@ class ExpirePassword extends Command {
 		parent::__construct();
 		$this->config = $config;
 		$this->userManager = $userManager;
-		$this->mapper = $mapper;
 		$this->timeFactory = $timeFactory;
+		$this->mapper = $mapper;
 	}
 
 	protected function configure() {

--- a/tests/Command/ExpirePasswordTest.php
+++ b/tests/Command/ExpirePasswordTest.php
@@ -79,20 +79,21 @@ class ExpirePasswordTest extends TestCase {
 	public function providesExpirePassword() {
 		return [
 			// expire immediately, no policy, defaults to -1 days
-			[null, null, '2018-06-27 10:13:00 UTC'],
+			[null, null, '2018-06-27 10:13:00 UTC', '2018-06-27 10:13:00 UTC'],
 			// expire later, no policy
-			['2018-06-28 10:13 UTC', null, '2018-06-28 10:13:00 UTC'],
+			['2018-06-28 10:13 UTC', null, '2018-06-28 10:13:00 UTC', '2018-06-28 10:13:00 UTC'],
 			// expire immediately, with policy, defaults to -1 days
-			[null, 7, '2018-06-20 10:13:00 UTC'],
+			[null, 7, '2018-06-20 10:13:00 UTC', '2018-06-27 10:13:00 UTC'],
 			// expire later, with policy
-			['2018-06-28 10:13 UTC', 7, '2018-06-21 10:13:00 UTC'],
+			['2018-06-28 10:13 UTC', 7, '2018-06-21 10:13:00 UTC', '2018-06-28 10:13:00 UTC'],
 		];
 	}
 
 	/**
 	 * @dataProvider providesExpirePassword
 	 */
-	public function testExpirePassword($expireArg, $expireRuleDays, $expectedTimestamp) {
+	public function testExpirePassword(
+		$expireArg, $expireRuleDays, $expectedHistoryTimestamp, $expectedReportedTimestamp) {
 		$user = $this->createMock(IUser::class);
 		$user
 			->expects($this->once())
@@ -129,11 +130,11 @@ class ExpirePasswordTest extends TestCase {
 		]);
 
 		$output = $this->commandTester->getDisplay();
-		self::assertContains("The password for existing-uid is set to expire on $expectedTimestamp.", $output);
+		self::assertContains("The password for existing-uid is set to expire on $expectedReportedTimestamp.", $output);
 
 		$this->assertEquals('existing-uid', $oldPassword->getUid());
 		$this->assertEquals(OldPassword::EXPIRED, $oldPassword->getPassword());
-		$this->assertEquals((new \DateTime($expectedTimestamp))->getTimestamp(), $oldPassword->getChangeTime());
+		$this->assertEquals((new \DateTime($expectedHistoryTimestamp))->getTimestamp(), $oldPassword->getChangeTime());
 	}
 
 	public function testCannotExpirePassword() {


### PR DESCRIPTION
The command was doing stuff like:
```
./occ user:expire-password u222
The password for u222 is set to expire on 2018-04-13 15:45:48 UTC.

./occ user:expire-password u222 "2018-07-20"
The password for u222 is set to expire on 2018-04-21 00:00:00 UTC.
```
reporting the date 90 days before the expiry date.

After this change:
```
./occ user:expire-password u222 "2018-07-21 00:01:00"
The password for u222 is set to expire on 2018-07-21 00:01:00 UTC.
```
and the ``user_password_history`` table has a timestamp back 90 days from that, as it should.