### PR TITLE
Name the drone step owncloud-coding-standard

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -54,14 +54,14 @@ pipeline:
       matrix:
         NEED_SERVER: true
 
-  php-cs-fixer:
+  owncloud-coding-standard:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     commands:
       - make test-php-style
     when:
       matrix:
-        TEST_SUITE: php-cs-fixer
+        TEST_SUITE: owncloud-coding-standard
 
   phpunit-tests:
     image: owncloudci/php:${PHP_VERSION}
@@ -187,9 +187,9 @@ services:
 
 matrix:
   include:
-    # php-cs-fixer
+    # owncloud-coding-standard
     - PHP_VERSION: 7.2
-      TEST_SUITE: php-cs-fixer
+      TEST_SUITE: owncloud-coding-standard
 
     # Unit Tests
     - PHP_VERSION: 7.1

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ PHPSTAN=php -d zend.enable_gc=0 vendor-bin/phpstan/vendor/bin/phpstan
 
 .DEFAULT_GOAL := help
 
+# start with displaying help
 help:
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
 


### PR DESCRIPTION
I noticed in the testing app, and in other places recently, we started calling the step ``owncloud-coding-standard``. That seems a good thing, because it separates the name from the detail underneath of what tool or tool combinations we are using at any time. ``php-cs-fixer`` is no longer explicitly mentioned in ``.drone.yml``, because that detail is a level down in ``Makefile``.

I am proposing the change here, because I  am trying to keep ``password_policy`` CI infrastructure as "gold" as possible so that it can be used some day as the source of cut-paste to standardize other app CI scripts.

