### PR TITLE
Do not pin codecov xml file name

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -123,7 +123,7 @@ pipeline:
     secrets: [codecov_token]
     pull: true
     paths:
-      - tests/output/clover.xml
+      - tests/output/*.xml
     when:
       matrix:
         COVERAGE: true

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 .php_cs.cache
 
 # Composer
-composer.phar
 vendor/
 vendor-bin/**/vendor
 vendor-bin/**/composer.lock

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ vendor-bin/**/composer.lock
 
 # Tests - auto-generated files
 /tests/acceptance/output*
-/tests/output/clover.xml
+/tests/output
 
 # Node.js modules
 node_modules/


### PR DESCRIPTION
and gitignore anything in ``tests/output`` - anything we put there should be temporary rubbish, not to be committed to the repo.

and do not bother ignoring ``composer.phar`` - it is no longer downloaded inside the repo anyway.