### PR TITLE
Check that coding standard passes on PHP 5.6

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -202,6 +202,9 @@ matrix:
     - PHP_VERSION: 7.2
       TEST_SUITE: owncloud-coding-standard
 
+    - PHP_VERSION: 5.6
+      TEST_SUITE: owncloud-coding-standard
+
     # Unit Tests
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa


### PR DESCRIPTION
This will report any syntax issues if there is new 7.* syntax used in the code.
For the moment we need to still use syntax that works on PHP 5.6

I left the PHP 7.2 coding standard check in the matrix. It feels good to know that the code also passes syntax checks on PHP 7.2 - maybe there are things that work in PHP 5.6 and are deprecated and gone by PHP 7.2