### PR TITLE
Verify that expected password works

### DIFF
--- a/tests/acceptance/features/apiPasswordAddUser/occAddUserLowercaseLetters.feature
+++ b/tests/acceptance/features/apiPasswordAddUser/occAddUserLowercaseLetters.feature
@@ -16,6 +16,7 @@ Feature: enforce the required number of lowercase letters in a password when cre
     Then the command should have been successful
     And the command output should contain the text 'The user "user1" was created successfully'
     And user "user1" should exist
+    And the content of file "textfile0.txt" for user "user1" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
     Examples:
       | password                  |
       | 3LCase                    |

--- a/tests/acceptance/features/apiPasswordAddUser/occAddUserMinimumLength.feature
+++ b/tests/acceptance/features/apiPasswordAddUser/occAddUserMinimumLength.feature
@@ -16,6 +16,7 @@ Feature: enforce the minimum length of a password when creating a user
     Then the command should have been successful
     And the command output should contain the text 'The user "user1" was created successfully'
     And user "user1" should exist
+    And the content of file "textfile0.txt" for user "user1" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
     Examples:
       | password             |
       | 10tenchars           |

--- a/tests/acceptance/features/apiPasswordAddUser/occAddUserNumbers.feature
+++ b/tests/acceptance/features/apiPasswordAddUser/occAddUserNumbers.feature
@@ -16,6 +16,7 @@ Feature: enforce the required number of numbers in a password when creating a us
     Then the command should have been successful
     And the command output should contain the text 'The user "user1" was created successfully'
     And user "user1" should exist
+    And the content of file "textfile0.txt" for user "user1" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
     Examples:
       | password        |
       | 333Numbers      |

--- a/tests/acceptance/features/apiPasswordAddUser/occAddUserRequirementCombinations.feature
+++ b/tests/acceptance/features/apiPasswordAddUser/occAddUserRequirementCombinations.feature
@@ -24,6 +24,7 @@ Feature: enforce combinations of password policies when creating a user
     Then the command should have been successful
     And the command output should contain the text 'The user "user1" was created successfully'
     And user "user1" should exist
+    And the content of file "textfile0.txt" for user "user1" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
     Examples:
       | password                  |
       | 15***UPPloweZZZ           |

--- a/tests/acceptance/features/apiPasswordAddUser/occAddUserSpecialCharacters.feature
+++ b/tests/acceptance/features/apiPasswordAddUser/occAddUserSpecialCharacters.feature
@@ -16,6 +16,7 @@ Feature: enforce the required number of special characters in a password when cr
     Then the command should have been successful
     And the command output should contain the text 'The user "user1" was created successfully'
     And user "user1" should exist
+    And the content of file "textfile0.txt" for user "user1" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
     Examples:
       | password              |
       | 3#Special$Characters! |

--- a/tests/acceptance/features/apiPasswordAddUser/occAddUserSpecialCharactersRestrictions.feature
+++ b/tests/acceptance/features/apiPasswordAddUser/occAddUserSpecialCharactersRestrictions.feature
@@ -18,6 +18,7 @@ Feature: enforce the restricted special characters in a password when creating a
     Then the command should have been successful
     And the command output should contain the text 'The user "user1" was created successfully'
     And user "user1" should exist
+    And the content of file "textfile0.txt" for user "user1" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
     Examples:
       | password              |
       | 3$Special%Characters^ |

--- a/tests/acceptance/features/apiPasswordAddUser/occAddUserUppercaseLetters.feature
+++ b/tests/acceptance/features/apiPasswordAddUser/occAddUserUppercaseLetters.feature
@@ -16,6 +16,7 @@ Feature: enforce the required number of uppercase letters in a password when cre
     Then the command should have been successful
     And the command output should contain the text 'The user "user1" was created successfully'
     And user "user1" should exist
+    And the content of file "textfile0.txt" for user "user1" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
     Examples:
       | password                  |
       | 3UpperCaseLetters         |

--- a/tests/acceptance/features/apiPasswordAddUser/provisioningAddUserLowercaseLetters.feature
+++ b/tests/acceptance/features/apiPasswordAddUser/provisioningAddUserLowercaseLetters.feature
@@ -16,6 +16,7 @@ Feature: enforce the required number of lowercase letters in a password when cre
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
     And user "brand-new-user" should exist
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
     Examples:
       | password                  | ocs-api-version | ocs-status |
       | 3LCase                    | 1               | 100        |

