### PR TITLE
Add missing insulated disablePreviews tags to webUI feature files

### DIFF
--- a/tests/acceptance/features/webUIPasswordAddUser/addUserLowercaseLetters.feature
+++ b/tests/acceptance/features/webUIPasswordAddUser/addUserLowercaseLetters.feature
@@ -1,4 +1,4 @@
-@webUI @mailhog
+@webUI @insulated @disablePreviews @mailhog
 Feature: enforce the required number of lowercase letters in a password on user creation
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordAddUser/addUserMinimumLength.feature
+++ b/tests/acceptance/features/webUIPasswordAddUser/addUserMinimumLength.feature
@@ -1,4 +1,4 @@
-@webUI @mailhog
+@webUI @insulated @disablePreviews @mailhog
 Feature: enforce the minimum length of a password on user creation
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordAddUser/addUserNumbers.feature
+++ b/tests/acceptance/features/webUIPasswordAddUser/addUserNumbers.feature
@@ -1,4 +1,4 @@
-@webUI @mailhog
+@webUI @insulated @disablePreviews @mailhog
 Feature: enforce the required number of numbers in a password on user creation
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordAddUser/addUserRequirementCombinations.feature
+++ b/tests/acceptance/features/webUIPasswordAddUser/addUserRequirementCombinations.feature
@@ -1,4 +1,4 @@
-@webUI @mailhog
+@webUI @insulated @disablePreviews @mailhog
 Feature: enforce combinations of password policies on user creation
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordAddUser/addUserSpecialCharacters.feature
+++ b/tests/acceptance/features/webUIPasswordAddUser/addUserSpecialCharacters.feature
@@ -1,4 +1,4 @@
-@webUI @mailhog
+@webUI @insulated @disablePreviews @mailhog
 Feature: enforce the required number of special characters in a password on user creation
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordAddUser/addUserSpecialCharactersRestrictions.feature
+++ b/tests/acceptance/features/webUIPasswordAddUser/addUserSpecialCharactersRestrictions.feature
@@ -1,4 +1,4 @@
-@webUI @mailhog
+@webUI @insulated @disablePreviews @mailhog
 Feature: enforce the restricted special characters in a password on user creation
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordAddUser/addUserUppercaseLetters.feature
+++ b/tests/acceptance/features/webUIPasswordAddUser/addUserUppercaseLetters.feature
@@ -1,4 +1,4 @@
-@webUI @mailhog
+@webUI @insulated @disablePreviews @mailhog
 Feature: enforce the required number of uppercase letters in a password on user creation
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordChange/passwordChangeLastPasswords.feature
+++ b/tests/acceptance/features/webUIPasswordChange/passwordChangeLastPasswords.feature
@@ -1,4 +1,4 @@
-@webUI
+@webUI @insulated @disablePreviews
 Feature: enforce the number of last passwords that must not be used when resetting the password on the password change UI page
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordChange/passwordChangeLowercaseLetters.feature
+++ b/tests/acceptance/features/webUIPasswordChange/passwordChangeLowercaseLetters.feature
@@ -1,4 +1,4 @@
-@webUI
+@webUI @insulated @disablePreviews
 Feature: enforce the required number of lowercase letters in a password on the password change UI page
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordChange/passwordChangeMinimumLength.feature
+++ b/tests/acceptance/features/webUIPasswordChange/passwordChangeMinimumLength.feature
@@ -1,4 +1,4 @@
-@webUI
+@webUI @insulated @disablePreviews
 Feature: enforce the minimum length of a password on the password change UI page
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordChange/passwordChangeNumbers.feature
+++ b/tests/acceptance/features/webUIPasswordChange/passwordChangeNumbers.feature
@@ -1,4 +1,4 @@
-@webUI
+@webUI @insulated @disablePreviews
 Feature: enforce the required number of numbers in a password on the password change UI page
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordChange/passwordChangeRequirementCombinations.feature
+++ b/tests/acceptance/features/webUIPasswordChange/passwordChangeRequirementCombinations.feature
@@ -1,4 +1,4 @@
-@webUI
+@webUI @insulated @disablePreviews
 Feature: enforce combinations of password policies on the password change UI page
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordChange/passwordChangeSpecialCharacters.feature
+++ b/tests/acceptance/features/webUIPasswordChange/passwordChangeSpecialCharacters.feature
@@ -1,4 +1,4 @@
-@webUI
+@webUI @insulated @disablePreviews
 Feature: enforce the required number of special characters in a password on the password change UI page
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordChange/passwordChangeSpecialCharactersRestrictions.feature
+++ b/tests/acceptance/features/webUIPasswordChange/passwordChangeSpecialCharactersRestrictions.feature
@@ -1,4 +1,4 @@
-@webUI
+@webUI @insulated @disablePreviews
 Feature: enforce the restricted special characters in a password on the password change UI page
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordChange/passwordChangeUppercaseLetters.feature
+++ b/tests/acceptance/features/webUIPasswordChange/passwordChangeUppercaseLetters.feature
@@ -1,4 +1,4 @@
-@webUI
+@webUI @insulated @disablePreviews
 Feature: enforce the required number of uppercase letters in a password on the password change UI page
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordPolicySettings/disablePolicySettings.feature
+++ b/tests/acceptance/features/webUIPasswordPolicySettings/disablePolicySettings.feature
@@ -1,4 +1,4 @@
-@webUI
+@webUI @insulated @disablePreviews
 Feature: disable password policy settings
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordPolicySettings/enablePolicySettings.feature
+++ b/tests/acceptance/features/webUIPasswordPolicySettings/enablePolicySettings.feature
@@ -1,4 +1,4 @@
-@webUI
+@webUI @insulated @disablePreviews
 Feature: enable password policy settings
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordPolicySettings/setPolicySettings.feature
+++ b/tests/acceptance/features/webUIPasswordPolicySettings/setPolicySettings.feature
@@ -1,4 +1,4 @@
-@webUI
+@webUI @insulated @disablePreviews
 Feature: set password policy settings
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordReset/passwordResetLastPasswords.feature
+++ b/tests/acceptance/features/webUIPasswordReset/passwordResetLastPasswords.feature
@@ -1,4 +1,4 @@
-@webUI @mailhog
+@webUI @insulated @disablePreviews @mailhog
 Feature: enforce the number of last passwords that must not be used when resetting the password on the password reset UI page
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordReset/passwordResetLowercaseLetters.feature
+++ b/tests/acceptance/features/webUIPasswordReset/passwordResetLowercaseLetters.feature
@@ -1,4 +1,4 @@
-@webUI @mailhog
+@webUI @insulated @disablePreviews @mailhog
 Feature: enforce the required number of lowercase letters in a password on the password reset UI page
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordReset/passwordResetMinimumLength.feature
+++ b/tests/acceptance/features/webUIPasswordReset/passwordResetMinimumLength.feature
@@ -1,4 +1,4 @@
-@webUI @mailhog
+@webUI @insulated @disablePreviews @mailhog
 Feature: enforce the minimum length of a password on the password reset UI page
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordReset/passwordResetNumbers.feature
+++ b/tests/acceptance/features/webUIPasswordReset/passwordResetNumbers.feature
@@ -1,4 +1,4 @@
-@webUI @mailhog
+@webUI @insulated @disablePreviews @mailhog
 Feature: enforce the required number of numbers in a password on the password reset UI page
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordReset/passwordResetRequirementCombinations.feature
+++ b/tests/acceptance/features/webUIPasswordReset/passwordResetRequirementCombinations.feature
@@ -1,4 +1,4 @@
-@webUI @mailhog
+@webUI @insulated @disablePreviews @mailhog
 Feature: enforce combinations of password policies on the password reset UI page
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordReset/passwordResetSpecialCharacters.feature
+++ b/tests/acceptance/features/webUIPasswordReset/passwordResetSpecialCharacters.feature
@@ -1,4 +1,4 @@
-@webUI @mailhog
+@webUI @insulated @disablePreviews @mailhog
 Feature: enforce the required number of special characters in a password on the password reset UI page
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordReset/passwordResetSpecialCharactersRestriction.feature
+++ b/tests/acceptance/features/webUIPasswordReset/passwordResetSpecialCharactersRestriction.feature
@@ -1,4 +1,4 @@
-@webUI @mailhog
+@webUI @insulated @disablePreviews @mailhog
 Feature: enforce the restricted special characters in a password on the password reset UI page
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordReset/passwordResetUppercaseLetters.feature
+++ b/tests/acceptance/features/webUIPasswordReset/passwordResetUppercaseLetters.feature
@@ -1,4 +1,4 @@
-@webUI @mailhog
+@webUI @insulated @disablePreviews @mailhog
 Feature: enforce the required number of uppercase letters in a password on the password reset UI page
 
   As an administrator

