### PR TITLE
[do not merge] Revert "Remove unneeded phpunit Makefile dependencies"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,12 +104,12 @@ clean: clean-deps clean-dist clean-build
 
 .PHONY: test-php-unit
 test-php-unit:             ## Run php unit tests
-test-php-unit:
+test-php-unit: vendor/bin/phpunit
 	$(PHPUNIT) --configuration ./phpunit.xml --testsuite unit
 
 .PHONY: test-php-unit-dbg
 test-php-unit-dbg:         ## Run php unit tests using phpdbg
-test-php-unit-dbg:
+test-php-unit-dbg: vendor/bin/phpunit
 	$(PHPUNITDBG) --configuration ./phpunit.xml --testsuite unit
 
 .PHONY: test-php-style
@@ -134,17 +134,17 @@ test-php-phpstan: vendor-bin/phpstan/vendor
 
 .PHONY: test-acceptance-api
 test-acceptance-api:       ## Run API acceptance tests
-test-acceptance-api:
+test-acceptance-api: vendor/bin/phpunit
 	../../tests/acceptance/run.sh --remote --type api
 
 .PHONY: test-acceptance-cli
 test-acceptance-cli:       ## Run CLI acceptance tests
-test-acceptance-cli:
+test-acceptance-cli: vendor/bin/phpunit
 	../../tests/acceptance/run.sh --remote --type cli
 
 .PHONY: test-acceptance-webui
 test-acceptance-webui:     ## Run webUI acceptance tests
-test-acceptance-webui:
+test-acceptance-webui: vendor/bin/phpunit
 	../../tests/acceptance/run.sh --remote --type webUI
 
 #
@@ -156,6 +156,9 @@ composer.lock: composer.json
 
 vendor: composer.lock
 	composer install --no-dev
+
+vendor/bin/phpunit: composer.lock
+	composer install
 
 vendor/bamarni/composer-bin-plugin: composer.lock
 	composer install


### PR DESCRIPTION
Reverts owncloud/password_policy#183

Just to see if this does any magic related to the 30-minute long-test fails.