### PR TITLE
Adjust user creation steps

### DIFF
--- a/tests/acceptance/features/apiPasswordChange/provisioningChangeUserPasswordLastPasswords.feature
+++ b/tests/acceptance/features/apiPasswordChange/provisioningChangeUserPasswordLastPasswords.feature
@@ -8,7 +8,7 @@ Feature: enforce the number of last passwords that must not be used when resetti
   Background:
     Given the administrator has enabled the last passwords user password policy
     And the administrator has set the number of last passwords that should not be used to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password |
       | user1    | Number1  |
 

--- a/tests/acceptance/features/apiPasswordChange/provisioningChangeUserPasswordLowercaseLetters.feature
+++ b/tests/acceptance/features/apiPasswordChange/provisioningChangeUserPasswordLowercaseLetters.feature
@@ -8,7 +8,7 @@ Feature: enforce the required number of lowercase letters in a password when cha
   Background:
     Given the administrator has enabled the lowercase letters password policy
     And the administrator has set the lowercase letters required to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | abcABC1234 |
 

--- a/tests/acceptance/features/apiPasswordChange/provisioningChangeUserPasswordMinimumLength.feature
+++ b/tests/acceptance/features/apiPasswordChange/provisioningChangeUserPasswordMinimumLength.feature
@@ -8,7 +8,7 @@ Feature: enforce the minimum length of a password when changing a user password
   Background:
     Given the administrator has enabled the minimum characters password policy
     And the administrator has set the minimum characters required to "10"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | 1234567890 |
 

--- a/tests/acceptance/features/apiPasswordChange/provisioningChangeUserPasswordNumbers.feature
+++ b/tests/acceptance/features/apiPasswordChange/provisioningChangeUserPasswordNumbers.feature
@@ -8,7 +8,7 @@ Feature: enforce the required number of numbers in a password when changing a us
   Background:
     Given the administrator has enabled the numbers password policy
     And the administrator has set the numbers required to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | abcABC1234 |
 

--- a/tests/acceptance/features/apiPasswordChange/provisioningChangeUserPasswordRequirementCombinations.feature
+++ b/tests/acceptance/features/apiPasswordChange/provisioningChangeUserPasswordRequirementCombinations.feature
@@ -16,7 +16,7 @@ Feature: enforce combinations of password policies when changing a user password
     And the administrator has set the numbers required to "2"
     And the administrator has enabled the special characters password policy
     And the administrator has set the special characters required to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password        |
       | user1    | aA1!bB2#cC&deee |
 

--- a/tests/acceptance/features/apiPasswordChange/provisioningChangeUserPasswordSpecialCharacters.feature
+++ b/tests/acceptance/features/apiPasswordChange/provisioningChangeUserPasswordSpecialCharacters.feature
@@ -8,7 +8,7 @@ Feature: enforce the required number of special characters in a password when ch
   Background:
     Given the administrator has enabled the special characters password policy
     And the administrator has set the special characters required to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | a!b@c#1234 |
 

--- a/tests/acceptance/features/apiPasswordChange/provisioningChangeUserPasswordSpecialCharactersRestrictions.feature
+++ b/tests/acceptance/features/apiPasswordChange/provisioningChangeUserPasswordSpecialCharactersRestrictions.feature
@@ -10,7 +10,7 @@ Feature: enforce the required number of restricted special characters in a passw
     And the administrator has set the special characters required to "3"
     And the administrator has enabled the restrict to these special characters password policy
     And the administrator has set the restricted special characters required to "$%^&*"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | a$b%c^1234 |
 

--- a/tests/acceptance/features/apiPasswordChange/provisioningChangeUserPasswordUppercaseLetters.feature
+++ b/tests/acceptance/features/apiPasswordChange/provisioningChangeUserPasswordUppercaseLetters.feature
@@ -8,7 +8,7 @@ Feature: enforce the required number of uppercase letters in a password when cha
   Background:
     Given the administrator has enabled the uppercase letters password policy
     And the administrator has set the uppercase letters required to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | abcABC1234 |
 

--- a/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateLowercaseLetters.feature
+++ b/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateLowercaseLetters.feature
@@ -8,7 +8,7 @@ Feature: enforce the required number of lowercase letters on public share links
   Background:
     Given the administrator has enabled the lowercase letters password policy
     And the administrator has set the lowercase letters required to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | abcABC1234 |
     And user "user1" has created a public link share with settings

