### PR TITLE
Add options 'all' and 'group' to expire-password command

### DIFF
--- a/tests/Command/ExpirePasswordTest.php
+++ b/tests/Command/ExpirePasswordTest.php
@@ -26,6 +26,7 @@ use OCA\PasswordPolicy\Command\ExpirePassword;
 use OCA\PasswordPolicy\Db\OldPasswordMapper;
 use OCA\PasswordPolicy\Db\OldPassword;
 use OCP\IConfig;
+use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\IUserManager;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -38,6 +39,7 @@ class ExpirePasswordTest extends TestCase {
 	protected $config;
 	/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject */
 	protected $userManager;
+	protected $groupManager;
 	/** @var ITimeFactory | \PHPUnit_Framework_MockObject_MockObject */
 	private $timeFactory;
 	/** @var OldPasswordMapper | \PHPUnit_Framework_MockObject_MockObject */
@@ -50,11 +52,13 @@ class ExpirePasswordTest extends TestCase {
 
 		$this->config = $this->createMock(IConfig::class);
 		$this->userManager = $this->createMock(IUserManager::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->mapper = $this->createMock(OldPasswordMapper::class);
 		$command = new ExpirePassword(
 			$this->config,
 			$this->userManager,
+			$this->groupManager,
 			$this->timeFactory,
 			$this->mapper
 		);
@@ -68,14 +72,110 @@ class ExpirePasswordTest extends TestCase {
 			->with('not-existing-uid')
 			->willReturn(null);
 
-		$returnCode = $this->commandTester->execute([
-			'uid' => 'not-existing-uid',
+		$this->commandTester->execute([
+			'--uid' => ['not-existing-uid'],
 			'expiredate' => '2018-06-28 10:13 UTC'
 		]);
 		$output = $this->commandTester->getDisplay();
 
 		self::assertContains('Unknown user: not-existing-uid', $output);
-		self::assertSame(67, $returnCode);
+	}
+
+	private function getAllUsers($numberOfUsers, $groupName = null) {
+		$users = [];
+		for ($i = 1; $i <= $numberOfUsers; $i++) {
+			$user = $this->createMock(IUser::class);
+			$user->expects($this->any())
+				->method('getUID')
+				->willReturn('user' . $i);
+			$user->expects($this->any())
+				->method('canChangePassword')
+				->willReturn(true);
+			if ($groupName === null) {
+				$users[] = $user;
+			} else {
+				$users[$groupName][] = $user;
+			}
+		}
+		return $users;
+	}
+
+	public function testAllUsersExpirePassword() {
+		//Lets say we have 5 users
+		$this->userManager->expects($this->once())
+			->method('callForAllUsers')
+			->will($this->returnCallback(function ($closure) {
+				for ($i = 1; $i <= 5; $i++) {
+					$user = $this->createMock(IUser::class);
+					$user->expects($this->any())
+						->method('getUID')
+						->willReturn('user' . $i);
+					$user->expects($this->once())
+						->method('canChangePassword')
+						->willReturn(true);
+					$closure($user);
+				}
+			}));
+
+		$this->timeFactory
+			->method('getTime')
+			->willReturn(1530180780);
+
+		$this->config
+			->method('getAppValue')
+			->will($this->returnValueMap([
+				['password_policy', 'spv_user_password_expiration_checked', false, 'on'],
+				['password_policy', 'spv_user_password_expiration_value', 90, 10]
+			]));
+
+		$this->commandTester->execute([
+			'--all' => null
+		]);
+
+		$output = $this->commandTester->getDisplay();
+		$expectedOutput = "The password for user1 is set to expire on 2018-06-27 10:13:00 UTC.
+The password for user2 is set to expire on 2018-06-27 10:13:00 UTC.
+The password for user3 is set to expire on 2018-06-27 10:13:00 UTC.
+The password for user4 is set to expire on 2018-06-27 10:13:00 UTC.
+The password for user5 is set to expire on 2018-06-27 10:13:00 UTC.
+";
+		$this->assertEquals($expectedOutput, $output);
+	}
+
+	public function testGroupsExpirePassword() {
+		$group1Users = $this->getAllUsers(2, 'group1');
+		$group2Users = $this->getAllUsers(3, 'group2');
+		$group4Users = $this->getAllUsers(2, 'group4,foo');
+
+		$this->groupManager->expects($this->exactly(4))
+			->method('groupExists')
+			->willReturnMap([
+				['group1', true],
+				['group2', true],
+				['group3', false],
+				['group4,foo', true]
+			]);
+
+		$this->groupManager->expects($this->any())
+			->method('findUsersInGroup')
+			->willReturnOnConsecutiveCalls($group1Users['group1'], $group2Users['group2'], $group4Users['group4,foo']);
+
+		$this->timeFactory
+			->method('getTime')
+			->willReturn(1530180780);
+
+		$this->commandTester->execute([
+			'--group' => ['group1', 'group2', 'group4,foo', 'group3'],
+			'expiredate' => '2019-01-01 14:00:00 CET'
+		]);
+
+		$output = $this->commandTester->getDisplay();
+		$expectedOutput = "The password for user1 is set to expire on 2019-01-01 14:00:00 UTC.
+The password for user2 is set to expire on 2019-01-01 14:00:00 UTC.
+The password for user3 is set to expire on 2019-01-01 14:00:00 UTC.
+Ignoring missing group group3
+";
+		$this->assertEquals($expectedOutput, $output);
 	}
 
 	public function providesExpirePassword() {
@@ -97,6 +197,9 @@ class ExpirePasswordTest extends TestCase {
 	public function testExpirePassword(
 		$expireArg, $expireRuleDays, $expectedHistoryTimestamp, $expectedReportedTimestamp) {
 		$user = $this->createMock(IUser::class);
+		$user->expects($this->any())
+			->method('getUID')
+			->willReturn('existing-uid');
 		$user
 			->expects($this->once())
 			->method('canChangePassword')
@@ -127,12 +230,12 @@ class ExpirePasswordTest extends TestCase {
 			}));
 
 		$this->commandTester->execute([
-			'uid' => 'existing-uid',
+			'--uid' => ['existing-uid'],
 			'expiredate' => $expireArg
 		]);
 
 		$output = $this->commandTester->getDisplay();
-		self::assertContains("The password for existing-uid is set to expire on $expectedReportedTimestamp.", $output);
+		$this->assertContains("The password for existing-uid is set to expire on $expectedReportedTimestamp.", $output);
 
 		$this->assertEquals('existing-uid', $oldPassword->getUid());
 		$this->assertEquals(OldPassword::EXPIRED, $oldPassword->getPassword());
@@ -152,14 +255,12 @@ class ExpirePasswordTest extends TestCase {
 			->with('existing-uid')
 			->willReturn($user);
 
-		$returnCode = $this->commandTester->execute([
-			'uid' => 'existing-uid',
+		$this->commandTester->execute([
+			'--uid' => ['existing-uid'],
 			'expiredate' => '2018-06-28 10:13 UTC'
 		]);
 		$output = $this->commandTester->getDisplay();
 
 		self::assertContains("The user's backend doesn't support password changes. The password cannot be expired for user: existing-uid", $output);
-		self::assertSame(1, $returnCode);
 	}
-
 }


### PR DESCRIPTION
Adding options 'all' and 'group' to expire-password command.

Signed-off-by: Sujith H <sharidasan@owncloud.com>