--- a/tests/acceptance/features/apiPasswordAddUser/provisioningAddUserMinimumLength.feature
+++ b/tests/acceptance/features/apiPasswordAddUser/provisioningAddUserMinimumLength.feature
@@ -16,6 +16,7 @@ Feature: enforce the minimum length of a password when creating a user
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
     And user "brand-new-user" should exist
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
     Examples:
       | password             | ocs-api-version | ocs-status |
       | 10tenchars           | 1               | 100        |

--- a/tests/acceptance/features/apiPasswordAddUser/provisioningAddUserNumbers.feature
+++ b/tests/acceptance/features/apiPasswordAddUser/provisioningAddUserNumbers.feature
@@ -16,6 +16,7 @@ Feature: enforce the required number of numbers in a password when creating a us
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
     And user "brand-new-user" should exist
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
     Examples:
       | password        | ocs-api-version | ocs-status |
       | 333Numbers      | 1               | 100        |

--- a/tests/acceptance/features/apiPasswordAddUser/provisioningAddUserRequirementCombinations.feature
+++ b/tests/acceptance/features/apiPasswordAddUser/provisioningAddUserRequirementCombinations.feature
@@ -24,6 +24,7 @@ Feature: enforce combinations of password policies when creating a user
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
     And user "brand-new-user" should exist
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
     Examples:
       | password                  | ocs-api-version | ocs-status |
       | 15***UPPloweZZZ           | 1               | 100        |
@@ -68,6 +69,7 @@ Feature: enforce combinations of password policies when creating a user
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
     And user "brand-new-user" should exist
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
     Examples:
       | password                  | ocs-api-version | ocs-status |
       | 15%&*UPPloweZZZ           | 1               | 100        |

--- a/tests/acceptance/features/apiPasswordAddUser/provisioningAddUserSpecialCharacters.feature
+++ b/tests/acceptance/features/apiPasswordAddUser/provisioningAddUserSpecialCharacters.feature
@@ -16,6 +16,7 @@ Feature: enforce the required number of special characters in a password when cr
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
     And user "brand-new-user" should exist
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
     Examples:
       | password              | ocs-api-version | ocs-status |
       | 3#Special$Characters! | 1               | 100        |

--- a/tests/acceptance/features/apiPasswordAddUser/provisioningAddUserSpecialCharactersRestrictions.feature
+++ b/tests/acceptance/features/apiPasswordAddUser/provisioningAddUserSpecialCharactersRestrictions.feature
@@ -18,6 +18,7 @@ Feature: enforce the restricted special characters in a password when creating a
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
     And user "brand-new-user" should exist
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
     Examples:
       | password              | ocs-api-version | ocs-status |
       | 3$Special%Characters^ | 1               | 100        |

--- a/tests/acceptance/features/apiPasswordAddUser/provisioningAddUserUppercaseLetters.feature
+++ b/tests/acceptance/features/apiPasswordAddUser/provisioningAddUserUppercaseLetters.feature
@@ -16,6 +16,7 @@ Feature: enforce the required number of uppercase letters in a password when cre
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
     And user "brand-new-user" should exist
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
     Examples:
       | password                  | ocs-api-version | ocs-status |
       | 3UpperCaseLetters         | 1               | 100        |

--- a/tests/acceptance/features/apiPasswordChange/occResetPasswordLowercaseLetters.feature
+++ b/tests/acceptance/features/apiPasswordChange/occResetPasswordLowercaseLetters.feature
@@ -16,6 +16,8 @@ Feature: enforce the required number of lowercase letters in a password when res
     When the administrator resets the password of user "user1" to "<password>" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'Successfully reset password for user1'
+    And the content of file "textfile0.txt" for user "user1" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "abcABC1234" should not be able to download file "textfile0.txt"
     Examples:
       | password                  |
       | 3LCase                    |
@@ -26,6 +28,8 @@ Feature: enforce the required number of lowercase letters in a password when res
     Then the command should have failed with exit code 1
     # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
     And the command error output should contain the text 'The password contains too few lowercase letters. At least 3 lowercase'
+    And the content of file "textfile0.txt" for user "user1" using password "abcABC1234" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "<password>" should not be able to download file "textfile0.txt"
     Examples:
       | password   |
       | 0LOWERCASE |

