### PR TITLE
Return a constant not a magic number if the user is null

### DIFF
--- a/lib/Command/ExpirePassword.php
+++ b/lib/Command/ExpirePassword.php
@@ -40,6 +40,12 @@ class ExpirePassword extends Command {
 	 */
 	const EX_GENERAL_ERROR = 1;
 
+	/**
+	 * return EX_NOUSER from /usr/include/sysexits.h
+	 * @see http://tldp.org/LDP/abs/html/exitcodes.html#FTN.AEN23647
+	 */
+	const EX_NOUSER = 67;
+
 	/** @var \OCP\IConfig */
 	private $config;
 
@@ -107,11 +113,7 @@ class ExpirePassword extends Command {
 
 		if ($user === null) {
 			$output->writeln("<error>Unknown user: $uid</error>");
-			/**
-			 * return EX_NOUSER from /usr/include/sysexits.h
-			 * @see http://tldp.org/LDP/abs/html/exitcodes.html#FTN.AEN23647
-			 */
-			return 67;
+			return self::EX_NOUSER;
 		}
 
 		if (!$user->canChangePassword()) {

--- a/tests/Command/ExpirePasswordTest.php
+++ b/tests/Command/ExpirePasswordTest.php
@@ -68,12 +68,14 @@ class ExpirePasswordTest extends TestCase {
 			->with('not-existing-uid')
 			->willReturn(null);
 
-		$this->commandTester->execute([
+		$returnCode = $this->commandTester->execute([
 			'uid' => 'not-existing-uid',
 			'expiredate' => '2018-06-28 10:13 UTC'
-			]);
+		]);
 		$output = $this->commandTester->getDisplay();
+
 		self::assertContains('Unknown user: not-existing-uid', $output);
+		self::assertSame(67, $returnCode);
 	}
 
 	public function providesExpirePassword() {


### PR DESCRIPTION
This PR refactors the return of the magic (though documented) number "67" as a class constant. While the return statement, when the user is null, is clearly documented, I believe that using a constant instead of a magic number makes the code clearer and more maintainable.