--- a/tests/acceptance/features/webUIPublicShareLink/publicShareLinkLowercaseLetters.feature
+++ b/tests/acceptance/features/webUIPublicShareLink/publicShareLinkLowercaseLetters.feature
@@ -1,4 +1,4 @@
-@webUI
+@webUI @insulated @disablePreviews
 Feature: enforce the required number of lowercase letters in a password on the public share link page
 
   As an administrator

--- a/tests/acceptance/features/webUIPublicShareLink/publicShareLinkMinimumLength.feature
+++ b/tests/acceptance/features/webUIPublicShareLink/publicShareLinkMinimumLength.feature
@@ -1,4 +1,4 @@
-@webUI
+@webUI @insulated @disablePreviews
 Feature: enforce the minimum length of a password on the public share link page
 
   As an administrator

--- a/tests/acceptance/features/webUIPublicShareLink/publicShareLinkNumbers.feature
+++ b/tests/acceptance/features/webUIPublicShareLink/publicShareLinkNumbers.feature
@@ -1,4 +1,4 @@
-@webUI
+@webUI @insulated @disablePreviews
 Feature: enforce the required number of numbers in a password on the public share link page
 
   As an administrator

--- a/tests/acceptance/features/webUIPublicShareLink/publicShareLinkRequirementCombinations.feature
+++ b/tests/acceptance/features/webUIPublicShareLink/publicShareLinkRequirementCombinations.feature
@@ -1,4 +1,4 @@
-@webUI
+@webUI @insulated @disablePreviews
 Feature: enforce combinations of password policies on the public share link page
 
   As an administrator

