### PR TITLE
Change paths to files in drone codecov step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -122,7 +122,7 @@ pipeline:
     image: plugins/codecov:2
     secrets: [codecov_token]
     pull: true
-    paths:
+    files:
       - tests/output/clover.xml
     when:
       matrix:


### PR DESCRIPTION
It looks odd to me writing a full file name in ``paths:`` (although it does work)
It feels nicer to put a specific codecov file in ``files:``

Change it here before we copy this in too many other places.