--- a/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateMinimumLength.feature
+++ b/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateMinimumLength.feature
@@ -8,7 +8,7 @@ Feature: enforce the minimum length of a password on public share links
   Background:
     Given the administrator has enabled the minimum characters password policy
     And the administrator has set the minimum characters required to "10"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | 1234567890 |
     And user "user1" has created a public link share with settings

--- a/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateNumbers.feature
+++ b/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateNumbers.feature
@@ -8,7 +8,7 @@ Feature: enforce the required number of numbers in a password on public share li
   Background:
     Given the administrator has enabled the numbers password policy
     And the administrator has set the numbers required to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | abcABC1234 |
     And user "user1" has created a public link share with settings

--- a/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateRequirementCombinations.feature
+++ b/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateRequirementCombinations.feature
@@ -16,7 +16,7 @@ Feature: enforce combinations of password policies on public share links
     And the administrator has set the numbers required to "2"
     And the administrator has enabled the special characters password policy
     And the administrator has set the special characters required to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password        |
       | user1    | aA1!bB2#cC&deee |
     And user "user1" has created a public link share with settings

--- a/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateSpecialCharacters.feature
+++ b/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateSpecialCharacters.feature
@@ -8,7 +8,7 @@ Feature: enforce the required number of special characters in a password on publ
   Background:
     Given the administrator has enabled the special characters password policy
     And the administrator has set the special characters required to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | a!b@c#1234 |
     And user "user1" has created a public link share with settings

--- a/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateSpecialCharactersRestrictions.feature
+++ b/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateSpecialCharactersRestrictions.feature
@@ -10,7 +10,7 @@ Feature: enforce the restricted special characters in a password on public share
     And the administrator has set the special characters required to "3"
     And the administrator has enabled the restrict to these special characters password policy
     And the administrator has set the restricted special characters required to "$%^&*"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | a$b%c^1234 |
     And user "user1" has created a public link share with settings

--- a/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateUppercaseLetters.feature
+++ b/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateUppercaseLetters.feature
@@ -8,7 +8,7 @@ Feature: enforce the required number of uppercase letters in a password on publi
   Background:
     Given the administrator has enabled the uppercase letters password policy
     And the administrator has set the uppercase letters required to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | abcABC1234 |
     And user "user1" has created a public link share with settings

--- a/tests/acceptance/features/cliPasswordChange/occResetPasswordLastPasswords.feature
+++ b/tests/acceptance/features/cliPasswordChange/occResetPasswordLastPasswords.feature
@@ -8,7 +8,7 @@ Feature: enforce the number of last passwords that must not be used when resetti
   Background:
     Given the administrator has enabled the last passwords user password policy
     And the administrator has set the number of last passwords that should not be used to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password |
       | user1    | Number1  |
 

--- a/tests/acceptance/features/cliPasswordChange/occResetPasswordLowercaseLetters.feature
+++ b/tests/acceptance/features/cliPasswordChange/occResetPasswordLowercaseLetters.feature
@@ -8,7 +8,7 @@ Feature: enforce the required number of lowercase letters in a password when res
   Background:
     Given the administrator has enabled the lowercase letters password policy
     And the administrator has set the lowercase letters required to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | abcABC1234 |
 

--- a/tests/acceptance/features/cliPasswordChange/occResetPasswordMinimumLength.feature
+++ b/tests/acceptance/features/cliPasswordChange/occResetPasswordMinimumLength.feature
@@ -8,7 +8,7 @@ Feature: enforce the minimum length of a password when resetting the password us
   Background:
     Given the administrator has enabled the minimum characters password policy
     And the administrator has set the minimum characters required to "10"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | 1234567890 |
 

--- a/tests/acceptance/features/cliPasswordChange/occResetPasswordNumbers.feature
+++ b/tests/acceptance/features/cliPasswordChange/occResetPasswordNumbers.feature
@@ -8,7 +8,7 @@ Feature: enforce the required number of numbers in a password when resetting the
   Background:
     Given the administrator has enabled the numbers password policy
     And the administrator has set the numbers required to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | abcABC1234 |
 

--- a/tests/acceptance/features/cliPasswordChange/occResetPasswordRequirementCombinations.feature
+++ b/tests/acceptance/features/cliPasswordChange/occResetPasswordRequirementCombinations.feature
@@ -16,7 +16,7 @@ Feature: enforce combinations of password policies when resetting a user passwor
     And the administrator has set the numbers required to "2"
     And the administrator has enabled the special characters password policy
     And the administrator has set the special characters required to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password        |
       | user1    | aA1!bB2#cC&deee |
 