--- a/tests/acceptance/features/apiPasswordChange/occResetPasswordMinimumLength.feature
+++ b/tests/acceptance/features/apiPasswordChange/occResetPasswordMinimumLength.feature
@@ -16,6 +16,8 @@ Feature: enforce the minimum length of a password when resetting the password us
     When the administrator resets the password of user "user1" to "<password>" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'Successfully reset password for user1'
+    And the content of file "textfile0.txt" for user "user1" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "1234567890" should not be able to download file "textfile0.txt"
     Examples:
       | password             |
       | 10tenchars           |
@@ -25,6 +27,8 @@ Feature: enforce the minimum length of a password when resetting the password us
     When the administrator resets the password of user "user1" to "<password>" using the occ command
     Then the command should have failed with exit code 1
     And the command error output should contain the text 'The password is too short. At least 10 characters are required.'
+    And the content of file "textfile0.txt" for user "user1" using password "1234567890" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "<password>" should not be able to download file "textfile0.txt"
     Examples:
       | password  |
       | A         |

--- a/tests/acceptance/features/apiPasswordChange/occResetPasswordNumbers.feature
+++ b/tests/acceptance/features/apiPasswordChange/occResetPasswordNumbers.feature
@@ -16,6 +16,8 @@ Feature: enforce the required number of numbers in a password when resetting the
     When the administrator resets the password of user "user1" to "<password>" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'Successfully reset password for user1'
+    And the content of file "textfile0.txt" for user "user1" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "abcABC1234" should not be able to download file "textfile0.txt"
     Examples:
       | password        |
       | 333Numbers      |
@@ -25,6 +27,8 @@ Feature: enforce the required number of numbers in a password when resetting the
     When the administrator resets the password of user "user1" to "<password>" using the occ command
     Then the command should have failed with exit code 1
     And the command error output should contain the text 'The password contains too few numbers. At least 3 numbers are required.'
+    And the content of file "textfile0.txt" for user "user1" using password "abcABC1234" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "<password>" should not be able to download file "textfile0.txt"
     Examples:
       | password      |
       | NoNumbers     |

--- a/tests/acceptance/features/apiPasswordChange/occResetPasswordRequirementCombinations.feature
+++ b/tests/acceptance/features/apiPasswordChange/occResetPasswordRequirementCombinations.feature
@@ -24,6 +24,8 @@ Feature: enforce combinations of password policies when resetting a user passwor
     When the administrator resets the password of user "user1" to "<password>" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'Successfully reset password for user1'
+    And the content of file "textfile0.txt" for user "user1" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "aA1!bB2#cC&deee" should not be able to download file "textfile0.txt"
     Examples:
       | password                  |
       | 15***UPPloweZZZ           |
@@ -33,6 +35,8 @@ Feature: enforce combinations of password policies when resetting a user passwor
     When the administrator resets the password of user "user1" to "<password>" using the occ command
     Then the command should have failed with exit code 1
     And the command error output should contain the text '<message>'
+    And the content of file "textfile0.txt" for user "user1" using password "aA1!bB2#cC&deee" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "<password>" should not be able to download file "textfile0.txt"
     Examples:
       | password                       | message                                                                   |
         # where just one of the requirements is not met
@@ -51,7 +55,8 @@ Feature: enforce combinations of password policies when resetting a user passwor
     When the administrator resets the password of user "user1" to "<password>" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'Successfully reset password for user1'
-    And user "user1" should exist
+    And the content of file "textfile0.txt" for user "user1" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "aA1!bB2#cC&deee" should not be able to download file "textfile0.txt"
     Examples:
       | password                  |
       | 15%&*UPPloweZZZ           |
@@ -63,6 +68,8 @@ Feature: enforce combinations of password policies when resetting a user passwor
     When the administrator resets the password of user "user1" to "<password>" using the occ command
     Then the command should have failed with exit code 1
     And the command error output should contain the text '<message>'
+    And the content of file "textfile0.txt" for user "user1" using password "aA1!bB2#cC&deee" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "<password>" should not be able to download file "textfile0.txt"
     Examples:
       | password        | message                                                                   |
       | 15#!!UPPloweZZZ | The password contains invalid special characters. Only $%^&* are allowed. |

