### PR TITLE
Simplify acceptance test make-run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,12 +135,12 @@ test-php-phpstan: vendor-bin/phpstan/vendor
 .PHONY: test-acceptance-api
 test-acceptance-api:       ## Run API acceptance tests
 test-acceptance-api: vendor/bin/phpunit
-	../../tests/acceptance/run.sh --config tests/acceptance/config/behat.yml --type api
+	../../tests/acceptance/run.sh --type api
 
 .PHONY: test-acceptance-webui
 test-acceptance-webui:     ## Run webUI acceptance tests
 test-acceptance-webui: vendor/bin/phpunit
-	../../tests/acceptance/run.sh --config tests/acceptance/config/behat.yml --type webUI
+	../../tests/acceptance/run.sh --type webUI
 
 #
 # Dependency management

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -17,7 +17,7 @@ Administrators find the configuration options in the 'Security' section of the o
 		<admin>https://doc.owncloud.com/server/10.0/admin_manual/configuration/server/security/password_policy.html</admin>
 	</documentation>
 	<dependencies>
-		<owncloud min-version="10.0.9" max-version="10.1" />
+		<owncloud min-version="10.0.9" max-version="11.0.0.0" />
 	</dependencies>
 	<namespace>PasswordPolicy</namespace>
 	<settings>


### PR DESCRIPTION
core ``run.sh`` was enhanced a week ago to "guess" where the default ``behat.yml`` is when running app acceptance tests. Get rid of the unneeded parameter here.

(noticed while doing similar stuff in guests app)