--- a/tests/acceptance/features/cliPasswordChange/occResetPasswordSpecialCharacters.feature
+++ b/tests/acceptance/features/cliPasswordChange/occResetPasswordSpecialCharacters.feature
@@ -8,7 +8,7 @@ Feature: enforce the required number of special characters in a password when re
   Background:
     Given the administrator has enabled the special characters password policy
     And the administrator has set the special characters required to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | a!b@c#1234 |
 

--- a/tests/acceptance/features/cliPasswordChange/occResetPasswordSpecialCharactersRestrictions.feature
+++ b/tests/acceptance/features/cliPasswordChange/occResetPasswordSpecialCharactersRestrictions.feature
@@ -10,7 +10,7 @@ Feature: enforce the required number of restricted special characters in a passw
     And the administrator has set the special characters required to "3"
     And the administrator has enabled the restrict to these special characters password policy
     And the administrator has set the restricted special characters required to "$%^&*"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | a$b%c^1234 |
 

--- a/tests/acceptance/features/cliPasswordChange/occResetPasswordUppercaseLetters.feature
+++ b/tests/acceptance/features/cliPasswordChange/occResetPasswordUppercaseLetters.feature
@@ -8,7 +8,7 @@ Feature: enforce the required number of uppercase letters in a password when res
   Background:
     Given the administrator has enabled the uppercase letters password policy
     And the administrator has set the uppercase letters required to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | abcABC1234 |
 

--- a/tests/acceptance/features/webUIPasswordChange/passwordChangeLastPasswords.feature
+++ b/tests/acceptance/features/webUIPasswordChange/passwordChangeLastPasswords.feature
@@ -8,7 +8,7 @@ Feature: enforce the number of last passwords that must not be used when resetti
   Background:
     Given the administrator has enabled the last passwords user password policy
     And the administrator has set the number of last passwords that should not be used to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password |
       | user1    | Number1  |
     And the administrator has reset the password of user "user1" to "Number2"

--- a/tests/acceptance/features/webUIPasswordChange/passwordChangeLowercaseLetters.feature
+++ b/tests/acceptance/features/webUIPasswordChange/passwordChangeLowercaseLetters.feature
@@ -8,7 +8,7 @@ Feature: enforce the required number of lowercase letters in a password on the p
   Background:
     Given the administrator has enabled the lowercase letters password policy
     And the administrator has set the lowercase letters required to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | abcABC1234 |
     And the user has browsed to the login page

--- a/tests/acceptance/features/webUIPasswordChange/passwordChangeMinimumLength.feature
+++ b/tests/acceptance/features/webUIPasswordChange/passwordChangeMinimumLength.feature
@@ -8,7 +8,7 @@ Feature: enforce the minimum length of a password on the password change UI page
   Background:
     Given the administrator has enabled the minimum characters password policy
     And the administrator has set the minimum characters required to "10"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | 1234567890 |
     And the user has browsed to the login page

--- a/tests/acceptance/features/webUIPasswordChange/passwordChangeNumbers.feature
+++ b/tests/acceptance/features/webUIPasswordChange/passwordChangeNumbers.feature
@@ -8,7 +8,7 @@ Feature: enforce the required number of numbers in a password on the password ch
   Background:
     Given the administrator has enabled the numbers password policy
     And the administrator has set the numbers required to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | abcABC1234 |
     And the user has browsed to the login page

--- a/tests/acceptance/features/webUIPasswordChange/passwordChangeRequirementCombinations.feature
+++ b/tests/acceptance/features/webUIPasswordChange/passwordChangeRequirementCombinations.feature
@@ -16,7 +16,7 @@ Feature: enforce combinations of password policies on the password change UI pag
     And the administrator has set the numbers required to "2"
     And the administrator has enabled the special characters password policy
     And the administrator has set the special characters required to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password        |
       | user1    | aA1!bB2#cC&deee |
     And the user has browsed to the login page

--- a/tests/acceptance/features/webUIPasswordChange/passwordChangeSpecialCharacters.feature
+++ b/tests/acceptance/features/webUIPasswordChange/passwordChangeSpecialCharacters.feature
@@ -8,7 +8,7 @@ Feature: enforce the required number of special characters in a password on the 
   Background:
     Given the administrator has enabled the special characters password policy
     And the administrator has set the special characters required to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | a!b@c#1234 |
     And the user has browsed to the login page

