### PR TITLE
More flexible Makefile help column format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ PHPSTAN=php -d zend.enable_gc=0 vendor-bin/phpstan/vendor/bin/phpstan
 
 # start with displaying help
 help:
-	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//' | sed -e 's/  */ /' | column -t -s :
 
 #
 # Node dependencies
@@ -98,52 +98,52 @@ clean-deps:
 .PHONY: clean
 clean: clean-deps clean-dist clean-build
 
-##
+##---------------------
 ## Tests
-##--------------------------------------
+##---------------------
 
 .PHONY: test-php-unit
-test-php-unit:             ## Run php unit tests
+test-php-unit: ## Run php unit tests
 test-php-unit:
 	$(PHPUNIT) --configuration ./phpunit.xml --testsuite unit
 
 .PHONY: test-php-unit-dbg
-test-php-unit-dbg:         ## Run php unit tests using phpdbg
+test-php-unit-dbg: ## Run php unit tests using phpdbg
 test-php-unit-dbg:
 	$(PHPUNITDBG) --configuration ./phpunit.xml --testsuite unit
 
 .PHONY: test-php-style
-test-php-style:            ## Run php-cs-fixer and check owncloud code-style
+test-php-style: ## Run php-cs-fixer and check owncloud code-style
 test-php-style: vendor-bin/owncloud-codestyle/vendor
 	$(PHP_CS_FIXER) fix -v --diff --diff-format udiff --allow-risky yes --dry-run
 
 .PHONY: test-php-style-fix
-test-php-style-fix:        ## Run php-cs-fixer and fix code style issues
+test-php-style-fix: ## Run php-cs-fixer and fix code style issues
 test-php-style-fix: vendor-bin/owncloud-codestyle/vendor
 	$(PHP_CS_FIXER) fix -v --diff --diff-format udiff --allow-risky yes
 
 .PHONY: test-php-phan
-test-php-phan:             ## Run phan
+test-php-phan: ## Run phan
 test-php-phan: vendor-bin/phan/vendor
 	$(PHAN) --config-file .phan/config.php --require-config-exists
 
 .PHONY: test-php-phpstan
-test-php-phpstan:          ## Run phpstan
+test-php-phpstan: ## Run phpstan
 test-php-phpstan: vendor-bin/phpstan/vendor
 	$(PHPSTAN) analyse --memory-limit=4G --configuration=./phpstan.neon --no-progress --level=5 appinfo lib
 
 .PHONY: test-acceptance-api
-test-acceptance-api:       ## Run API acceptance tests
+test-acceptance-api: ## Run API acceptance tests
 test-acceptance-api:
 	../../tests/acceptance/run.sh --remote --type api
 
 .PHONY: test-acceptance-cli
-test-acceptance-cli:       ## Run CLI acceptance tests
+test-acceptance-cli: ## Run CLI acceptance tests
 test-acceptance-cli:
 	../../tests/acceptance/run.sh --remote --type cli
 
 .PHONY: test-acceptance-webui
-test-acceptance-webui:     ## Run webUI acceptance tests
+test-acceptance-webui: ## Run webUI acceptance tests
 test-acceptance-webui:
 	../../tests/acceptance/run.sh --remote --type webUI
 


### PR DESCRIPTION
When formatting the ``make help`` output:
- replace multiple spaces by a single space
- use the ``column`` command to line up the ``Makefile`` targets and descriptions into columns

At the moment we have to get the correct number of spaces in each ``test-xyz:        ## Description of command`` line.

After this change, we can put whatever spaces we like before and after the ``##`` and the ``make help`` still lines up.