### PR TITLE
Remove strip_tags to include tags as special chars

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -91,7 +91,7 @@ class SettingsController extends Controller implements ISettings {
 					}
 					$this->config->setAppValue('password_policy', $key, $value);
 				} else {
-					$this->config->setAppValue('password_policy', $key, \strip_tags($this->request->getParam($key)));
+					$this->config->setAppValue('password_policy', $key, $this->request->getParam($key));
 				}
 			} else {
 				$this->config->setAppValue('password_policy', $key, $default);


### PR DESCRIPTION
If user wants to add php/html tags as special chars,
then strip_tags should not be used. This patch
addresses the issue.

Signed-off-by: Sujith H <sharidasan@owncloud.com>