### PR TITLE
Add OccUsersGroupsContext to behat.yml

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -47,6 +47,7 @@ default:
       contexts:
         - PasswordPolicyContext:
         - OccContext:
+        - OccUsersGroupsContext:
         - FeatureContext: *common_feature_context_params
 
     cliPasswordChange:
@@ -55,6 +56,7 @@ default:
       contexts:
         - PasswordPolicyContext:
         - OccContext:
+        - OccUsersGroupsContext:
         - FeatureContext: *common_feature_context_params
 
     webUIPasswordAddUser:


### PR DESCRIPTION
that was created recently in core
because some steps used by password_policy were moved into OccUsersGroupsContext