### PR TITLE
Adjust CI

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -8,7 +8,7 @@ $config
 	->exclude('l10n')
 	->exclude('vendor')
 	->exclude('vendor-bin')
-	->exclude('c3.php')
+	->notPath('/^c3.php/')
 	->in(__DIR__);
 
 return $config;

--- a/Makefile
+++ b/Makefile
@@ -135,17 +135,17 @@ test-php-phpstan: vendor-bin/phpstan/vendor
 .PHONY: test-acceptance-api
 test-acceptance-api:       ## Run API acceptance tests
 test-acceptance-api: vendor/bin/phpunit
-	../../tests/acceptance/run.sh --type api
+	../../tests/acceptance/run.sh --remote --type api
 
 .PHONY: test-acceptance-cli
 test-acceptance-cli:       ## Run CLI acceptance tests
 test-acceptance-cli: vendor/bin/phpunit
-	../../tests/acceptance/run.sh --type cli
+	../../tests/acceptance/run.sh --remote --type cli
 
 .PHONY: test-acceptance-webui
 test-acceptance-webui:     ## Run webUI acceptance tests
 test-acceptance-webui: vendor/bin/phpunit
-	../../tests/acceptance/run.sh --type webUI
+	../../tests/acceptance/run.sh --remote --type webUI
 
 #
 # Dependency management


### PR DESCRIPTION
Exclude the top-level file ``c3.php`` from ``php-cs-fixer`` by specifying it using the ``notPath()`` method of Symfony Finder. This is the "proper" way to do this. The ``exclude()`` method is actually supposed to be for directories only, and it seems that in a more recent Symfony Finder version that it really is now only for directories.

Add the ``--remote`` switch when running acceptance tests. This helps in situations where the system-under-test and the test runner are on different systems, or running as different users. e.g. when a developer is running their server as ``www-data`` and the test runner is running as themselves.