### PR TITLE
PHP style and PHP unit on drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,209 @@
+workspace:
+  base: /var/www/owncloud
+  path: apps/password_policy
+
+branches: [master, release*, release/*]
+
+pipeline:
+  install-server:
+    image: owncloudci/core
+    version: ${OC_VERSION}
+    pull: true
+    db_type: ${DB_TYPE}
+    db_name: ${DB_NAME}
+    db_host: ${DB_TYPE}
+    db_username: autotest
+    db_password: owncloud
+    exclude: apps/password_policy
+    when:
+      matrix:
+        NEED_SERVER: true
+
+  install-app:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    commands:
+      - cd /var/www/owncloud/
+      - php occ a:l
+      - php occ a:e password_policy
+      - php occ a:e testing
+      - php occ a:l
+      - php occ config:system:set trusted_domains 1 --value=owncloud
+      - php occ log:manage --level 0
+    when:
+      matrix:
+        NEED_INSTALL_APP: true
+
+  fix-permissions:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    commands:
+    - chown www-data /var/www/owncloud -R
+
+  owncloud-log:
+    image: owncloud/ubuntu:16.04
+    detach: true
+    pull: true
+    commands:
+      - tail -f /var/www/owncloud/data/owncloud.log
+    when:
+      matrix:
+        NEED_SERVER: true
+
+  php-cs-fixer:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    commands:
+      - cd /var/www/owncloud/apps/password_policy
+      - make test-php-style
+    when:
+      matrix:
+        TEST_SUITE: php-cs-fixer
+
+  phpunit-tests:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    environment:
+      - PHP_VERSION=${PHP_VERSION}
+    commands:
+      - cd /var/www/owncloud/apps/password_policy
+      - make test-php-unit
+    when:
+      matrix:
+        TEST_SUITE: phpunit
+
+# TODO codecov
+#  codecov:
+#    image: plugins/codecov:2
+#    secrets: [codecov_token]
+#    pull: true
+#    paths:
+#     - tests/unit/clover.xml
+#    files:
+#     - '*.xml'
+#    when:
+#      matrix:
+#        TEST_SUITE: phpunit
+#        PHP_VERSION: 7.2
+#        DB_TYPE: mysql
+#        OC_VERSION: daily-master-qa
+
+  notify:
+    image: plugins/slack:1
+    pull: true
+    secrets: [ slack_webhook ]
+    channel: builds
+    when:
+      status: [ failure, changed ]
+      event: [ push, tag ]
+
+services:
+  mysql:
+    image: mysql:5.5
+    environment:
+      - MYSQL_USER=autotest
+      - MYSQL_PASSWORD=owncloud
+      - MYSQL_DATABASE=${DB_NAME}
+      - MYSQL_ROOT_PASSWORD=owncloud
+    when:
+      matrix:
+        DB_TYPE: mysql
+
+  pgsql:
+    image: postgres:9.4
+    environment:
+      - POSTGRES_USER=autotest
+      - POSTGRES_PASSWORD=owncloud
+      - POSTGRES_DB=${DB_NAME}
+    when:
+      matrix:
+        DB_TYPE: pgsql
+
+  oci:
+    image: deepdiver/docker-oracle-xe-11g
+    environment:
+       - ORACLE_USER=system
+       - ORACLE_PASSWORD=oracle
+       - ORACLE_DB=${DB_NAME}
+    when:
+      matrix:
+        DB_TYPE: oci
+
+matrix:
+  include:
+    # php-cs-fixer
+    - PHP_VERSION: 7.2
+      TEST_SUITE: php-cs-fixer
+
+    # Unit Tests
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      TEST_SUITE: phpunit
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      TEST_SUITE: phpunit
+      DB_TYPE: pgsql
+      DB_NAME: owncloud
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      TEST_SUITE: phpunit
+      DB_TYPE: oci
+      DB_NAME: XE
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+
+    - PHP_VERSION: 7.2
+      OC_VERSION: daily-master-qa
+      TEST_SUITE: phpunit
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+
+    - PHP_VERSION: 5.6
+      OC_VERSION: daily-stable10-qa
+      TEST_SUITE: phpunit
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+
+    - PHP_VERSION: 7.0
+      OC_VERSION: daily-stable10-qa
+      TEST_SUITE: phpunit
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+
+    - PHP_VERSION: 7.0
+      OC_VERSION: daily-stable10-qa
+      TEST_SUITE: phpunit
+      DB_TYPE: pgsql
+      DB_NAME: owncloud
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+
+    - PHP_VERSION: 7.0
+      OC_VERSION: daily-stable10-qa
+      TEST_SUITE: phpunit
+      DB_TYPE: oci
+      DB_NAME: XE
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-stable10-qa
+      TEST_SUITE: phpunit
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -152,13 +152,14 @@ matrix:
       NEED_SERVER: true
       NEED_INSTALL_APP: true
 
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: phpunit
-      DB_TYPE: oci
-      DB_NAME: XE
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
+# Oracle unit test failures - see issue 103
+#    - PHP_VERSION: 7.1
+#      OC_VERSION: daily-master-qa
+#      TEST_SUITE: phpunit
+#      DB_TYPE: oci
+#      DB_NAME: XE
+#      NEED_SERVER: true
+#      NEED_INSTALL_APP: true
 
     - PHP_VERSION: 7.2
       OC_VERSION: daily-master-qa
@@ -192,13 +193,14 @@ matrix:
       NEED_SERVER: true
       NEED_INSTALL_APP: true
 
-    - PHP_VERSION: 7.0
-      OC_VERSION: daily-stable10-qa
-      TEST_SUITE: phpunit
-      DB_TYPE: oci
-      DB_NAME: XE
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
+# Oracle unit test failures - see issue 103
+#    - PHP_VERSION: 7.0
+#      OC_VERSION: daily-stable10-qa
+#      TEST_SUITE: phpunit
+#      DB_TYPE: oci
+#      DB_NAME: XE
+#      NEED_SERVER: true
+#      NEED_INSTALL_APP: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-stable10-qa

--- a/.drone.yml
+++ b/.drone.yml
@@ -139,6 +139,14 @@ matrix:
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
       TEST_SUITE: phpunit
+      DB_TYPE: sqlite
+      DB_NAME: owncloud
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      TEST_SUITE: phpunit
       DB_TYPE: mysql
       DB_NAME: owncloud
       NEED_SERVER: true
@@ -165,6 +173,14 @@ matrix:
       OC_VERSION: daily-master-qa
       TEST_SUITE: phpunit
       DB_TYPE: mysql
+      DB_NAME: owncloud
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+
+    - PHP_VERSION: 5.6
+      OC_VERSION: daily-stable10-qa
+      TEST_SUITE: phpunit
+      DB_TYPE: sqlite
       DB_NAME: owncloud
       NEED_SERVER: true
       NEED_INSTALL_APP: true


### PR DESCRIPTION
Add ``.drone.yml`` that runs php-cs-fixer ("equivalent/better than" lint on Travis) and PHP unit tests (on sqLite, mySQL and pgSQL). See issue #101 for the reason that Oracle is commented out.

codecov is commented out for now. It can be added by whoever manages the "secrets".

I suggest we:
- commit this
- change the GitHub CI so drone is required and Travis is optional
- then I will make a PR to remove the Travis stuff