--- a/tests/acceptance/features/apiPasswordChange/occResetPasswordSpecialCharacters.feature
+++ b/tests/acceptance/features/apiPasswordChange/occResetPasswordSpecialCharacters.feature
@@ -16,6 +16,8 @@ Feature: enforce the required number of special characters in a password when re
     When the administrator resets the password of user "user1" to "<password>" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'Successfully reset password for user1'
+    And the content of file "textfile0.txt" for user "user1" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "a!b@c#1234" should not be able to download file "textfile0.txt"
     Examples:
       | password              |
       | 3#Special$Characters! |
@@ -26,6 +28,8 @@ Feature: enforce the required number of special characters in a password when re
     Then the command should have failed with exit code 1
     # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
     And the command error output should contain the text 'The password contains too few special characters. At least 3 special char'
+    And the content of file "textfile0.txt" for user "user1" using password "a!b@c#1234" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "<password>" should not be able to download file "textfile0.txt"
     Examples:
       | password                 |
       | NoSpecialCharacters123   |

--- a/tests/acceptance/features/apiPasswordChange/occResetPasswordSpecialCharactersRestrictions.feature
+++ b/tests/acceptance/features/apiPasswordChange/occResetPasswordSpecialCharactersRestrictions.feature
@@ -18,6 +18,8 @@ Feature: enforce the required number of restricted special characters in a passw
     When the administrator resets the password of user "user1" to "<password>" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'Successfully reset password for user1'
+    And the content of file "textfile0.txt" for user "user1" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "a$b%c^1234" should not be able to download file "textfile0.txt"
     Examples:
       | password              |
       | 3$Special%Characters^ |
@@ -28,6 +30,8 @@ Feature: enforce the required number of restricted special characters in a passw
     Then the command should have failed with exit code 1
     # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
     And the command error output should contain the text 'The password contains too few special characters. At least 3 special char'
+    And the content of file "textfile0.txt" for user "user1" using password "a$b%c^1234" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "<password>" should not be able to download file "textfile0.txt"
     Examples:
       | password                 |
       | NoSpecialCharacters123   |
@@ -38,6 +42,8 @@ Feature: enforce the required number of restricted special characters in a passw
     Then the command should have failed with exit code 1
     # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
     And the command error output should contain the text 'The password contains invalid special characters. Only $%^&* are allowed.'
+    And the content of file "textfile0.txt" for user "user1" using password "a$b%c^1234" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "<password>" should not be able to download file "textfile0.txt"
     Examples:
       | password                                 |
       | Only#Invalid!Special@Characters          |

--- a/tests/acceptance/features/apiPasswordChange/occResetPasswordUppercaseLetters.feature
+++ b/tests/acceptance/features/apiPasswordChange/occResetPasswordUppercaseLetters.feature
@@ -16,6 +16,8 @@ Feature: enforce the required number of uppercase letters in a password when res
     When the administrator resets the password of user "user1" to "<password>" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'Successfully reset password for user1'
+    And the content of file "textfile0.txt" for user "user1" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "abcABC1234" should not be able to download file "textfile0.txt"
     Examples:
       | password                  |
       | 3UpperCaseLetters         |
@@ -26,6 +28,8 @@ Feature: enforce the required number of uppercase letters in a password when res
     Then the command should have failed with exit code 1
     # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
     And the command error output should contain the text 'The password contains too few uppercase letters. At least 3 uppercase'
+    And the content of file "textfile0.txt" for user "user1" using password "abcABC1234" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "<password>" should not be able to download file "textfile0.txt"
     Examples:
       | password       |
       | 0uppercase     |

--- a/tests/acceptance/features/apiPasswordChange/provisioningChangeUserPasswordLowercaseLetters.feature
+++ b/tests/acceptance/features/apiPasswordChange/provisioningChangeUserPasswordLowercaseLetters.feature
@@ -19,6 +19,8 @@ Feature: enforce the required number of lowercase letters in a password when cha
       | value | <password> |
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
+    And the content of file "textfile0.txt" for user "user1" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "abcABC1234" should not be able to download file "textfile0.txt"
     Examples:
       | password                  | ocs-api-version | ocs-status |
       | 3LCase                    | 1               | 100        |
@@ -38,6 +40,8 @@ Feature: enforce the required number of lowercase letters in a password when cha
       """
       The password contains too few lowercase letters. At least 3 lowercase letters are required.
       """