--- a/tests/acceptance/features/webUIPublicShareLink/publicShareLinkSpecialCharacters.feature
+++ b/tests/acceptance/features/webUIPublicShareLink/publicShareLinkSpecialCharacters.feature
@@ -1,4 +1,4 @@
-@webUI
+@webUI @insulated @disablePreviews
 Feature: enforce the required number of special characters on the public share link page
 
   As an administrator

--- a/tests/acceptance/features/webUIPublicShareLink/publicShareLinkSpecialCharactersRestrictions.feature
+++ b/tests/acceptance/features/webUIPublicShareLink/publicShareLinkSpecialCharactersRestrictions.feature
@@ -1,4 +1,4 @@
-@webUI
+@webUI @insulated @disablePreviews
 Feature: enforce the restricted special characters in a password on the public share link page
 
   As an administrator

--- a/tests/acceptance/features/webUIPublicShareLink/publicShareLinkUppercaseLetters.feature
+++ b/tests/acceptance/features/webUIPublicShareLink/publicShareLinkUppercaseLetters.feature
@@ -1,4 +1,4 @@
-@webUI
+@webUI @insulated @disablePreviews
 Feature: enforce the required number of uppercase letters in a password on the public share link page
 
   As an administrator


### PR DESCRIPTION
Related to issue #209 

Sometimes elements are (sometimes) not clickable, not interactable... during test scenarios.

I managed to get this this type of issue locally once, but can't reproduce reliably.

Anyway, these extra tags should be on all webUI feature files:
`insulated` - behat-mink-selenium will restart the browser between each scenario - gives better isolation
`disablePreviews` - when not doing test that check for previews display, avoids the slowness of previews being constantly generated and slowly drawing up on the UI (not really relevant to these particular tests, but does reduce the "noise" as the test logs in and the files page is displayed)