--- a/tests/acceptance/features/webUIPasswordChange/passwordChangeSpecialCharactersRestrictions.feature
+++ b/tests/acceptance/features/webUIPasswordChange/passwordChangeSpecialCharactersRestrictions.feature
@@ -10,7 +10,7 @@ Feature: enforce the restricted special characters in a password on the password
     And the administrator has set the special characters required to "3"
     And the administrator has enabled the restrict to these special characters password policy
     And the administrator has set the restricted special characters required to "$%^&*"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | a$b%c^1234 |
     And the user has browsed to the login page

--- a/tests/acceptance/features/webUIPasswordChange/passwordChangeUppercaseLetters.feature
+++ b/tests/acceptance/features/webUIPasswordChange/passwordChangeUppercaseLetters.feature
@@ -8,7 +8,7 @@ Feature: enforce the required number of uppercase letters in a password on the p
   Background:
     Given the administrator has enabled the uppercase letters password policy
     And the administrator has set the uppercase letters required to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | abcABC1234 |
     And the user has browsed to the login page

--- a/tests/acceptance/features/webUIPasswordReset/passwordResetLastPasswords.feature
+++ b/tests/acceptance/features/webUIPasswordReset/passwordResetLastPasswords.feature
@@ -8,7 +8,7 @@ Feature: enforce the number of last passwords that must not be used when resetti
   Background:
     Given the administrator has enabled the last passwords user password policy
     And the administrator has set the number of last passwords that should not be used to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password |
       | user1    | Number1  |
     And the administrator has reset the password of user "user1" to "Number2"

--- a/tests/acceptance/features/webUIPasswordReset/passwordResetLowercaseLetters.feature
+++ b/tests/acceptance/features/webUIPasswordReset/passwordResetLowercaseLetters.feature
@@ -8,7 +8,7 @@ Feature: enforce the required number of lowercase letters in a password on the p
   Background:
     Given the administrator has enabled the lowercase letters password policy
     And the administrator has set the lowercase letters required to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | abcABC1234 |
     And the user has browsed to the login page

--- a/tests/acceptance/features/webUIPasswordReset/passwordResetMinimumLength.feature
+++ b/tests/acceptance/features/webUIPasswordReset/passwordResetMinimumLength.feature
@@ -8,7 +8,7 @@ Feature: enforce the minimum length of a password on the password reset UI page
   Background:
     Given the administrator has enabled the minimum characters password policy
     And the administrator has set the minimum characters required to "10"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | 1234567890 |
     And the user has browsed to the login page

--- a/tests/acceptance/features/webUIPasswordReset/passwordResetNumbers.feature
+++ b/tests/acceptance/features/webUIPasswordReset/passwordResetNumbers.feature
@@ -8,7 +8,7 @@ Feature: enforce the required number of numbers in a password on the password re
   Background:
     Given the administrator has enabled the numbers password policy
     And the administrator has set the numbers required to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | abcABC1234 |
     And the user has browsed to the login page

--- a/tests/acceptance/features/webUIPasswordReset/passwordResetRequirementCombinations.feature
+++ b/tests/acceptance/features/webUIPasswordReset/passwordResetRequirementCombinations.feature
@@ -16,7 +16,7 @@ Feature: enforce combinations of password policies on the password reset UI page
     And the administrator has set the numbers required to "2"
     And the administrator has enabled the special characters password policy
     And the administrator has set the special characters required to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password        |
       | user1    | aA1!bB2#cC&deee |
     And the user has browsed to the login page

--- a/tests/acceptance/features/webUIPasswordReset/passwordResetSpecialCharacters.feature
+++ b/tests/acceptance/features/webUIPasswordReset/passwordResetSpecialCharacters.feature
@@ -8,7 +8,7 @@ Feature: enforce the required number of special characters in a password on the 
   Background:
     Given the administrator has enabled the special characters password policy
     And the administrator has set the special characters required to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | a!b@c#1234 |
     And the user has browsed to the login page

--- a/tests/acceptance/features/webUIPasswordReset/passwordResetSpecialCharactersRestriction.feature
+++ b/tests/acceptance/features/webUIPasswordReset/passwordResetSpecialCharactersRestriction.feature
@@ -10,7 +10,7 @@ Feature: enforce the restricted special characters in a password on the password
     And the administrator has set the special characters required to "3"
     And the administrator has enabled the restrict to these special characters password policy
     And the administrator has set the restricted special characters required to "$%^&*"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | a$b%c^1234 |
     And the user has browsed to the login page

