### PR TITLE
Tests for setting password policy values on the webUI

### DIFF
--- a/tests/acceptance/features/bootstrap/PasswordPolicyContext.php
+++ b/tests/acceptance/features/bootstrap/PasswordPolicyContext.php
@@ -286,6 +286,25 @@ class PasswordPolicyContext implements Context {
 	}
 
 	/**
+	 * @Then /^the required minimum characters should be set to "([^"]*)"$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theMinimumCharactersShouldBeSetTo(
+		$value
+	) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$value,
+			$this->getPasswordPolicySetting(
+				'spv_min_chars_value'
+			)
+		);
+	}
+
+	/**
 	 * @Then /^the lowercase letters password policy should be (enabled|disabled)$/
 	 *
 	 * @param string $enabledOrDisabled
@@ -300,6 +319,25 @@ class PasswordPolicyContext implements Context {
 			$this->appSettingIsExpectedToBe($enabledOrDisabled),
 			$this->getPasswordPolicySetting(
 				'spv_lowercase_checked'
+			)
+		);
+	}
+
+	/**
+	 * @Then /^the required number of lowercase letters should be set to "([^"]*)"$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theLowercaseLettersShouldBeSetTo(
+		$value
+	) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$value,
+			$this->getPasswordPolicySetting(
+				'spv_lowercase_value'
 			)
 		);
 	}
@@ -324,6 +362,25 @@ class PasswordPolicyContext implements Context {
 	}
 
 	/**
+	 * @Then /^the required number of uppercase letters should be set to "([^"]*)"$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theUppercaseLettersShouldBeSetTo(
+		$value
+	) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$value,
+			$this->getPasswordPolicySetting(
+				'spv_uppercase_value'
+			)
+		);
+	}
+
+	/**
 	 * @Then /^the numbers password policy should be (enabled|disabled)$/
 	 *
 	 * @param string $enabledOrDisabled
@@ -338,6 +395,25 @@ class PasswordPolicyContext implements Context {
 			$this->appSettingIsExpectedToBe($enabledOrDisabled),
 			$this->getPasswordPolicySetting(
 				'spv_numbers_checked'
+			)
+		);
+	}
+
+	/**
+	 * @Then /^the required number of numbers should be set to "([^"]*)"$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theNumbersShouldBeSetTo(
+		$value
+	) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$value,
+			$this->getPasswordPolicySetting(
+				'spv_numbers_value'
 			)
 		);
 	}
@@ -362,6 +438,25 @@ class PasswordPolicyContext implements Context {
 	}
 
 	/**
+	 * @Then /^the required number of special characters should be set to "([^"]*)"$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theSpecialCharactersShouldBeSetTo(
+		$value
+	) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$value,
+			$this->getPasswordPolicySetting(
+				'spv_special_chars_value'
+			)
+		);
+	}
+
+	/**
 	 * @Then /^the restrict to these special characters password policy should be (enabled|disabled)$/
 	 *
 	 * @param string $enabledOrDisabled
@@ -376,6 +471,25 @@ class PasswordPolicyContext implements Context {
 			$this->appSettingIsExpectedToBe($enabledOrDisabled),
 			$this->getPasswordPolicySetting(
 				'spv_def_special_chars_checked'
+			)
+		);
+	}
+
+	/**
+	 * @Then /^restrict to these special characters should be set to "([^"]*)"$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function restrictSpecialCharactersShouldBeSetTo(
+		$value
+	) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$value,
+			$this->getPasswordPolicySetting(
+				'spv_def_special_chars_value'
 			)
 		);
 	}
@@ -400,6 +514,25 @@ class PasswordPolicyContext implements Context {
 	}
 
 	/**
+	 * @Then /^last passwords that should not be used should be set to "([^"]*)"$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theLastPasswordsShouldBeSetTo(
+		$value
+	) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$value,
+			$this->getPasswordPolicySetting(
+				'spv_password_history_value'
+			)
+		);
+	}
+
+	/**
 	 * @Then /^the days until user password expires user password policy should be (enabled|disabled)$/
 	 *
 	 * @param string $enabledOrDisabled
@@ -419,6 +552,25 @@ class PasswordPolicyContext implements Context {
 	}
 
 	/**
+	 * @Then /^the number of days until user password expires should be set to "([^"]*)"$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theDaysUntilUserPasswordExpiresShouldBeSetTo(
+		$value
+	) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$value,
+			$this->getPasswordPolicySetting(
+				'spv_user_password_expiration_value'
+			)
+		);
+	}
+
+	/**
 	 * @Then /^the notification days before password expires user password policy should be (enabled|disabled)$/
 	 *
 	 * @param string $enabledOrDisabled
@@ -433,6 +585,25 @@ class PasswordPolicyContext implements Context {
 			$this->appSettingIsExpectedToBe($enabledOrDisabled),
 			$this->getPasswordPolicySetting(
 				'spv_user_password_expiration_notification_checked'
+			)
+		);
+	}
+
+	/**
+	 * @Then /^the notification seconds before password expires should be set to "([^"]*)"$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theNotificationSecondsBeforeUserPasswordExpiresShouldBeSetTo(
+		$value
+	) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$value,
+			$this->getPasswordPolicySetting(
+				'spv_user_password_expiration_notification_value'
 			)
 		);
 	}
@@ -476,6 +647,25 @@ class PasswordPolicyContext implements Context {
 	}
 
 	/**
+	 * @Then /^the number of days until link expires if password is set should be set to "([^"]*)"$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theDaysUntilLinkExpiresWithPasswordShouldBeSetTo(
+		$value
+	) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$value,
+			$this->getPasswordPolicySetting(
+				'spv_expiration_password_value'
+			)
+		);
+	}
+
+	/**
 	 * @Then /^the days until link expires if password is not set public link password policy should be (enabled|disabled)$/
 	 *
 	 * @param string $enabledOrDisabled
@@ -490,6 +680,25 @@ class PasswordPolicyContext implements Context {
 			$this->appSettingIsExpectedToBe($enabledOrDisabled),
 			$this->getPasswordPolicySetting(
 				'spv_expiration_nopassword_checked'
+			)
+		);
+	}
+
+	/**
+	 * @Then /^the number of days until link expires if password is not set should be set to "([^"]*)"$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theDaysUntilLinkExpiresWithoutPasswordShouldBeSetTo(
+		$value
+	) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$value,
+			$this->getPasswordPolicySetting(
+				'spv_expiration_nopassword_value'
 			)
 		);
 	}

--- a/tests/acceptance/features/bootstrap/WebUIPasswordPolicyContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPasswordPolicyContext.php
@@ -122,6 +122,22 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @When /^the administrator sets the minimum characters required to "([^"]*)" using the webUI$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdminSetsMinimumCharactersUsingTheWebui(
+		$value
+	) {
+		$this->passwordPolicySettingsPage->enterPolicyValue(
+			'minimumCharacters', $value
+		);
+	}
+
+	/**
 	 * @When /^the administrator (enables|disables) the lowercase letters password policy using the webUI$/
 	 *
 	 * @param string $action
@@ -134,6 +150,22 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	) {
 		$this->passwordPolicySettingsPage->togglePolicyCheckbox(
 			'lowercaseLetters', $action
+		);
+	}
+
+	/**
+	 * @When /^the administrator sets the lowercase letters required to "([^"]*)" using the webUI$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdminSetsLowercaseLettersUsingTheWebui(
+		$value
+	) {
+		$this->passwordPolicySettingsPage->enterPolicyValue(
+			'lowercaseLetters', $value
 		);
 	}
 
@@ -154,6 +186,22 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @When /^the administrator sets the uppercase letters required to "([^"]*)" using the webUI$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdminSetsUppercaseLettersUsingTheWebui(
+		$value
+	) {
+		$this->passwordPolicySettingsPage->enterPolicyValue(
+			'uppercaseLetters', $value
+		);
+	}
+
+	/**
 	 * @When /^the administrator (enables|disables) the numbers password policy using the webUI$/
 	 *
 	 * @param string $action
@@ -166,6 +214,22 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	) {
 		$this->passwordPolicySettingsPage->togglePolicyCheckbox(
 			'numbers', $action
+		);
+	}
+
+	/**
+	 * @When /^the administrator sets the numbers required to "([^"]*)" using the webUI$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdminSetsNumbersUsingTheWebui(
+		$value
+	) {
+		$this->passwordPolicySettingsPage->enterPolicyValue(
+			'numbers', $value
 		);
 	}
 
@@ -186,6 +250,22 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @When /^the administrator sets the special characters required to "([^"]*)" using the webUI$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdminSetsSpecialCharactersUsingTheWebui(
+		$value
+	) {
+		$this->passwordPolicySettingsPage->enterPolicyValue(
+			'specialCharacters', $value
+		);
+	}
+
+	/**
 	 * @When /^the administrator (enables|disables) the restrict to these special characters password policy using the webUI$/
 	 *
 	 * @param string $action
@@ -198,6 +278,22 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	) {
 		$this->passwordPolicySettingsPage->togglePolicyCheckbox(
 			'restrictToTheseSpecialCharacters', $action
+		);
+	}
+
+	/**
+	 * @When /^the administrator sets the restricted list of special characters to "([^"]*)" using the webUI$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdminSetsRestrictSpecialCharactersUsingTheWebui(
+		$value
+	) {
+		$this->passwordPolicySettingsPage->enterPolicyValue(
+			'restrictToTheseSpecialCharacters', $value
 		);
 	}
 
@@ -218,6 +314,22 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @When /^the administrator sets the number of last passwords that should not be used to "([^"]*)" using the webUI$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdminSetsLastPasswordsUsingTheWebui(
+		$value
+	) {
+		$this->passwordPolicySettingsPage->enterPolicyValue(
+			'lastPasswords', $value
+		);
+	}
+
+	/**
 	 * @When /^the administrator (enables|disables) the days until user password expires user password policy using the webUI$/
 	 *
 	 * @param string $action
@@ -234,6 +346,22 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @When /^the administrator sets the number of days until user password expires to "([^"]*)" using the webUI$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdminSetsDaysUntilUserPasswordExpiresUsingTheWebui(
+		$value
+	) {
+		$this->passwordPolicySettingsPage->enterPolicyValue(
+			'daysUntilUserPasswordExpires', $value
+		);
+	}
+
+	/**
 	 * @When /^the administrator (enables|disables) the notification days before password expires user password policy using the webUI$/
 	 *
 	 * @param string $action
@@ -246,6 +374,22 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	) {
 		$this->passwordPolicySettingsPage->togglePolicyCheckbox(
 			'notificationDaysBeforeUserPasswordExpires', $action
+		);
+	}
+
+	/**
+	 * @When /^the administrator sets the notification days before password expires to "([^"]*)" using the webUI$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdminSetsNotificationDaysBeforeUserPasswordExpiresUsingTheWebui(
+		$value
+	) {
+		$this->passwordPolicySettingsPage->enterPolicyValue(
+			'notificationDaysBeforeUserPasswordExpires', $value
 		);
 	}
 
@@ -282,6 +426,22 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @When /^the administrator sets the number of days until link expires if password is set to "([^"]*)" using the webUI$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdminSetsDaysUntilLinkExpiresWithPasswordUsingTheWebui(
+		$value
+	) {
+		$this->passwordPolicySettingsPage->enterPolicyValue(
+			'daysUntilLinkExpiresWithPassword', $value
+		);
+	}
+
+	/**
 	 * @When /^the administrator (enables|disables) the days until link expires if password is not set public link password policy using the webUI$/
 	 *
 	 * @param string $action
@@ -294,6 +454,22 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	) {
 		$this->passwordPolicySettingsPage->togglePolicyCheckbox(
 			'daysUntilLinkExpiresWithoutPassword', $action
+		);
+	}
+
+	/**
+	 * @When /^the administrator sets the number of days until link expires if password is not set to "([^"]*)" using the webUI$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdminSetsDaysUntilLinkExpiresWithoutPasswordUsingTheWebui(
+		$value
+	) {
+		$this->passwordPolicySettingsPage->enterPolicyValue(
+			'daysUntilLinkExpiresWithoutPassword', $value
 		);
 	}
 
@@ -337,6 +513,25 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @Then /^the required minimum characters should be set to "([^"]*)" on the webUI$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theMinimumCharactersShouldBeSetToOnTheWebui(
+		$value
+	) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$value,
+			$this->passwordPolicySettingsPage->getPolicyValue(
+				'minimumCharacters'
+			)
+		);
+	}
+
+	/**
 	 * @Then /^the lowercase letters password policy checkbox should be (checked|unchecked) on the webUI$/
 	 *
 	 * @param string $checkedOrUnchecked
@@ -350,6 +545,25 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 		PHPUnit_Framework_Assert::assertEquals(
 			$this->isExpectedToBeChecked($checkedOrUnchecked),
 			$this->passwordPolicySettingsPage->isPolicyCheckboxChecked(
+				'lowercaseLetters'
+			)
+		);
+	}
+
+	/**
+	 * @Then /^the required number of lowercase letters should be set to "([^"]*)" on the webUI$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theLowercaseLettersShouldBeSetToOnTheWebui(
+		$value
+	) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$value,
+			$this->passwordPolicySettingsPage->getPolicyValue(
 				'lowercaseLetters'
 			)
 		);
@@ -375,6 +589,25 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @Then /^the required number of uppercase letters should be set to "([^"]*)" on the webUI$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theUppercaseLettersShouldBeSetToOnTheWebui(
+		$value
+	) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$value,
+			$this->passwordPolicySettingsPage->getPolicyValue(
+				'uppercaseLetters'
+			)
+		);
+	}
+
+	/**
 	 * @Then /^the numbers password policy checkbox should be (checked|unchecked) on the webUI$/
 	 *
 	 * @param string $checkedOrUnchecked
@@ -386,6 +619,25 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 		PHPUnit_Framework_Assert::assertEquals(
 			$this->isExpectedToBeChecked($checkedOrUnchecked),
 			$this->passwordPolicySettingsPage->isPolicyCheckboxChecked(
+				'numbers'
+			)
+		);
+	}
+
+	/**
+	 * @Then /^the required number of numbers should be set to "([^"]*)" on the webUI$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theNumbersShouldBeSetToOnTheWebui(
+		$value
+	) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$value,
+			$this->passwordPolicySettingsPage->getPolicyValue(
 				'numbers'
 			)
 		);
@@ -411,6 +663,25 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @Then /^the required number of special characters should be set to "([^"]*)" on the webUI$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theSpecialCharactersShouldBeSetToOnTheWebui(
+		$value
+	) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$value,
+			$this->passwordPolicySettingsPage->getPolicyValue(
+				'specialCharacters'
+			)
+		);
+	}
+
+	/**
 	 * @Then /^the restrict to these special characters password policy checkbox should be (checked|unchecked) on the webUI$/
 	 *
 	 * @param string $checkedOrUnchecked
@@ -424,6 +695,25 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 		PHPUnit_Framework_Assert::assertEquals(
 			$this->isExpectedToBeChecked($checkedOrUnchecked),
 			$this->passwordPolicySettingsPage->isPolicyCheckboxChecked(
+				'restrictToTheseSpecialCharacters'
+			)
+		);
+	}
+
+	/**
+	 * @Then /^restrict to these special characters should be set to "([^"]*)" on the webUI$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function restrictSpecialCharactersShouldBeSetToOnTheWebui(
+		$value
+	) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$value,
+			$this->passwordPolicySettingsPage->getPolicyValue(
 				'restrictToTheseSpecialCharacters'
 			)
 		);
@@ -449,6 +739,25 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @Then /^last passwords that should not be used should be set to "([^"]*)" on the webUI$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function lastPasswordsShouldBeSetToOnTheWebui(
+		$value
+	) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$value,
+			$this->passwordPolicySettingsPage->getPolicyValue(
+				'lastPasswords'
+			)
+		);
+	}
+
+	/**
 	 * @Then /^the days until user password expires user password policy checkbox should be (checked|unchecked) on the webUI$/
 	 *
 	 * @param string $checkedOrUnchecked
@@ -468,6 +777,25 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @Then /^the number of days until user password expires should be set to "([^"]*)" on the webUI$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theDaysUntilUserPasswordExpiresShouldBeSetToOnTheWebui(
+		$value
+	) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$value,
+			$this->passwordPolicySettingsPage->getPolicyValue(
+				'daysUntilUserPasswordExpires'
+			)
+		);
+	}
+
+	/**
 	 * @Then /^the notification days before password expires user password policy checkbox should be (checked|unchecked) on the webUI$/
 	 *
 	 * @param string $checkedOrUnchecked
@@ -481,6 +809,25 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 		PHPUnit_Framework_Assert::assertEquals(
 			$this->isExpectedToBeChecked($checkedOrUnchecked),
 			$this->passwordPolicySettingsPage->isPolicyCheckboxChecked(
+				'notificationDaysBeforeUserPasswordExpires'
+			)
+		);
+	}
+
+	/**
+	 * @Then /^the notification days before password expires should be set to "([^"]*)" on the webUI$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theNotificationDaysBeforeUserPasswordExpiresShouldBeSetToOnTheWebui(
+		$value
+	) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$value,
+			$this->passwordPolicySettingsPage->getPolicyValue(
 				'notificationDaysBeforeUserPasswordExpires'
 			)
 		);
@@ -525,6 +872,25 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @Then /^the number of days until link expires if password is set should be set to "([^"]*)" on the webUI$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theDaysUntilLinkExpiresWithPasswordShouldBeSetToOnTheWebui(
+		$value
+	) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$value,
+			$this->passwordPolicySettingsPage->getPolicyValue(
+				'daysUntilLinkExpiresWithPassword'
+			)
+		);
+	}
+
+	/**
 	 * @Then /^the days until link expires if password is not set public link password policy checkbox should be (checked|unchecked) on the webUI$/
 	 *
 	 * @param string $checkedOrUnchecked
@@ -538,6 +904,25 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 		PHPUnit_Framework_Assert::assertEquals(
 			$this->isExpectedToBeChecked($checkedOrUnchecked),
 			$this->passwordPolicySettingsPage->isPolicyCheckboxChecked(
+				'daysUntilLinkExpiresWithoutPassword'
+			)
+		);
+	}
+
+	/**
+	 * @Then /^the number of days until link expires if password is not set should be set to "([^"]*)" on the webUI$/
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theDaysUntilLinkExpiresWithoutPasswordShouldBeSetToOnTheWebui(
+		$value
+	) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$value,
+			$this->passwordPolicySettingsPage->getPolicyValue(
 				'daysUntilLinkExpiresWithoutPassword'
 			)
 		);

--- a/tests/acceptance/features/lib/PasswordPolicySettingsPage.php
+++ b/tests/acceptance/features/lib/PasswordPolicySettingsPage.php
@@ -52,6 +52,19 @@ class PasswordPolicySettingsPage extends OwncloudPage {
 		'daysUntilLinkExpiresWithPassword' => 'spv_expiration_password_checked',
 		'daysUntilLinkExpiresWithoutPassword' => 'spv_expiration_nopassword_checked',
 	];
+	private $policyValueNames = [
+		'minimumCharacters' => 'spv_min_chars_value',
+		'lowercaseLetters' => 'spv_lowercase_value',
+		'uppercaseLetters' => 'spv_uppercase_value',
+		'numbers' => 'spv_numbers_value',
+		'specialCharacters' => 'spv_special_chars_value',
+		'restrictToTheseSpecialCharacters' => 'spv_def_special_chars_value',
+		'lastPasswords' => 'spv_password_history_value',
+		'daysUntilUserPasswordExpires' => 'spv_user_password_expiration_value',
+		'notificationDaysBeforeUserPasswordExpires' => 'spv_user_password_expiration_notification_value',
+		'daysUntilLinkExpiresWithPassword' => 'spv_expiration_password_value',
+		'daysUntilLinkExpiresWithoutPassword' => 'spv_expiration_nopassword_value',
+	];
 	private $passwordPolicyFormId = 'password_policy';
 	private $saveButtonValue = 'Save';
 
@@ -64,7 +77,7 @@ class PasswordPolicySettingsPage extends OwncloudPage {
 	 * @throws ElementNotFoundException
 	 */
 	public function findSettingsCheckbox($checkboxName) {
-		$checkbox = $this->find("named", ["id_or_name", $checkboxName]);
+		$checkbox = $this->findField($checkboxName);
 		if ($checkbox === null) {
 			throw new ElementNotFoundException(
 				__METHOD__ .
@@ -138,6 +151,54 @@ class PasswordPolicySettingsPage extends OwncloudPage {
 		} else {
 			throw new \Exception(
 				__METHOD__ . " unknown policyCheckboxKey: $policyCheckboxKey"
+			);
+		}
+	}
+
+	/**
+	 * enter a value in the specified field
+	 *
+	 * @param string $policyValueKey one of the known keys in the policyValueNames array
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws \Behat\Mink\Exception\ElementNotFoundException
+	 * @throws \Exception
+	 */
+	public function enterPolicyValue($policyValueKey, $value) {
+		if (\array_key_exists($policyValueKey, $this->policyValueNames)) {
+			$this->fillField($this->policyValueNames[$policyValueKey], $value);
+		} else {
+			throw new \Exception(
+				__METHOD__ . " unknown policyValueKey: $policyValueKey"
+			);
+		}
+	}
+
+	/**
+	 * get the value in the specified field
+	 *
+	 * @param string $policyValueKey one of the known keys in the policyValueNames array
+	 *
+	 * @return string value in the field
+	 * @throws \Behat\Mink\Exception\ElementNotFoundException
+	 * @throws \Exception
+	 */
+	public function getPolicyValue($policyValueKey) {
+		if (\array_key_exists($policyValueKey, $this->policyValueNames)) {
+			$name = $this->policyValueNames[$policyValueKey];
+			$field = $this->findField($name);
+			if ($field === null) {
+				throw new ElementNotFoundException(
+					__METHOD__ .
+					" could not find field with name $name "
+				);
+			}
+
+			return $field->getValue();
+		} else {
+			throw new \Exception(
+				__METHOD__ . " unknown policyValueKey: $policyValueKey"
 			);
 		}
 	}

--- a/tests/acceptance/features/webUIPasswordPolicy/setPolicySettings.feature
+++ b/tests/acceptance/features/webUIPasswordPolicy/setPolicySettings.feature
@@ -1,0 +1,120 @@
+@webUI
+Feature: set password policy settings
+
+  As an administrator
+  I want to be able to set password requirements (minimum length, lowercase/uppercase/numeric/special characters)
+  So that user and public link passwords have a minimum level of complexity
+
+  Background:
+    Given the administrator has browsed to the admin security settings page
+
+  Scenario: set minimum length of password
+    When the administrator enables the minimum characters password policy using the webUI
+    And the administrator sets the minimum characters required to "5" using the webUI
+    And the administrator saves the password policy settings using the webUI
+    And the administrator reloads the admin security settings page
+    Then the minimum characters password policy checkbox should be checked on the webUI
+    And the required minimum characters should be set to "5" on the webUI
+    And the required minimum characters should be set to "5"
+    And the minimum characters password policy should be enabled
+
+  Scenario: set lowercase letters required in password
+    When the administrator enables the lowercase letters password policy using the webUI
+    And the administrator sets the lowercase letters required to "2" using the webUI
+    And the administrator saves the password policy settings using the webUI
+    And the administrator reloads the admin security settings page
+    Then the lowercase letters password policy checkbox should be checked on the webUI
+    And the required number of lowercase letters should be set to "2" on the webUI
+    And the required number of lowercase letters should be set to "2"
+    And the lowercase letters password policy should be enabled
+
+  Scenario: set uppercase letters required in password
+    When the administrator enables the uppercase letters password policy using the webUI
+    And the administrator sets the uppercase letters required to "2" using the webUI
+    And the administrator saves the password policy settings using the webUI
+    And the administrator reloads the admin security settings page
+    Then the uppercase letters password policy checkbox should be checked on the webUI
+    And the required number of uppercase letters should be set to "2" on the webUI
+    And the required number of uppercase letters should be set to "2"
+    And the uppercase letters password policy should be enabled
+
+  Scenario: set numbers required in password
+    When the administrator enables the numbers password policy using the webUI
+    And the administrator sets the numbers required to "2" using the webUI
+    And the administrator saves the password policy settings using the webUI
+    And the administrator reloads the admin security settings page
+    Then the numbers password policy checkbox should be checked on the webUI
+    And the required number of numbers should be set to "2" on the webUI
+    And the required number of numbers should be set to "2"
+    And the numbers password policy should be enabled
+
+  Scenario: set special characters required in password
+    When the administrator enables the special characters password policy using the webUI
+    And the administrator sets the special characters required to "2" using the webUI
+    And the administrator saves the password policy settings using the webUI
+    And the administrator reloads the admin security settings page
+    Then the special characters password policy checkbox should be checked on the webUI
+    And the required number of special characters should be set to "2" on the webUI
+    And the required number of special characters should be set to "2"
+    And the special characters password policy should be enabled
+
+  Scenario: set "restrict to these special characters" list of characters
+    When the administrator enables the restrict to these special characters password policy using the webUI
+    And the administrator sets the restricted list of special characters to "!@#$%^&*" using the webUI
+    And the administrator saves the password policy settings using the webUI
+    And the administrator reloads the admin security settings page
+    Then the restrict to these special characters password policy checkbox should be checked on the webUI
+    And restrict to these special characters should be set to "!@#$%^&*" on the webUI
+    And restrict to these special characters should be set to "!@#$%^&*"
+    And the restrict to these special characters password policy should be enabled
+
+  Scenario: set number of last passwords that should not be used
+    When the administrator enables the last passwords user password policy using the webUI
+    And the administrator sets the number of last passwords that should not be used to "12" using the webUI
+    And the administrator saves the password policy settings using the webUI
+    And the administrator reloads the admin security settings page
+    Then the last passwords user password policy checkbox should be checked on the webUI
+    And last passwords that should not be used should be set to "12" on the webUI
+    And last passwords that should not be used should be set to "12"
+    And the last passwords user password policy should be enabled
+
+  Scenario: set "days until user password expires"
+    When the administrator enables the days until user password expires user password policy using the webUI
+    And the administrator sets the number of days until user password expires to "42" using the webUI
+    And the administrator saves the password policy settings using the webUI
+    And the administrator reloads the admin security settings page
+    Then the days until user password expires user password policy checkbox should be checked on the webUI
+    And the number of days until user password expires should be set to "42" on the webUI
+    And the number of days until user password expires should be set to "42"
+    And the days until user password expires user password policy should be enabled
+
+  Scenario: set "notification days before password expires"
+    When the administrator enables the notification days before password expires user password policy using the webUI
+    And the administrator sets the notification days before password expires to "14" using the webUI
+    And the administrator saves the password policy settings using the webUI
+    And the administrator reloads the admin security settings page
+    Then the notification days before password expires user password policy checkbox should be checked on the webUI
+    And the notification days before password expires should be set to "14" on the webUI
+    # This settting is stored in seconds. 14 days = 14*24*60*60 = 1209600 seconds
+    And the notification seconds before password expires should be set to "1209600"
+    And the notification days before password expires user password policy should be enabled
+
+  Scenario: set "days until link expires if password is set" for public links
+    When the administrator enables the days until link expires if password is set public link password policy using the webUI
+    And the administrator sets the number of days until link expires if password is set to "35" using the webUI
+    And the administrator saves the password policy settings using the webUI
+    And the administrator reloads the admin security settings page
+    Then the days until link expires if password is set public link password policy checkbox should be checked on the webUI
+    And the number of days until link expires if password is set should be set to "35" on the webUI
+    And the number of days until link expires if password is set should be set to "35"
+    And the days until link expires if password is set public link password policy should be enabled
+
+  Scenario: set "days until link expires if password is not set" for public links
+    When the administrator enables the days until link expires if password is not set public link password policy using the webUI
+    And the administrator sets the number of days until link expires if password is not set to "19" using the webUI
+    And the administrator saves the password policy settings using the webUI
+    And the administrator reloads the admin security settings page
+    Then the days until link expires if password is not set public link password policy checkbox should be checked on the webUI
+    And the number of days until link expires if password is not set should be set to "19" on the webUI
+    And the number of days until link expires if password is not set should be set to "19"
+    And the days until link expires if password is not set public link password policy should be enabled


### PR DESCRIPTION
Note: ``notification days before password expires`` is displayed in days on the webUI but stored in seconds in the backend. I need to double-check that that is expected, and is the only setting stored in seconds.