### PR TITLE
Return a constant if the user cannot change their password

### DIFF
--- a/lib/Command/ExpirePassword.php
+++ b/lib/Command/ExpirePassword.php
@@ -34,6 +34,12 @@ use OCP\AppFramework\Utility\ITimeFactory;
 
 
 class ExpirePassword extends Command {
+	/**
+	 * Catchall for general errors
+	 * @see http://tldp.org/LDP/abs/html/exitcodes.html#FTN.AEN23647
+	 */
+	const EX_GENERAL_ERROR = 1;
+
 	/** @var \OCP\IConfig */
 	private $config;
 
@@ -110,7 +116,7 @@ class ExpirePassword extends Command {
 
 		if (!$user->canChangePassword()) {
 			$output->writeln("<error>The user's backend doesn't support password changes. The password cannot be expired for user: $uid</error>");
-			return 1;
+			return self::EX_GENERAL_ERROR;
 		}
 
 		$expireDate = new \DateTime();

--- a/tests/Command/ExpirePasswordTest.php
+++ b/tests/Command/ExpirePasswordTest.php
@@ -150,12 +150,14 @@ class ExpirePasswordTest extends TestCase {
 			->with('existing-uid')
 			->willReturn($user);
 
-		$this->commandTester->execute([
+		$returnCode = $this->commandTester->execute([
 			'uid' => 'existing-uid',
 			'expiredate' => '2018-06-28 10:13 UTC'
 		]);
 		$output = $this->commandTester->getDisplay();
+
 		self::assertContains("The user's backend doesn't support password changes. The password cannot be expired for user: existing-uid", $output);
+		self::assertSame(1, $returnCode);
 	}
 
 }


### PR DESCRIPTION
This PR refactors the return of the magic number "1" when the user cannot change their password to be a class constant. I believe that using a constant instead of a magic number makes the code clearer and more maintainable.