### PR TITLE
Update the messages for first time login

### DIFF
--- a/lib/HooksHandler.php
+++ b/lib/HooksHandler.php
@@ -257,7 +257,10 @@ class HooksHandler {
 	/**
 	 * Flags the session to require a password change
 	 */
-	protected function forcePasswordChange() {
+	protected function forcePasswordChange($firstLogin = null, IUser $user = null) {
+		if (($firstLogin === true) && ($user !== null)) {
+			$this->config->setUserValue($user->getUID(), 'password_policy', 'firstLoginPasswordChange', '1');
+		}
 		$this->session->set('password_policy.forcePasswordChange', true);
 	}
 
@@ -322,7 +325,7 @@ class HooksHandler {
 		// If option is enabled in security settings check first login
 		if ($this->engine->yes('spv_user_password_force_change_on_first_login_checked')) {
 			// try to find user in account table, needs find to search additional search terms,
-			$this->forcePasswordChange();
+			$this->forcePasswordChange(true, $user);
 		}
 	}
 }

--- a/templates/password.php
+++ b/templates/password.php
@@ -33,8 +33,22 @@ style('password_policy', 'styles');
 <form id="password_policy" method="post">
 	<fieldset>
 		<h1 class="warning">
-			<div><?php p($l->t('Your password has expired.')); ?></div>
-			<div><?php p($l->t('Please choose a new password.')); ?></div>
+			<div>
+				<?php
+					if ($_['firstLogin'] === true) {
+						p($l->t('Please set a new password'));
+					} else {
+						p($l->t('Your password has expired.'));
+					}
+				?>
+			</div>
+			<div>
+				<?php
+					if ($_['firstLogin'] !== true) {
+						p($l->t('Please choose a new password.'));
+					}
+				?>
+			</div>
 		</h1>
 		<?php if (isset($_['error'])) { ?><div id="error" class="warning"><?php p($_['error']) ?></div> <?php } ?>
 		<input type="hidden" name="redirect_url" value="<?php p($_['redirect_url']) ?>" />

--- a/tests/HooksHandlerTest.php
+++ b/tests/HooksHandlerTest.php
@@ -423,6 +423,14 @@ class HooksHandlerTest extends TestCase {
 
 		$event = new GenericEvent($user);
 		$this->handler->checkForcePasswordChangeOnFirstLogin($event);
+	}
 
+	/**
+	 * @expectedException \UnexpectedValueException
+	 * @expectedExceptionMessage 'foo' is not an instance of IUser.
+	 */
+	public function testCheckForcePasswordChangeOnFirstLoginException() {
+		$event = new GenericEvent('foo');
+		$this->handler->checkForcePasswordChangeOnFirstLogin($event);
 	}
 }


### PR DESCRIPTION
When first time login password change is enforced
and user tries to provide wrong passwords to the
current password, the message shown is
"Old password is wrong."

The first time login password reset is also improved to
"Please set a new password"

Signed-off-by: Sujith H <sharidasan@owncloud.com>