### PR TITLE
webUI tests for disabling password policies

### DIFF
--- a/tests/acceptance/features/bootstrap/PasswordPolicyContext.php
+++ b/tests/acceptance/features/bootstrap/PasswordPolicyContext.php
@@ -43,11 +43,227 @@ class PasswordPolicyContext implements Context {
 	 * @return string "on" or ""
 	 */
 	private function appSettingIsExpectedToBe($enabledOrDisabled) {
-		if ($enabledOrDisabled === "enabled") {
+		if (\substr($enabledOrDisabled, 0, 6) === "enable") {
 			return 'on';
 		} else {
 			return '';
 		}
+	}
+
+	/**
+	 * @When /^the administrator (enables|disables) the minimum characters password policy using the occ commmand$/
+	 * @Given /^the administrator has (enabled|disabled) the minimum characters password policy$/
+	 *
+	 * @param string $action
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdminTogglesMinimumCharactersPasswordPolicyUsingOcc(
+		$action
+	) {
+		$this->setPasswordPolicySetting(
+			'spv_min_chars_checked',
+			$this->appSettingIsExpectedToBe($action)
+		);
+	}
+
+	/**
+	 * @When /^the administrator (enables|disables) the lowercase letters password policy using the occ commmand$/
+	 * @Given /^the administrator has (enabled|disabled) the lowercase letters password policy$/
+	 *
+	 * @param string $action
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdminTogglesLowercaseLettersPasswordPolicyUsingOcc(
+		$action
+	) {
+		$this->setPasswordPolicySetting(
+			'spv_lowercase_checked',
+			$this->appSettingIsExpectedToBe($action)
+		);
+	}
+
+	/**
+	 * @When /^the administrator (enables|disables) the uppercase letters password policy using the occ commmand$/
+	 * @Given /^the administrator has (enabled|disabled) the uppercase letters password policy$/
+	 *
+	 * @param string $action
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdminTogglesUppercaseLettersPasswordPolicyUsingOcc(
+		$action
+	) {
+		$this->setPasswordPolicySetting(
+			'spv_uppercase_checked',
+			$this->appSettingIsExpectedToBe($action)
+		);
+	}
+
+	/**
+	 * @When /^the administrator (enables|disables) the numbers password policy using the occ commmand$/
+	 * @Given /^the administrator has (enabled|disabled) the numbers password policy$/
+	 *
+	 * @param string $action
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdminTogglesNumbersPasswordPolicyUsingOcc(
+		$action
+	) {
+		$this->setPasswordPolicySetting(
+			'spv_numbers_checked',
+			$this->appSettingIsExpectedToBe($action)
+		);
+	}
+
+	/**
+	 * @When /^the administrator (enables|disables) the special characters password policy using the occ commmand$/
+	 * @Given /^the administrator has (enabled|disabled) the special characters password policy$/
+	 *
+	 * @param string $action
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdminTogglesSpecialCharactersPasswordPolicyUsingOcc(
+		$action
+	) {
+		$this->setPasswordPolicySetting(
+			'spv_special_chars_checked',
+			$this->appSettingIsExpectedToBe($action)
+		);
+	}
+
+	/**
+	 * @When /^the administrator (enables|disables) the restrict to these special characters password policy using the occ commmand$/
+	 * @Given /^the administrator has (enabled|disabled) the restrict to these special characters password policy$/
+	 *
+	 * @param string $action
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdminTogglesRestrictSpecialCharactersPasswordPolicyUsingOcc(
+		$action
+	) {
+		$this->setPasswordPolicySetting(
+			'spv_def_special_chars_checked',
+			$this->appSettingIsExpectedToBe($action)
+		);
+	}
+
+	/**
+	 * @When /^the administrator (enables|disables) the last passwords user password policy using the occ commmand$/
+	 * @Given /^the administrator has (enabled|disabled) the last passwords user password policy$/
+	 *
+	 * @param string $action
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdminTogglesLastPasswordsPasswordPolicyUsingOcc(
+		$action
+	) {
+		$this->setPasswordPolicySetting(
+			'spv_password_history_checked',
+			$this->appSettingIsExpectedToBe($action)
+		);
+	}
+
+	/**
+	 * @When /^the administrator (enables|disables) the days until user password expires user password policy using the occ commmand$/
+	 * @Given /^the administrator has (enabled|disabled) the days until user password expires user password policy$/
+	 *
+	 * @param string $action
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdminTogglesDaysUntilUserPasswordExpiresPasswordPolicyUsingOcc(
+		$action
+	) {
+		$this->setPasswordPolicySetting(
+			'spv_user_password_expiration_checked',
+			$this->appSettingIsExpectedToBe($action)
+		);
+	}
+
+	/**
+	 * @When /^the administrator (enables|disables) the notification days before password expires user password policy using the occ commmand$/
+	 * @Given /^the administrator has (enabled|disabled) the notification days before password expires user password policy$/
+	 *
+	 * @param string $action
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdminTogglesNotificationDaysBeforeUserPasswordExpiresPasswordPolicyUsingOcc(
+		$action
+	) {
+		$this->setPasswordPolicySetting(
+			'spv_user_password_expiration_notification_checked',
+			$this->appSettingIsExpectedToBe($action)
+		);
+	}
+
+	/**
+	 * @When /^the administrator (enables|disables) the force password change on first login user password policy using the occ commmand$/
+	 * @Given /^the administrator has (enabled|disabled) the force password change on first login user password policy$/
+	 *
+	 * @param string $action
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdminTogglesForcePasswordChangeOnFirstLoginPasswordPolicyUsingOcc(
+		$action
+	) {
+		$this->setPasswordPolicySetting(
+			'spv_user_password_force_change_on_first_login_checked',
+			$this->appSettingIsExpectedToBe($action)
+		);
+	}
+
+	/**
+	 * @When /^the administrator (enables|disables) the days until link expires if password is set public link password policy using the occ commmand$/
+	 * @Given /^the administrator has (enabled|disabled) the days until link expires if password is set public link password policy$/
+	 *
+	 * @param string $action
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdminTogglesDaysUntilLinkExpiresWithPasswordPublicLinkPasswordPolicyUsingOcc(
+		$action
+	) {
+		$this->setPasswordPolicySetting(
+			'spv_expiration_password_checked',
+			$this->appSettingIsExpectedToBe($action)
+		);
+	}
+
+	/**
+	 * @When /^the administrator (enables|disables) the days until link expires if password is not set public link password policy using the occ commmand$/
+	 * @Given /^the administrator has (enabled|disabled) the days until link expires if password is not set public link password policy$/
+	 *
+	 * @param string $action
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdminTogglesDaysUntilLinkExpiresWithoutPasswordPublicLinkPasswordPolicyUsingOcc(
+		$action
+	) {
+		$this->setPasswordPolicySetting(
+			'spv_expiration_nopassword_checked',
+			$this->appSettingIsExpectedToBe($action)
+		);
 	}
 
 	/**
@@ -294,7 +510,7 @@ class PasswordPolicyContext implements Context {
 			]
 		);
 		if ($occResult['code'] !== "0") {
-			// The setting is not set. This is expectd if settings have never
+			// The setting is not set. This is expected if settings have never
 			// been saved yet. Treat this as the empty string.
 			return '';
 		}

--- a/tests/acceptance/features/webUIPasswordPolicy/disablePolicySettings.feature
+++ b/tests/acceptance/features/webUIPasswordPolicy/disablePolicySettings.feature
@@ -1,0 +1,141 @@
+@webUI
+Feature: disable password policy settings
+
+  As an administrator
+  I want to be able to disable password requirements (minimum length, lowercase/uppercase/numeric/special characters)
+  So that the password policy can be customized to the needs of the installation
+
+  Scenario: password policy checkboxes are checked when password policies have been enabled
+    Given the administrator has enabled the minimum characters password policy
+    And the administrator has enabled the lowercase letters password policy
+    And the administrator has enabled the uppercase letters password policy
+    And the administrator has enabled the numbers password policy
+    And the administrator has enabled the special characters password policy
+    And the administrator has enabled the restrict to these special characters password policy
+    And the administrator has enabled the last passwords user password policy
+    And the administrator has enabled the days until user password expires user password policy
+    And the administrator has enabled the notification days before password expires user password policy
+    And the administrator has enabled the force password change on first login user password policy
+    And the administrator has enabled the days until link expires if password is set public link password policy
+    And the administrator has enabled the days until link expires if password is not set public link password policy
+    And the administrator has browsed to the admin security settings page
+    Then the minimum characters password policy checkbox should be checked on the webUI
+    And the lowercase letters password policy checkbox should be checked on the webUI
+    And the uppercase letters password policy checkbox should be checked on the webUI
+    And the numbers password policy checkbox should be checked on the webUI
+    And the special characters password policy checkbox should be checked on the webUI
+    And the restrict to these special characters password policy checkbox should be checked on the webUI
+    And the last passwords user password policy checkbox should be checked on the webUI
+    And the days until user password expires user password policy checkbox should be checked on the webUI
+    And the notification days before password expires user password policy checkbox should be checked on the webUI
+    And the force password change on first login user password policy checkbox should be checked on the webUI
+    And the days until link expires if password is set public link password policy checkbox should be checked on the webUI
+    And the days until link expires if password is not set public link password policy checkbox should be checked on the webUI
+
+  Scenario: disable minimum length of password policy
+    Given the administrator has enabled the minimum characters password policy
+    And the administrator has browsed to the admin security settings page
+    When the administrator disables the minimum characters password policy using the webUI
+    And the administrator saves the password policy settings using the webUI
+    And the administrator reloads the admin security settings page
+    Then the minimum characters password policy checkbox should be unchecked on the webUI
+    And the minimum characters password policy should be disabled
+
+  Scenario: disable lowercase letters password policy
+    Given the administrator has enabled the lowercase letters password policy
+    And the administrator has browsed to the admin security settings page
+    When the administrator disables the lowercase letters password policy using the webUI
+    And the administrator saves the password policy settings using the webUI
+    And the administrator reloads the admin security settings page
+    Then the lowercase letters password policy checkbox should be unchecked on the webUI
+    And the lowercase letters password policy should be disabled
+
+  Scenario: disable uppercase letters password policy
+    Given the administrator has enabled the uppercase letters password policy
+    And the administrator has browsed to the admin security settings page
+    When the administrator disables the uppercase letters password policy using the webUI
+    And the administrator saves the password policy settings using the webUI
+    And the administrator reloads the admin security settings page
+    Then the uppercase letters password policy checkbox should be unchecked on the webUI
+    And the uppercase letters password policy should be disabled
+
+  Scenario: disable numbers password policy
+    Given the administrator has enabled the numbers password policy
+    And the administrator has browsed to the admin security settings page
+    When the administrator disables the numbers password policy using the webUI
+    And the administrator saves the password policy settings using the webUI
+    And the administrator reloads the admin security settings page
+    Then the numbers password policy checkbox should be unchecked on the webUI
+    And the numbers password policy should be disabled
+
+  Scenario: disable special characters password policy
+    Given the administrator has enabled the special characters password policy
+    And the administrator has browsed to the admin security settings page
+    When the administrator disables the special characters password policy using the webUI
+    And the administrator saves the password policy settings using the webUI
+    And the administrator reloads the admin security settings page
+    Then the special characters password policy checkbox should be unchecked on the webUI
+    And the special characters password policy should be disabled
+
+  Scenario: disable "restrict to these special characters" password policy
+    Given the administrator has enabled the restrict to these special characters password policy
+    And the administrator has browsed to the admin security settings page
+    When the administrator disables the restrict to these special characters password policy using the webUI
+    And the administrator saves the password policy settings using the webUI
+    And the administrator reloads the admin security settings page
+    Then the restrict to these special characters password policy checkbox should be unchecked on the webUI
+    And the restrict to these special characters password policy should be disabled
+
+  Scenario: disable "last passwords" user password policy
+    Given the administrator has enabled the last passwords user password policy
+    And the administrator has browsed to the admin security settings page
+    When the administrator disables the last passwords user password policy using the webUI
+    And the administrator saves the password policy settings using the webUI
+    And the administrator reloads the admin security settings page
+    Then the last passwords user password policy checkbox should be unchecked on the webUI
+    And the last passwords user password policy should be disabled
+
+  Scenario: disable "days until user password expires" user password policy
+    Given the administrator has enabled the days until user password expires user password policy
+    And the administrator has browsed to the admin security settings page
+    When the administrator disables the days until user password expires user password policy using the webUI
+    And the administrator saves the password policy settings using the webUI
+    And the administrator reloads the admin security settings page
+    Then the days until user password expires user password policy checkbox should be unchecked on the webUI
+    And the days until user password expires user password policy should be disabled
+
+  Scenario: disable "notification days before password expires" user password policy
+    Given the administrator has enabled the notification days before password expires user password policy
+    And the administrator has browsed to the admin security settings page
+    When the administrator disables the notification days before password expires user password policy using the webUI
+    And the administrator saves the password policy settings using the webUI
+    And the administrator reloads the admin security settings page
+    Then the notification days before password expires user password policy checkbox should be unchecked on the webUI
+    And the notification days before password expires user password policy should be disabled
+
+  Scenario: disable "force password change on first login" user password policy
+    Given the administrator has enabled the force password change on first login user password policy
+    And the administrator has browsed to the admin security settings page
+    When the administrator disables the force password change on first login user password policy using the webUI
+    And the administrator saves the password policy settings using the webUI
+    And the administrator reloads the admin security settings page
+    Then the force password change on first login user password policy checkbox should be unchecked on the webUI
+    And the force password change on first login user password policy should be disabled
+
+  Scenario: disable "days until link expires if password is set" public link password policy
+    Given the administrator has enabled the days until link expires if password is set public link password policy
+    And the administrator has browsed to the admin security settings page
+    When the administrator disables the days until link expires if password is set public link password policy using the webUI
+    And the administrator saves the password policy settings using the webUI
+    And the administrator reloads the admin security settings page
+    Then the days until link expires if password is set public link password policy checkbox should be unchecked on the webUI
+    And the days until link expires if password is set public link password policy should be disabled
+
+  Scenario: disable "days until link expires if password is not set" public link password policy
+    Given the administrator has enabled the days until link expires if password is not set public link password policy
+    And the administrator has browsed to the admin security settings page
+    When the administrator disables the days until link expires if password is not set public link password policy using the webUI
+    And the administrator saves the password policy settings using the webUI
+    And the administrator reloads the admin security settings page
+    Then the days until link expires if password is not set public link password policy checkbox should be unchecked on the webUI
+    And the days until link expires if password is not set public link password policy should be disabled

--- a/tests/acceptance/features/webUIPasswordPolicy/enablePolicySettings.feature
+++ b/tests/acceptance/features/webUIPasswordPolicy/enablePolicySettings.feature
@@ -1,8 +1,8 @@
 @webUI
-Feature: password requirement settings
+Feature: enable password policy settings
 
   As an administrator
-  I want to be able to set password requirements (minimum length, lowercase/uppercase/numeric/special characters)
+  I want to be able to enable password requirements (minimum length, lowercase/uppercase/numeric/special characters)
   So that user and public link passwords have a minimum level of complexity
 
   Background:


### PR DESCRIPTION
- adds test steps that let us enable/disable policy settings with the occ command
- adds test scenarios that verify that policy settings are disabled when the corresponding checkbox in the settings is unchecked