### PR TITLE
Do not rely on sorted list from getPasswordsAboutToExpire()

### DIFF
--- a/tests/unit/Db/OldPasswordMapperTest.php
+++ b/tests/unit/Db/OldPasswordMapperTest.php
@@ -169,6 +169,14 @@ class OldPasswordMapperTest extends TestCase {
 		// last password change before the timestamp
 		$this->assertCount(2, $passwordList);
 
+		// The password list is not necessarily sorted in the order of the UIDs
+		if ($passwordList[1]->getUid() == $this->testUIDs[0]) {
+			// Swap entries to sort them for the checks below
+			$savedEntry = $passwordList[0];
+			$passwordList[0] = $passwordList[1];
+			$passwordList[1] = $savedEntry;
+		}
+
 		$uid = $this->testUIDs[0];
 		$latestPassword = $passwordList[0];
 		$this->assertSame("{$uid}testpass3", $latestPassword->getPassword());
@@ -190,6 +198,26 @@ class OldPasswordMapperTest extends TestCase {
 		$passwordList = \iterator_to_array($passwordList);  // convert to array
 		// last password change before the timestamp
 		$this->assertCount(3, $passwordList);
+
+		// The password list is not necessarily sorted in the order of the UIDs
+		if ($passwordList[1]->getUid() == $this->testUIDs[0]) {
+			// Swap entries to sort them for the checks below
+			$savedEntry = $passwordList[0];
+			$passwordList[0] = $passwordList[1];
+			$passwordList[1] = $savedEntry;
+		}
+		if ($passwordList[2]->getUid() == $this->testUIDs[0]) {
+			// Swap entries to sort them for the checks below
+			$savedEntry = $passwordList[0];
+			$passwordList[0] = $passwordList[2];
+			$passwordList[2] = $savedEntry;
+		}
+		if ($passwordList[2]->getUid() == $this->testUIDs[1]) {
+			// Swap entries to sort them for the checks below
+			$savedEntry = $passwordList[1];
+			$passwordList[1] = $passwordList[2];
+			$passwordList[2] = $savedEntry;
+		}
 
 		$uid = $this->testUIDs[0];
 		$latestPassword = $passwordList[0];


### PR DESCRIPTION
When I run these tests that do ``getPasswordsAboutToExpire()`` and parse/check the returned list, they fail on pgSQL. The underlying query does not do any sorting - the list is returned from the database in whatever order the database feels like. This should be OK, I think we just need to make the tests not expect any particular order.

I have implemented just a dumb "serial" sort for the test cases that expect more than 1 item in the returned list.