### PR TITLE
Remove unneeded phpunit Makefile dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,12 +104,12 @@ clean: clean-deps clean-dist clean-build
 
 .PHONY: test-php-unit
 test-php-unit:             ## Run php unit tests
-test-php-unit: vendor/bin/phpunit
+test-php-unit:
 	$(PHPUNIT) --configuration ./phpunit.xml --testsuite unit
 
 .PHONY: test-php-unit-dbg
 test-php-unit-dbg:         ## Run php unit tests using phpdbg
-test-php-unit-dbg: vendor/bin/phpunit
+test-php-unit-dbg:
 	$(PHPUNITDBG) --configuration ./phpunit.xml --testsuite unit
 
 .PHONY: test-php-style
@@ -134,17 +134,17 @@ test-php-phpstan: vendor-bin/phpstan/vendor
 
 .PHONY: test-acceptance-api
 test-acceptance-api:       ## Run API acceptance tests
-test-acceptance-api: vendor/bin/phpunit
+test-acceptance-api:
 	../../tests/acceptance/run.sh --remote --type api
 
 .PHONY: test-acceptance-cli
 test-acceptance-cli:       ## Run CLI acceptance tests
-test-acceptance-cli: vendor/bin/phpunit
+test-acceptance-cli:
 	../../tests/acceptance/run.sh --remote --type cli
 
 .PHONY: test-acceptance-webui
 test-acceptance-webui:     ## Run webUI acceptance tests
-test-acceptance-webui: vendor/bin/phpunit
+test-acceptance-webui:
 	../../tests/acceptance/run.sh --remote --type webUI
 
 #
@@ -156,9 +156,6 @@ composer.lock: composer.json
 
 vendor: composer.lock
 	composer install --no-dev
-
-vendor/bin/phpunit: composer.lock
-	composer install
 
 vendor/bamarni/composer-bin-plugin: composer.lock
 	composer install


### PR DESCRIPTION
We run the ``phpunit`` that already comes "for free" in core.
The acceptance tests do not use ``phpunit`` and do not depend on any special dev/test framework code being installed in the app.
So neither of these need to depend on ``vendor/bin/phpunit`` - in fact nothing does.