### PR TITLE
test-acceptance-api and test-acceptance-webui makefile targets

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -84,8 +84,7 @@ pipeline:
     - PLATFORM=Linux
     - BEHAT_SUITE=${BEHAT_SUITE}
     commands:
-    - cd /var/www/owncloud/tests/acceptance/
-    - ./run.sh --remote --config /var/www/owncloud/apps/password_policy/tests/acceptance/config/behat.yml
+    - make test-acceptance-api
     when:
       matrix:
         TEST_SUITE: api-acceptance
@@ -102,8 +101,7 @@ pipeline:
       - BEHAT_SUITE=${BEHAT_SUITE}
       - MAILHOG_HOST=email
     commands:
-      - cd /var/www/owncloud/tests/acceptance/
-      - ./run.sh --remote --config /var/www/owncloud/apps/password_policy/tests/acceptance/config/behat.yml
+      - make test-acceptance-webui
     when:
       matrix:
         TEST_SUITE: web-acceptance

--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,16 @@ test-php-phpstan:          ## Run phpstan
 test-php-phpstan: vendor-bin/phpstan/vendor
 	$(PHPSTAN) analyse --memory-limit=4G --configuration=./phpstan.neon --no-progress --level=5 appinfo lib
 
+.PHONY: test-acceptance-api
+test-acceptance-api:     ## Run API acceptance tests
+test-acceptance-api: vendor/bin/phpunit
+	../../tests/acceptance/run.sh --config tests/acceptance/config/behat.yml --type api
+
+.PHONY: test-acceptance-webui
+test-acceptance-webui:     ## Run webUI acceptance tests
+test-acceptance-webui: vendor/bin/phpunit
+	../../tests/acceptance/run.sh --config tests/acceptance/config/behat.yml --type webUI
+
 #
 # Dependency management
 #--------------------------------------


### PR DESCRIPTION
We are working towards having proper Makefile build targets for each of the parts of testing - ``make test-php-style`` ``make test-php-style-fix`` etc.

Acceptance tests currently come in 2 different flavors. API tests only need a server running somewhere and some client utility code (Guzzle, curl...) on the test script side. webUI tests also need a browser environment and whatever middleware to talk to the browser (e.g. Mink to selenium). We currently do not mix running API and webUI acceptance tests in a single run.

So I am proposing that we have 2 build targets:
```
make test-acceptance-api
make test-acceptance-webui
```

For discussion, please comment. e.g.

- do we make 2 targets?
- if so, what do we call them?