+    And the content of file "textfile0.txt" for user "user1" using password "abcABC1234" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "<password>" should not be able to download file "textfile0.txt"
     Examples:
       | password   | ocs-api-version | ocs-status | http-status | http-reason-phrase |
       | 0LOWERCASE | 1               | 403        | 200         | OK                 |

--- a/tests/acceptance/features/apiPasswordChange/provisioningChangeUserPasswordMinimumLength.feature
+++ b/tests/acceptance/features/apiPasswordChange/provisioningChangeUserPasswordMinimumLength.feature
@@ -19,6 +19,8 @@ Feature: enforce the minimum length of a password when changing a user password
       | value | <password> |
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
+    And the content of file "textfile0.txt" for user "user1" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "1234567890" should not be able to download file "textfile0.txt"
     Examples:
       | password             | ocs-api-version | ocs-status |
       | 10tenchars           | 1               | 100        |
@@ -38,6 +40,8 @@ Feature: enforce the minimum length of a password when changing a user password
       """
       The password is too short. At least 10 characters are required.
       """
+    And the content of file "textfile0.txt" for user "user1" using password "1234567890" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "<password>" should not be able to download file "textfile0.txt"
     Examples:
       | password  | ocs-api-version | ocs-status | http-status | http-reason-phrase |
       | A         | 1               | 403        | 200         | OK                 |

--- a/tests/acceptance/features/apiPasswordChange/provisioningChangeUserPasswordNumbers.feature
+++ b/tests/acceptance/features/apiPasswordChange/provisioningChangeUserPasswordNumbers.feature
@@ -19,6 +19,8 @@ Feature: enforce the required number of numbers in a password when changing a us
       | value | <password> |
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
+    And the content of file "textfile0.txt" for user "user1" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "abcABC1234" should not be able to download file "textfile0.txt"
     Examples:
       | password        | ocs-api-version | ocs-status |
       | 333Numbers      | 1               | 100        |
@@ -38,6 +40,8 @@ Feature: enforce the required number of numbers in a password when changing a us
       """
       The password contains too few numbers. At least 3 numbers are required.
       """
+    And the content of file "textfile0.txt" for user "user1" using password "abcABC1234" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "<password>" should not be able to download file "textfile0.txt"
     Examples:
       | password      | ocs-api-version | ocs-status | http-status | http-reason-phrase |
       | NoNumbers     | 1               | 403        | 200         | OK                 |

--- a/tests/acceptance/features/apiPasswordChange/provisioningChangeUserPasswordRequirementCombinations.feature
+++ b/tests/acceptance/features/apiPasswordChange/provisioningChangeUserPasswordRequirementCombinations.feature
@@ -27,6 +27,8 @@ Feature: enforce combinations of password policies when changing a user password
       | value | <password> |
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
+    And the content of file "textfile0.txt" for user "user1" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "aA1!bB2#cC&deee" should not be able to download file "textfile0.txt"
     Examples:
       | password                  | ocs-api-version | ocs-status |
       | 15***UPPloweZZZ           | 1               | 100        |
@@ -43,6 +45,8 @@ Feature: enforce combinations of password policies when changing a user password
     And the HTTP reason phrase should be "<http-reason-phrase>"
     And the OCS status code should be "<ocs-status>"
     And the OCS status message should be "<ocs-status-message>"
+    And the content of file "textfile0.txt" for user "user1" using password "aA1!bB2#cC&deee" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "<password>" should not be able to download file "textfile0.txt"
     Examples:
       | password                       | ocs-api-version | ocs-status | http-status | http-reason-phrase | ocs-status-message                                                                            |
         # just one of the requirements is not met
@@ -71,6 +75,8 @@ Feature: enforce combinations of password policies when changing a user password
       | value | <password> |
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
+    And the content of file "textfile0.txt" for user "user1" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "aA1!bB2#cC&deee" should not be able to download file "textfile0.txt"
     Examples:
       | password                  | ocs-api-version | ocs-status |
       | 15%&*UPPloweZZZ           | 1               | 100        |
@@ -89,6 +95,8 @@ Feature: enforce combinations of password policies when changing a user password
     And the HTTP reason phrase should be "<http-reason-phrase>"
     And the OCS status code should be "<ocs-status>"
     And the OCS status message should be "<ocs-status-message>"
