### PR TITLE
Minimise ExpirePassword's execute method

### DIFF
--- a/lib/Command/ExpirePassword.php
+++ b/lib/Command/ExpirePassword.php
@@ -116,7 +116,10 @@ class ExpirePassword extends Command {
 		}
 
 		if (!$user->canChangePassword()) {
-			$output->writeln("<error>The user's backend doesn't support password changes. The password cannot be expired for user: {$user->getUID()}</error>");
+			$output->writeln(sprintf(
+				"<error>The user's backend doesn't support password changes. The password cannot be expired for user: %s.</error>",
+				$user->getUID()
+			));
 			return self::EX_GENERAL_ERROR;
 		}
 
@@ -144,7 +147,11 @@ class ExpirePassword extends Command {
 		// show expire date if it was given
 		if ($input->hasArgument('expiredate')) {
 			$expireDate = $this->getExpiryDateTime($input->getArgument('expiredate'));
-			$output->writeln("The password for {$user->getUID()} is set to expire on " . $expireDate->format('Y-m-d H:i:s T') . '.');
+			$output->writeln(sprintf(
+				"The password for %s is set to expire on %s.",
+				$user->getUID(),
+				$expireDate->format('Y-m-d H:i:s T')
+			));
 		}
 
 		return self::EX_SUCCESS;

--- a/lib/Command/ExpirePassword.php
+++ b/lib/Command/ExpirePassword.php
@@ -121,15 +121,7 @@ class ExpirePassword extends Command {
 			return self::EX_GENERAL_ERROR;
 		}
 
-		$expireDate = new \DateTime();
-		$expireDate->setTimezone(new \DateTimeZone('UTC'));
-		$expireDate->setTimestamp($this->timeFactory->getTime());
-		$expireDate->modify($input->getArgument('expiredate'));
-
-		$oldDate = new \DateTime();
-		$oldDate->setTimezone(new \DateTimeZone('UTC'));
-		$oldDate->setTimestamp($this->timeFactory->getTime());
-		$oldDate->modify($input->getArgument('expiredate'));
+		$oldDate = $this->getExpiryDateTime($input->getArgument('expiredate'));
 
 		if ($this->config->getAppValue('password_policy', 'spv_user_password_expiration_checked', false) === 'on') {
 			$delta = $this->config->getAppValue('password_policy', 'spv_user_password_expiration_value', 90);
@@ -153,7 +145,25 @@ class ExpirePassword extends Command {
 		// show expire date if it was given
 		if ($input->hasArgument('expiredate')) {
 			$output->writeln("The password for $uid is set to expire on ". $expireDate->format('Y-m-d H:i:s T').'.');
+			$expireDate = $this->getExpiryDateTime($input->getArgument('expiredate'));
 		}
 		return 0;
+
+	/**
+	 * Return a DateTime object, optionally modified by $expiryDate
+	 * @param string $expiryDate
+	 * @return \DateTime
+	 */
+	public function getExpiryDateTime($expiryDate)
+	{
+		$dateTime = (new \DateTime(
+			'now', new \DateTimeZone('UTC')
+		))->setTimestamp($this->timeFactory->getTime());
+
+		if (!empty((string)$expiryDate)) {
+			$dateTime->modify($expiryDate);
+		}
+
+		return $dateTime;
 	}
 }

--- a/lib/Command/ExpirePassword.php
+++ b/lib/Command/ExpirePassword.php
@@ -136,11 +136,11 @@ class ExpirePassword extends Command {
 
 		// add a dummy password in the user_password_history so the cron job
 		// can notify about the expiration of the password.
-		$oldPassword = new OldPassword();
-		$oldPassword->setUid($uid);
-		$oldPassword->setPassword(OldPassword::EXPIRED);
-		$oldPassword->setChangeTime($oldDate->getTimestamp());
-		$this->mapper->insert($oldPassword);
+		$this->mapper->insert(OldPassword::fromParams([
+			'uid' => $uid,
+			'password' => OldPassword::EXPIRED,
+			'changeTime' => $oldDate->getTimestamp(),
+		]));
 
 		// show expire date if it was given
 		if ($input->hasArgument('expiredate')) {

--- a/lib/Command/ExpirePassword.php
+++ b/lib/Command/ExpirePassword.php
@@ -39,6 +39,7 @@ class ExpirePassword extends Command {
 	 * @see http://tldp.org/LDP/abs/html/exitcodes.html#FTN.AEN23647
 	 */
 	const EX_GENERAL_ERROR = 1;
+	const EX_SUCCESS = 0;
 
 	/**
 	 * return EX_NOUSER from /usr/include/sysexits.h
@@ -105,8 +106,7 @@ class ExpirePassword extends Command {
 	 * @return int
 	 * @throws \OCP\PreConditionNotMetException
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output)
-	{
+	protected function execute(InputInterface $input, OutputInterface $output) {
 		/** @var $user \OCP\IUser */
 		$user = $this->userManager->get($input->getArgument('uid'));
 
@@ -147,7 +147,7 @@ class ExpirePassword extends Command {
 			$output->writeln("The password for {$user->getUID()} is set to expire on " . $expireDate->format('Y-m-d H:i:s T') . '.');
 		}
 
-		return 0;
+		return self::EX_SUCCESS;
 	}
 
 	/**

--- a/tests/Command/ExpirePasswordTest.php
+++ b/tests/Command/ExpirePasswordTest.php
@@ -162,4 +162,39 @@ class ExpirePasswordTest extends TestCase {
 		self::assertSame(1, $returnCode);
 	}
 
+	/**
+	 * @dataProvider providesDateTimeString
+	 */
+	public function testCanRetrieveDateTimeCorrectly($dateTimeString)
+	{
+		$time = 1530180780;
+
+		$this->timeFactory
+			->method('getTime')
+			->willReturn($time);
+
+		$command = new ExpirePassword(
+			$this->config,
+			$this->userManager,
+			$this->timeFactory,
+			$this->mapper
+		);
+
+		$dateTime = $command->getExpiryDateTime($dateTimeString);
+
+		if (is_null($dateTimeString)) {
+			$this->assertSame($dateTime->getTimestamp(), $time);
+		} else {
+			$this->assertSame($dateTime->format('Y-m-d H:i:s T'), $dateTimeString);
+		}
+	}
+
+	public function providesDateTimeString()
+	{
+		return [
+			[null],
+			['2018-06-28 10:13:00 UTC'],
+		];
+	}
+
 }

--- a/tests/Command/ExpirePasswordTest.php
+++ b/tests/Command/ExpirePasswordTest.php
@@ -102,6 +102,11 @@ class ExpirePasswordTest extends TestCase {
 			->method('canChangePassword')
 			->willReturn(true);
 
+		$user
+			->expects($this->exactly(3))
+			->method('getUID')
+			->willReturn('existing-uid');
+
 		$this->userManager
 			->expects($this->once())
 			->method('get')
@@ -145,6 +150,11 @@ class ExpirePasswordTest extends TestCase {
 			->expects($this->once())
 			->method('canChangePassword')
 			->willReturn(false);
+
+		$user
+			->expects($this->once())
+			->method('getUID')
+			->willReturn('existing-uid');
 
 		$this->userManager
 			->expects($this->once())


### PR DESCRIPTION
While learning about the `ExpirePassword` class, so that I can update the Password Policy app's documentation, I noticed a series of small areas where the code could be simplified, so that it's easier to read and maintain, reducing the chances of potential defects. 