### PR TITLE
Ignore ldap user for password change during first login

### DIFF
--- a/lib/HooksHandler.php
+++ b/lib/HooksHandler.php
@@ -334,8 +334,10 @@ class HooksHandler {
 			 * we can ignore the password change for the user.
 			 */
 			if (\count($last2PasswordOfUser) <= 1) {
-				// try to find user in account table, needs find to search additional search terms,
-				$this->forcePasswordChange(true, $user);
+				if ($user->getBackendClassName() === 'Database') {
+					// try to find user in account table, needs find to search additional search terms,
+					$this->forcePasswordChange(true, $user);
+				}
 			}
 		}
 	}

--- a/tests/unit/HooksHandlerTest.php
+++ b/tests/unit/HooksHandlerTest.php
@@ -411,6 +411,9 @@ class HooksHandlerTest extends TestCase {
 	public function testCheckForcePasswordChangeOnFirstLogin() {
 		/** @var IUser | \PHPUnit_Framework_MockObject_MockObject $user */
 		$user = $this->createMock(IUser::class);
+		$user->method('getBackendClassName')
+			->willReturn('Database');
+
 		$this->engine->expects($this->once())
 			->method('yes')
 			->with('spv_user_password_force_change_on_first_login_checked')
@@ -419,6 +422,30 @@ class HooksHandlerTest extends TestCase {
 		$this->session->expects($this->once())
 			->method('set')
 			->with('password_policy.forcePasswordChange', true);
+
+		$oldPassword = $this->createMock(OldPassword::class);
+		$this->oldPasswordMapper->method('getOldPasswords')
+			->willReturn([$oldPassword]);
+
+		$event = new GenericEvent($user);
+		$this->handler->checkForcePasswordChangeOnFirstLogin($event);
+	}
+
+	public function testCheckLDAPUserForcePasswordChangeOnFirstLogin() {
+		/** @var IUser | \PHPUnit_Framework_MockObject_MockObject $user */
+		$user = $this->createMock(IUser::class);
+		$user->method('getBackendClassName')
+			->willReturn('LDAP');
+
+		$this->engine->expects($this->once())
+			->method('yes')
+			->with('spv_user_password_force_change_on_first_login_checked')
+			->willReturn(true);
+
+		$this->session->expects($this->never())
+			->method('set');
+		$this->config->expects($this->never())
+			->method('setUserValue');
 
 		$oldPassword = $this->createMock(OldPassword::class);
 		$this->oldPasswordMapper->method('getOldPasswords')


### PR DESCRIPTION
LDAP users can be ignored for the password change
during first time login.

Signed-off-by: Sujith H <sharidasan@owncloud.com>