### PR TITLE
Remember errors in lint of PHP files

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -85,7 +85,9 @@ class SettingsController extends Controller implements ISettings {
 			if ($this->request->getParam($key) !== null) {
 				if ($key !== 'spv_def_special_chars_value' && \substr($key, -6) === '_value') {
 					$value = \min(\max(0, (int)$this->request->getParam($key)), 255);
-					if (isset(self::CONVERSIONS[$key]['in'])) {
+					if (array_key_exists($key, self::CONVERSIONS)
+						&& array_key_exists('in', self::CONVERSIONS[$key])
+					) {
 						$convertFuncName = self::CONVERSIONS[$key]['in'];
 						$value = $this->$convertFuncName($value);
 					}
@@ -111,7 +113,9 @@ class SettingsController extends Controller implements ISettings {
 		$template = new Template('password_policy', 'admin');
 		foreach (self::DEFAULTS as $key => $default) {
 			$value = $this->config->getAppValue('password_policy', $key, $default);
-			if (isset(self::CONVERSIONS[$key]['out'])) {
+			if (array_key_exists($key, self::CONVERSIONS)
+				&& array_key_exists('out', self::CONVERSIONS[$key])
+			) {
 				$convertFuncName = self::CONVERSIONS[$key]['out'];
 				$value = $this->$convertFuncName($value);
 			}

--- a/tests/travis/lint.sh
+++ b/tests/travis/lint.sh
@@ -2,4 +2,20 @@
 
 set -e
 
-find . -name \*.php -not -path './vendor/*' -exec php -l "{}" \;
+find . -name \*.php -not -path './vendor/*' -exec bash -c 'php -l "{}" || echo "{}">>lint-errors.txt' \;
+EXIT_STATUS=$?
+if [ ${EXIT_STATUS} -ne 0 ]
+then
+	echo "Error in find in lint.sh script"
+	exit ${EXIT_STATUS}
+fi
+
+if [ -e lint-errors.txt ]
+then
+	echo "**** Lint errors were detected in the following files:"
+	cat lint-errors.txt
+	rm lint-errors.txt
+	exit 1
+else
+	exit 0
+fi


### PR DESCRIPTION
The bash ``find`` command ignores the individual exit status of the ``exec``ed command that is done each time in the loop. So we are not getting a Travis fail when there is a lint problem found in the PHP code.

Taken from ideas here: https://unix.stackexchange.com/questions/195677/bash-error-handling-on-find-exec

When something goes wrong with ``php -l`` then put the related file names into a file. At the end, if the file exists, write out the file names with problems and exit with an error status.