### PR TITLE
Clean up tables after user deletion

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -61,6 +61,10 @@ $eventDispatcher->addListener(
 	\OCP\IUser::class . '::firstLogin',
 	[$handler, 'checkForcePasswordChangeOnFirstLogin']
 );
+$eventDispatcher->addListener(
+	'user.afterdelete',
+	[$handler, 'removeUserEntriesFromTable']
+);
 
 $app = new \OCA\PasswordPolicy\AppInfo\Application();
 $app->registerNotifier();

--- a/lib/Db/OldPasswordMapper.php
+++ b/lib/Db/OldPasswordMapper.php
@@ -105,4 +105,18 @@ class OldPasswordMapper extends Mapper {
 		}
 		$stmt->closeCursor();
 	}
+
+	/**
+	 * Remove the entries of user from the user_password_history table once the
+	 * user is deleted from oC
+	 *
+	 * @param string $uid uid of a user
+	 */
+	public function cleanUserHistory($uid) {
+		/* @var IQueryBuilder $qb */
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete('user_password_history')
+			->where($qb->expr()->eq('uid', $qb->createNamedParameter($uid)));
+		$qb->execute();
+	}
 }

--- a/lib/HooksHandler.php
+++ b/lib/HooksHandler.php
@@ -328,4 +328,17 @@ class HooksHandler {
 			$this->forcePasswordChange(true, $user);
 		}
 	}
+
+	/**
+	 * This method removes the entries which remain in oc_user_password_history
+	 * table and oc_notifications table after the deletion of the user
+	 *
+	 * @param GenericEvent $event
+	 */
+	public function removeUserEntriesFromTable(GenericEvent $event) {
+		$this->fixDI();
+		$uid = $event->getArgument('uid');
+
+		$this->oldPasswordMapper->cleanUserHistory($uid);
+	}
 }

--- a/tests/Db/OldPasswordMapperTest.php
+++ b/tests/Db/OldPasswordMapperTest.php
@@ -25,6 +25,8 @@ namespace OCA\PasswordPolicy\Tests\Db;
 
 use OCA\PasswordPolicy\Db\OldPassword;
 use OCA\PasswordPolicy\Db\OldPasswordMapper;
+use OCP\DB\QueryBuilder\IExpressionBuilder;
+use OCP\DB\QueryBuilder\IParameter;
 use OCP\IDBConnection;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use Test\TestCase;
@@ -206,5 +208,22 @@ class OldPasswordMapperTest extends TestCase {
 		$this->assertSame("{$uid}testpass3", $latestPassword->getPassword());
 		$this->assertSame($uid, $latestPassword->getUid());
 		$this->assertLessThan($baseTime + 130, $latestPassword->getChangeTime());
+	}
+
+	public function testCleanUserHistory() {
+		$baseTime = 80000;
+		$this->addInitialTestEntries($baseTime);
+
+		$this->mapper->cleanUserHistory("test1");
+
+		//No reference of test1 user should be there after cleanUserHistory called.
+		$this->assertNull($this->mapper->getLatestPassword("test1"));
+
+		$test2OldPasswordInstance = $this->mapper->getLatestPassword("test2");
+		$this->assertInstanceOf(OldPassword::class, $test2OldPasswordInstance);
+		$this->assertEquals('test2', $test2OldPasswordInstance->getUid());
+		$test3OldPasswordInstance = $this->mapper->getLatestPassword("test3");
+		$this->assertInstanceOf(OldPassword::class, $test3OldPasswordInstance);
+		$this->assertEquals('test3', $test3OldPasswordInstance->getUid());
 	}
 }

--- a/tests/HooksHandlerTest.php
+++ b/tests/HooksHandlerTest.php
@@ -433,4 +433,12 @@ class HooksHandlerTest extends TestCase {
 		$event = new GenericEvent('foo');
 		$this->handler->checkForcePasswordChangeOnFirstLogin($event);
 	}
+
+	public function testRemoveUserEntriesFromTable() {
+		$event = new GenericEvent(null, ['uid' => 'foo']);
+		$this->oldPasswordMapper->expects($this->once())
+			->method('cleanUserHistory');
+
+		$this->handler->removeUserEntriesFromTable($event);
+	}
 }


### PR DESCRIPTION
Clean up the user entries in the table after
the user is deleted.

Signed-off-by: Sujith H <sharidasan@owncloud.com>