+    And the content of file "textfile0.txt" for user "user1" using password "aA1!bB2#cC&deee" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "<password>" should not be able to download file "textfile0.txt"
     Examples:
       | password        | ocs-api-version | ocs-status | http-status | http-reason-phrase | ocs-status-message                                                                          |
       | 15#!!UPPloweZZZ | 1               | 403        | 200         | OK                 | The password contains invalid special characters. Only $%^&* are allowed.                   |

--- a/tests/acceptance/features/apiPasswordChange/provisioningChangeUserPasswordSpecialCharacters.feature
+++ b/tests/acceptance/features/apiPasswordChange/provisioningChangeUserPasswordSpecialCharacters.feature
@@ -19,6 +19,8 @@ Feature: enforce the required number of special characters in a password when ch
       | value | <password> |
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
+    And the content of file "textfile0.txt" for user "user1" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "a!b@c#1234" should not be able to download file "textfile0.txt"
     Examples:
       | password              | ocs-api-version | ocs-status |
       | 3#Special$Characters! | 1               | 100        |
@@ -38,6 +40,8 @@ Feature: enforce the required number of special characters in a password when ch
       """
       The password contains too few special characters. At least 3 special characters are required.
       """
+    And the content of file "textfile0.txt" for user "user1" using password "a!b@c#1234" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "<password>" should not be able to download file "textfile0.txt"
     Examples:
       | password                 | ocs-api-version | ocs-status | http-status | http-reason-phrase |
       | NoSpecialCharacters123   | 1               | 403        | 200         | OK                 |

--- a/tests/acceptance/features/apiPasswordChange/provisioningChangeUserPasswordSpecialCharactersRestrictions.feature
+++ b/tests/acceptance/features/apiPasswordChange/provisioningChangeUserPasswordSpecialCharactersRestrictions.feature
@@ -21,6 +21,8 @@ Feature: enforce the required number of restricted special characters in a passw
       | value | <password> |
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
+    And the content of file "textfile0.txt" for user "user1" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "a$b%c^1234" should not be able to download file "textfile0.txt"
     Examples:
       | password              | ocs-api-version | ocs-status |
       | 3$Special%Characters^ | 1               | 100        |
@@ -40,6 +42,8 @@ Feature: enforce the required number of restricted special characters in a passw
       """
       The password contains too few special characters. At least 3 special characters ($%^&*) are required.
       """
+    And the content of file "textfile0.txt" for user "user1" using password "a$b%c^1234" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "<password>" should not be able to download file "textfile0.txt"
     Examples:
       | password                 | ocs-api-version | ocs-status | http-status | http-reason-phrase |
       | NoSpecialCharacters123   | 1               | 403        | 200         | OK                 |
@@ -59,6 +63,8 @@ Feature: enforce the required number of restricted special characters in a passw
       """
       The password contains invalid special characters. Only $%^&* are allowed.
       """
+    And the content of file "textfile0.txt" for user "user1" using password "a$b%c^1234" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "<password>" should not be able to download file "textfile0.txt"
     Examples:
       | password                                 | ocs-api-version | ocs-status | http-status | http-reason-phrase |
       | Only#Invalid!Special@Characters          | 1               | 403        | 200         | OK                 |

--- a/tests/acceptance/features/apiPasswordChange/provisioningChangeUserPasswordUppercaseLetters.feature
+++ b/tests/acceptance/features/apiPasswordChange/provisioningChangeUserPasswordUppercaseLetters.feature
@@ -19,6 +19,8 @@ Feature: enforce the required number of uppercase letters in a password when cha
       | value | <password> |
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
+    And the content of file "textfile0.txt" for user "user1" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "abcABC1234" should not be able to download file "textfile0.txt"
     Examples:
       | password                  | ocs-api-version | ocs-status |
       | 3UpperCaseLetters         | 1               | 100        |
@@ -38,6 +40,8 @@ Feature: enforce the required number of uppercase letters in a password when cha
       """
       The password contains too few uppercase letters. At least 3 uppercase letters are required.
       """
+    And the content of file "textfile0.txt" for user "user1" using password "abcABC1234" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "<password>" should not be able to download file "textfile0.txt"
     Examples:
       | password       | ocs-api-version | ocs-status | http-status | http-reason-phrase |
       | 0uppercase     | 1               | 403        | 200         | OK                 |


### PR DESCRIPTION
Do not trust the status codes, also make sure that the expected password works and the other password does not work.