--- a/tests/acceptance/features/webUIPasswordReset/passwordResetUppercaseLetters.feature
+++ b/tests/acceptance/features/webUIPasswordReset/passwordResetUppercaseLetters.feature
@@ -8,7 +8,7 @@ Feature: enforce the required number of uppercase letters in a password on the p
   Background:
     Given the administrator has enabled the uppercase letters password policy
     And the administrator has set the uppercase letters required to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | abcABC1234 |
     And the user has browsed to the login page

--- a/tests/acceptance/features/webUIPublicShareLink/publicShareLinkLowercaseLetters.feature
+++ b/tests/acceptance/features/webUIPublicShareLink/publicShareLinkLowercaseLetters.feature
@@ -8,7 +8,7 @@ Feature: enforce the required number of lowercase letters in a password on the p
   Background:
     Given the administrator has enabled the lowercase letters password policy
     And the administrator has set the lowercase letters required to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | abcABC1234 |
     And the user has browsed to the login page

--- a/tests/acceptance/features/webUIPublicShareLink/publicShareLinkMinimumLength.feature
+++ b/tests/acceptance/features/webUIPublicShareLink/publicShareLinkMinimumLength.feature
@@ -8,7 +8,7 @@ Feature: enforce the minimum length of a password on the public share link page
   Background:
     Given the administrator has enabled the minimum characters password policy
     And the administrator has set the minimum characters required to "10"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | 1234567890 |
     And the user has browsed to the login page

--- a/tests/acceptance/features/webUIPublicShareLink/publicShareLinkNumbers.feature
+++ b/tests/acceptance/features/webUIPublicShareLink/publicShareLinkNumbers.feature
@@ -8,7 +8,7 @@ Feature: enforce the required number of numbers in a password on the public shar
   Background:
     Given the administrator has enabled the numbers password policy
     And the administrator has set the numbers required to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | abcABC1234 |
     And the user has browsed to the login page

--- a/tests/acceptance/features/webUIPublicShareLink/publicShareLinkRequirementCombinations.feature
+++ b/tests/acceptance/features/webUIPublicShareLink/publicShareLinkRequirementCombinations.feature
@@ -16,7 +16,7 @@ Feature: enforce combinations of password policies on the public share link page
     And the administrator has set the numbers required to "2"
     And the administrator has enabled the special characters password policy
     And the administrator has set the special characters required to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password        |
       | user1    | aA1!bB2#cC&deee |
     And the user has browsed to the login page

--- a/tests/acceptance/features/webUIPublicShareLink/publicShareLinkSpecialCharacters.feature
+++ b/tests/acceptance/features/webUIPublicShareLink/publicShareLinkSpecialCharacters.feature
@@ -8,7 +8,7 @@ Feature: enforce the required number of special characters on the public share l
   Background:
     Given the administrator has enabled the special characters password policy
     And the administrator has set the special characters required to "3"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | a!b@c#1234 |
     And the user has browsed to the login page

--- a/tests/acceptance/features/webUIPublicShareLink/publicShareLinkSpecialCharactersRestrictions.feature
+++ b/tests/acceptance/features/webUIPublicShareLink/publicShareLinkSpecialCharactersRestrictions.feature
@@ -10,7 +10,7 @@ Feature: enforce the restricted special characters in a password on the public s
     And the administrator has set the special characters required to "3"
     And the administrator has enabled the restrict to these special characters password policy
     And the administrator has set the restricted special characters required to "$%^&*"
-    And these users have been created:
+    And these users have been created with default attributes:
       | username | password   |
       | user1    | a$b%c^1234 |
     And the user has browsed to the login page

--- a/tests/acceptance/features/webUIPublicShareLink/publicShareLinkUppercaseLetters.feature
+++ b/tests/acceptance/features/webUIPublicShareLink/publicShareLinkUppercaseLetters.feature
@@ -6,7 +6,7 @@ Feature: enforce the required number of uppercase letters in a password on the p
   So that users cannot set passwords that are too easy to guess
 
   Background:
-    Given these users have been created:
+    Given these users have been created with default attributes:
       | username | password |
       | user1    | abc123   |
     And the administrator has enabled the uppercase letters password policy


### PR DESCRIPTION
This step was recently changed in master.

We want to create user with default attributes set unless it's required to create with different values.