### PR TITLE
PHPunit 5 to 6 preparation

### DIFF
--- a/tests/acceptance/features/bootstrap/PasswordPolicyContext.php
+++ b/tests/acceptance/features/bootstrap/PasswordPolicyContext.php
@@ -406,7 +406,7 @@ class PasswordPolicyContext implements Context {
 	public function theMinimumCharactersPasswordPolicyShouldBe(
 		$enabledOrDisabled
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$this->appSettingIsExpectedToBe($enabledOrDisabled),
 			$this->getPasswordPolicySetting(
 				'spv_min_chars_checked'
@@ -425,7 +425,7 @@ class PasswordPolicyContext implements Context {
 	public function theMinimumCharactersShouldBeSetTo(
 		$value
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$value,
 			$this->getPasswordPolicySetting(
 				'spv_min_chars_value'
@@ -444,7 +444,7 @@ class PasswordPolicyContext implements Context {
 	public function theLowercaseLettersPasswordPolicyShouldBe(
 		$enabledOrDisabled
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$this->appSettingIsExpectedToBe($enabledOrDisabled),
 			$this->getPasswordPolicySetting(
 				'spv_lowercase_checked'
@@ -463,7 +463,7 @@ class PasswordPolicyContext implements Context {
 	public function theLowercaseLettersShouldBeSetTo(
 		$value
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$value,
 			$this->getPasswordPolicySetting(
 				'spv_lowercase_value'
@@ -482,7 +482,7 @@ class PasswordPolicyContext implements Context {
 	public function theUppercaseLettersPasswordPolicyShouldBe(
 		$enabledOrDisabled
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$this->appSettingIsExpectedToBe($enabledOrDisabled),
 			$this->getPasswordPolicySetting(
 				'spv_uppercase_checked'
@@ -501,7 +501,7 @@ class PasswordPolicyContext implements Context {
 	public function theUppercaseLettersShouldBeSetTo(
 		$value
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$value,
 			$this->getPasswordPolicySetting(
 				'spv_uppercase_value'
@@ -520,7 +520,7 @@ class PasswordPolicyContext implements Context {
 	public function theNumbersPasswordPolicyShouldBe(
 		$enabledOrDisabled
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$this->appSettingIsExpectedToBe($enabledOrDisabled),
 			$this->getPasswordPolicySetting(
 				'spv_numbers_checked'
@@ -539,7 +539,7 @@ class PasswordPolicyContext implements Context {
 	public function theNumbersShouldBeSetTo(
 		$value
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$value,
 			$this->getPasswordPolicySetting(
 				'spv_numbers_value'
@@ -558,7 +558,7 @@ class PasswordPolicyContext implements Context {
 	public function theSpecialCharactersPasswordPolicyShouldBe(
 		$enabledOrDisabled
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$this->appSettingIsExpectedToBe($enabledOrDisabled),
 			$this->getPasswordPolicySetting(
 				'spv_special_chars_checked'
@@ -577,7 +577,7 @@ class PasswordPolicyContext implements Context {
 	public function theSpecialCharactersShouldBeSetTo(
 		$value
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$value,
 			$this->getPasswordPolicySetting(
 				'spv_special_chars_value'
@@ -596,7 +596,7 @@ class PasswordPolicyContext implements Context {
 	public function theRestrictSpecialCharactersPasswordPolicyShouldBe(
 		$enabledOrDisabled
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$this->appSettingIsExpectedToBe($enabledOrDisabled),
 			$this->getPasswordPolicySetting(
 				'spv_def_special_chars_checked'
@@ -615,7 +615,7 @@ class PasswordPolicyContext implements Context {
 	public function restrictSpecialCharactersShouldBeSetTo(
 		$value
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$value,
 			$this->getPasswordPolicySetting(
 				'spv_def_special_chars_value'
@@ -634,7 +634,7 @@ class PasswordPolicyContext implements Context {
 	public function theLastPasswordsPasswordPolicyShouldBe(
 		$enabledOrDisabled
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$this->appSettingIsExpectedToBe($enabledOrDisabled),
 			$this->getPasswordPolicySetting(
 				'spv_password_history_checked'
@@ -653,7 +653,7 @@ class PasswordPolicyContext implements Context {
 	public function theLastPasswordsShouldBeSetTo(
 		$value
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$value,
 			$this->getPasswordPolicySetting(
 				'spv_password_history_value'
@@ -672,7 +672,7 @@ class PasswordPolicyContext implements Context {
 	public function theDaysUntilUserPasswordExpiresPasswordPolicyShouldBe(
 		$enabledOrDisabled
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$this->appSettingIsExpectedToBe($enabledOrDisabled),
 			$this->getPasswordPolicySetting(
 				'spv_user_password_expiration_checked'
@@ -691,7 +691,7 @@ class PasswordPolicyContext implements Context {
 	public function theDaysUntilUserPasswordExpiresShouldBeSetTo(
 		$value
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$value,
 			$this->getPasswordPolicySetting(
 				'spv_user_password_expiration_value'
@@ -710,7 +710,7 @@ class PasswordPolicyContext implements Context {
 	public function theNotificationDaysBeforeUserPasswordExpiresPasswordPolicyShouldBe(
 		$enabledOrDisabled
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$this->appSettingIsExpectedToBe($enabledOrDisabled),
 			$this->getPasswordPolicySetting(
 				'spv_user_password_expiration_notification_checked'
@@ -729,7 +729,7 @@ class PasswordPolicyContext implements Context {
 	public function theNotificationSecondsBeforeUserPasswordExpiresShouldBeSetTo(
 		$value
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$value,
 			$this->getPasswordPolicySetting(
 				'spv_user_password_expiration_notification_value'
@@ -748,7 +748,7 @@ class PasswordPolicyContext implements Context {
 	public function theForcePasswordChangeOnFirstLoginPasswordPolicyShouldBe(
 		$enabledOrDisabled
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$this->appSettingIsExpectedToBe($enabledOrDisabled),
 			$this->getPasswordPolicySetting(
 				'spv_user_password_force_change_on_first_login_checked'
@@ -767,7 +767,7 @@ class PasswordPolicyContext implements Context {
 	public function theDaysUntilLinkExpiresWithPasswordPasswordPolicyShouldBe(
 		$enabledOrDisabled
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$this->appSettingIsExpectedToBe($enabledOrDisabled),
 			$this->getPasswordPolicySetting(
 				'spv_expiration_password_checked'
@@ -786,7 +786,7 @@ class PasswordPolicyContext implements Context {
 	public function theDaysUntilLinkExpiresWithPasswordShouldBeSetTo(
 		$value
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$value,
 			$this->getPasswordPolicySetting(
 				'spv_expiration_password_value'
@@ -805,7 +805,7 @@ class PasswordPolicyContext implements Context {
 	public function theDaysUntilLinkExpiresWithoutPasswordPasswordPolicyShouldBe(
 		$enabledOrDisabled
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$this->appSettingIsExpectedToBe($enabledOrDisabled),
 			$this->getPasswordPolicySetting(
 				'spv_expiration_nopassword_checked'
@@ -824,7 +824,7 @@ class PasswordPolicyContext implements Context {
 	public function theDaysUntilLinkExpiresWithoutPasswordShouldBeSetTo(
 		$value
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$value,
 			$this->getPasswordPolicySetting(
 				'spv_expiration_nopassword_value'

--- a/tests/acceptance/features/bootstrap/WebUIPasswordPolicyContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPasswordPolicyContext.php
@@ -504,7 +504,7 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	public function theMinimumCharactersCheckboxShouldBeOnTheWebui(
 		$checkedOrUnchecked
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$this->isExpectedToBeChecked($checkedOrUnchecked),
 			$this->passwordPolicySettingsPage->isPolicyCheckboxChecked(
 				'minimumCharacters'
@@ -523,7 +523,7 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	public function theMinimumCharactersShouldBeSetToOnTheWebui(
 		$value
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$value,
 			$this->passwordPolicySettingsPage->getPolicyValue(
 				'minimumCharacters'
@@ -542,7 +542,7 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	public function theLowercaseLettersCheckboxShouldBeOnTheWebui(
 		$checkedOrUnchecked
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$this->isExpectedToBeChecked($checkedOrUnchecked),
 			$this->passwordPolicySettingsPage->isPolicyCheckboxChecked(
 				'lowercaseLetters'
@@ -561,7 +561,7 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	public function theLowercaseLettersShouldBeSetToOnTheWebui(
 		$value
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$value,
 			$this->passwordPolicySettingsPage->getPolicyValue(
 				'lowercaseLetters'
@@ -580,7 +580,7 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	public function theUppercaseLettersCheckboxShouldBeOnTheWebui(
 		$checkedOrUnchecked
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$this->isExpectedToBeChecked($checkedOrUnchecked),
 			$this->passwordPolicySettingsPage->isPolicyCheckboxChecked(
 				'uppercaseLetters'
@@ -599,7 +599,7 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	public function theUppercaseLettersShouldBeSetToOnTheWebui(
 		$value
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$value,
 			$this->passwordPolicySettingsPage->getPolicyValue(
 				'uppercaseLetters'
@@ -616,7 +616,7 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	 * @throws Exception
 	 */
 	public function theNumbersCheckboxShouldBeOnTheWebui($checkedOrUnchecked) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$this->isExpectedToBeChecked($checkedOrUnchecked),
 			$this->passwordPolicySettingsPage->isPolicyCheckboxChecked(
 				'numbers'
@@ -635,7 +635,7 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	public function theNumbersShouldBeSetToOnTheWebui(
 		$value
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$value,
 			$this->passwordPolicySettingsPage->getPolicyValue(
 				'numbers'
@@ -654,7 +654,7 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	public function theSpecialCharactersCheckboxShouldBeOnTheWebui(
 		$checkedOrUnchecked
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$this->isExpectedToBeChecked($checkedOrUnchecked),
 			$this->passwordPolicySettingsPage->isPolicyCheckboxChecked(
 				'specialCharacters'
@@ -673,7 +673,7 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	public function theSpecialCharactersShouldBeSetToOnTheWebui(
 		$value
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$value,
 			$this->passwordPolicySettingsPage->getPolicyValue(
 				'specialCharacters'
@@ -692,7 +692,7 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	public function theRestrictSpecialCharactersCheckboxShouldBeOnTheWebui(
 		$checkedOrUnchecked
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$this->isExpectedToBeChecked($checkedOrUnchecked),
 			$this->passwordPolicySettingsPage->isPolicyCheckboxChecked(
 				'restrictToTheseSpecialCharacters'
@@ -711,7 +711,7 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	public function restrictSpecialCharactersShouldBeSetToOnTheWebui(
 		$value
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$value,
 			$this->passwordPolicySettingsPage->getPolicyValue(
 				'restrictToTheseSpecialCharacters'
@@ -730,7 +730,7 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	public function theLastPasswordsCheckboxShouldBeOnTheWebui(
 		$checkedOrUnchecked
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$this->isExpectedToBeChecked($checkedOrUnchecked),
 			$this->passwordPolicySettingsPage->isPolicyCheckboxChecked(
 				'lastPasswords'
@@ -749,7 +749,7 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	public function lastPasswordsShouldBeSetToOnTheWebui(
 		$value
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$value,
 			$this->passwordPolicySettingsPage->getPolicyValue(
 				'lastPasswords'
@@ -768,7 +768,7 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	public function theDaysUntilUserPasswordExpiresCheckboxShouldBeOnTheWebui(
 		$checkedOrUnchecked
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$this->isExpectedToBeChecked($checkedOrUnchecked),
 			$this->passwordPolicySettingsPage->isPolicyCheckboxChecked(
 				'daysUntilUserPasswordExpires'
@@ -787,7 +787,7 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	public function theDaysUntilUserPasswordExpiresShouldBeSetToOnTheWebui(
 		$value
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$value,
 			$this->passwordPolicySettingsPage->getPolicyValue(
 				'daysUntilUserPasswordExpires'
@@ -806,7 +806,7 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	public function theNotificationDaysBeforeUserPasswordExpiresCheckboxShouldBeOnTheWebui(
 		$checkedOrUnchecked
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$this->isExpectedToBeChecked($checkedOrUnchecked),
 			$this->passwordPolicySettingsPage->isPolicyCheckboxChecked(
 				'notificationDaysBeforeUserPasswordExpires'
@@ -825,7 +825,7 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	public function theNotificationDaysBeforeUserPasswordExpiresShouldBeSetToOnTheWebui(
 		$value
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$value,
 			$this->passwordPolicySettingsPage->getPolicyValue(
 				'notificationDaysBeforeUserPasswordExpires'
@@ -844,7 +844,7 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	public function theForcePasswordChangeOnFirstLoginCheckboxShouldBeOnTheWebui(
 		$checkedOrUnchecked
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$this->isExpectedToBeChecked($checkedOrUnchecked),
 			$this->passwordPolicySettingsPage->isPolicyCheckboxChecked(
 				'forcePasswordChangeOnFirstLogin'
@@ -863,7 +863,7 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	public function theDaysUntilLinkExpiresWithPasswordCheckboxShouldBeOnTheWebui(
 		$checkedOrUnchecked
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$this->isExpectedToBeChecked($checkedOrUnchecked),
 			$this->passwordPolicySettingsPage->isPolicyCheckboxChecked(
 				'daysUntilLinkExpiresWithPassword'
@@ -882,7 +882,7 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	public function theDaysUntilLinkExpiresWithPasswordShouldBeSetToOnTheWebui(
 		$value
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$value,
 			$this->passwordPolicySettingsPage->getPolicyValue(
 				'daysUntilLinkExpiresWithPassword'
@@ -901,7 +901,7 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	public function theDaysUntilLinkExpiresWithoutPasswordCheckboxShouldBeOnTheWebui(
 		$checkedOrUnchecked
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$this->isExpectedToBeChecked($checkedOrUnchecked),
 			$this->passwordPolicySettingsPage->isPolicyCheckboxChecked(
 				'daysUntilLinkExpiresWithoutPassword'
@@ -920,7 +920,7 @@ class WebUIPasswordPolicyContext extends RawMinkContext implements Context {
 	public function theDaysUntilLinkExpiresWithoutPasswordShouldBeSetToOnTheWebui(
 		$value
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$value,
 			$this->passwordPolicySettingsPage->getPolicyValue(
 				'daysUntilLinkExpiresWithoutPassword'

--- a/tests/unit/Command/ExpirePasswordTest.php
+++ b/tests/unit/Command/ExpirePasswordTest.php
@@ -35,14 +35,14 @@ use OCP\AppFramework\Utility\ITimeFactory;
 
 class ExpirePasswordTest extends TestCase {
 
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
-	/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject */
 	protected $userManager;
 	protected $groupManager;
-	/** @var ITimeFactory | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ITimeFactory | \PHPUnit\Framework\MockObject\MockObject */
 	private $timeFactory;
-	/** @var OldPasswordMapper | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var OldPasswordMapper | \PHPUnit\Framework\MockObject\MockObject */
 	private $mapper;
 	/** @var CommandTester */
 	private $commandTester;

--- a/tests/unit/Controller/PasswordControllerTest.php
+++ b/tests/unit/Controller/PasswordControllerTest.php
@@ -39,21 +39,21 @@ use Test\TestCase;
 
 class PasswordControllerTest extends TestCase {
 
-	/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject */
 	protected $request;
-	/** @var IUserSession | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserSession | \PHPUnit\Framework\MockObject\MockObject */
 	protected $userSession;
-	/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject */
 	protected $userManager;
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
-	/** @var ISession | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ISession | \PHPUnit\Framework\MockObject\MockObject */
 	protected $session;
-	/** @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IURLGenerator | \PHPUnit\Framework\MockObject\MockObject */
 	protected $urlGenerator;
-	/** @var IL10N | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IL10N | \PHPUnit\Framework\MockObject\MockObject */
 	protected $l10n;
-	/** @var PasswordController | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var PasswordController | \PHPUnit\Framework\MockObject\MockObject */
 	private $c;
 
 	public function setUp() {

--- a/tests/unit/EngineTest.php
+++ b/tests/unit/EngineTest.php
@@ -48,13 +48,13 @@ class EngineTest extends TestCase {
 		'spv_password_history_value' => 3,
 	];
 
-	/** @var IL10N | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IL10N | \PHPUnit\Framework\MockObject\MockObject */
 	protected $l10n;
-	/** @var ISecureRandom | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ISecureRandom | \PHPUnit\Framework\MockObject\MockObject */
 	protected $random;
-	/** @var IDBConnection | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IDBConnection | \PHPUnit\Framework\MockObject\MockObject */
 	protected $db;
-	/** @var IHasher | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IHasher | \PHPUnit\Framework\MockObject\MockObject */
 	protected $hasher;
 
 	protected function setUp() {

--- a/tests/unit/EngineTest.php
+++ b/tests/unit/EngineTest.php
@@ -96,7 +96,7 @@ class EngineTest extends TestCase {
 	 */
 	public function testPolicyPasses(array $config, $password) {
 		$engine = $this->createEngine($config);
-		$engine->verifyPassword($password);
+		$this->assertNull($engine->verifyPassword($password));
 	}
 
 	/**
@@ -134,7 +134,7 @@ class EngineTest extends TestCase {
 	 */
 	public function testPolicyPassesEmptyPasswordTypePublic() {
 		$engine = $this->createEngine(['spv_min_chars_checked' => true]);
-		$engine->verifyPassword('', null, 'public');
+		$this->assertNull($engine->verifyPassword('', null, 'public'));
 	}
 
 	/**
@@ -155,7 +155,7 @@ class EngineTest extends TestCase {
 	public function testPasswordGeneration(array $config) {
 		$engine = $this->createEngine($config);
 		$password = $engine->generatePassword();
-		$engine->verifyPassword($password);
+		$this->assertNull($engine->verifyPassword($password));
 	}
 
 	public function providesTestData() {

--- a/tests/unit/HooksHandlerTest.php
+++ b/tests/unit/HooksHandlerTest.php
@@ -42,27 +42,27 @@ use Test\TestCase;
 
 class HooksHandlerTest extends TestCase {
 
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
-	/** @var Engine | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Engine | \PHPUnit\Framework\MockObject\MockObject */
 	protected $engine;
-	/** @var IHasher | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IHasher | \PHPUnit\Framework\MockObject\MockObject */
 	protected $hasher;
-	/** @var ITimeFactory | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ITimeFactory | \PHPUnit\Framework\MockObject\MockObject */
 	protected $timeFactory;
-	/** @var IL10N | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IL10N | \PHPUnit\Framework\MockObject\MockObject */
 	protected $l10n;
-	/** @var PasswordExpired | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var PasswordExpired | \PHPUnit\Framework\MockObject\MockObject */
 	protected $passwordExpiredRule;
-	/** @var OldPasswordMapper | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var OldPasswordMapper | \PHPUnit\Framework\MockObject\MockObject */
 	protected $oldPasswordMapper;
-	/** @var ISession | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ISession | \PHPUnit\Framework\MockObject\MockObject */
 	protected $session;
-	/** @var HooksHandler | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var HooksHandler | \PHPUnit\Framework\MockObject\MockObject */
 	protected $handler;
-	/** @var UserNotificationConfigHandler | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var UserNotificationConfigHandler | \PHPUnit\Framework\MockObject\MockObject */
 	protected $unConfigHandler;
-	/** @var IManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IManager | \PHPUnit\Framework\MockObject\MockObject */
 	protected $manager;
 
 	protected function setUp() {
@@ -212,7 +212,7 @@ class HooksHandlerTest extends TestCase {
 	}
 
 	public function testSaveOldPassword() {
-		/** @var IUser | \PHPUnit_Framework_MockObject_MockObject $user */
+		/** @var IUser | \PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('testuid');
 
@@ -269,7 +269,7 @@ class HooksHandlerTest extends TestCase {
 	}
 
 	public function testSaveOldPasswordClearingNotifications() {
-		/** @var IUser | \PHPUnit_Framework_MockObject_MockObject $user */
+		/** @var IUser | \PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('testuid');
 
@@ -338,7 +338,7 @@ class HooksHandlerTest extends TestCase {
 	}
 
 	public function testCheckPasswordExpired() {
-		/** @var IUser | \PHPUnit_Framework_MockObject_MockObject $user */
+		/** @var IUser | \PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('testuid');
 		$this->engine->expects($this->once())
@@ -378,7 +378,7 @@ class HooksHandlerTest extends TestCase {
 	 * @param $time
 	 */
 	public function testCheckAdminRequestedPasswordChange($expired, $time) {
-		/** @var IUser | \PHPUnit_Framework_MockObject_MockObject $user */
+		/** @var IUser | \PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('testuid');
 		$this->config->expects($this->once())
@@ -409,7 +409,7 @@ class HooksHandlerTest extends TestCase {
 	}
 
 	public function testCheckForcePasswordChangeOnFirstLogin() {
-		/** @var IUser | \PHPUnit_Framework_MockObject_MockObject $user */
+		/** @var IUser | \PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$user->method('getBackendClassName')
 			->willReturn('Database');
@@ -432,7 +432,7 @@ class HooksHandlerTest extends TestCase {
 	}
 
 	public function testCheckLDAPUserForcePasswordChangeOnFirstLogin() {
-		/** @var IUser | \PHPUnit_Framework_MockObject_MockObject $user */
+		/** @var IUser | \PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$user->method('getBackendClassName')
 			->willReturn('LDAP');
@@ -465,7 +465,7 @@ class HooksHandlerTest extends TestCase {
 	}
 
 	public function testForcePasswordChangeOnFirstLoginNotHappen() {
-		/** @var IUser | \PHPUnit_Framework_MockObject_MockObject $user */
+		/** @var IUser | \PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$this->engine->expects($this->once())
 			->method('yes')

--- a/tests/unit/Rules/LengthTest.php
+++ b/tests/unit/Rules/LengthTest.php
@@ -58,7 +58,7 @@ class LengthTest extends TestCase {
 	 * @throws PolicyException
 	 */
 	public function testOkay() {
-		$this->r->verify('1234567890', 6);
+		$this->assertNull($this->r->verify('1234567890', 6));
 	}
 
 	/**
@@ -73,6 +73,6 @@ class LengthTest extends TestCase {
 	 * @throws PolicyException
 	 */
 	public function testSpecialCharsOkay() {
-		$this->r->verify('çççççç', 5);
+		$this->assertNull($this->r->verify('çççççç', 5));
 	}
 }

--- a/tests/unit/Rules/LengthTest.php
+++ b/tests/unit/Rules/LengthTest.php
@@ -35,7 +35,7 @@ class LengthTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		/** @var IL10N | \PHPUnit_Framework_MockObject_MockObject $l10n */
+		/** @var IL10N | \PHPUnit\Framework\MockObject\MockObject $l10n */
 		$l10n = $this->createMock(IL10N::class);
 		$l10n
 			->method('t')

--- a/tests/unit/Rules/LowercaseTest.php
+++ b/tests/unit/Rules/LowercaseTest.php
@@ -74,7 +74,7 @@ class LowercaseTest extends TestCase {
 	 * @throws \OCA\PasswordPolicy\Rules\PolicyException
 	 */
 	public function testOkay() {
-		$this->r->verify('abcfwaA12345', 6);
+		$this->assertNull($this->r->verify('abcfwaA12345', 6));
 	}
 
 	/**
@@ -89,7 +89,7 @@ class LowercaseTest extends TestCase {
 	 * @throws \OCA\PasswordPolicy\Rules\PolicyException
 	 */
 	public function testSpecialLowerCaseOkay() {
-		$this->r->verify('ÑñÑñÑñÑñÑñ', 5);
+		$this->assertNull($this->r->verify('ÑñÑñÑñÑñÑñ', 5));
 	}
 
 	/**

--- a/tests/unit/Rules/LowercaseTest.php
+++ b/tests/unit/Rules/LowercaseTest.php
@@ -34,7 +34,7 @@ class LowercaseTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		/** @var IL10N | \PHPUnit_Framework_MockObject_MockObject $l10n */
+		/** @var IL10N | \PHPUnit\Framework\MockObject\MockObject $l10n */
 		$l10n = $this->createMock(IL10N::class);
 		$l10n
 			->method('t')

--- a/tests/unit/Rules/NumbersTest.php
+++ b/tests/unit/Rules/NumbersTest.php
@@ -73,6 +73,6 @@ class NumbersTest extends \Test\TestCase {
 	 * @throws \OCA\PasswordPolicy\Rules\PolicyException
 	 */
 	public function testOkay() {
-		$this->r->verify('1234567890', 6);
+		$this->assertNull($this->r->verify('1234567890', 6));
 	}
 }

--- a/tests/unit/Rules/NumbersTest.php
+++ b/tests/unit/Rules/NumbersTest.php
@@ -33,7 +33,7 @@ class NumbersTest extends \Test\TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		/** @var IL10N | \PHPUnit_Framework_MockObject_MockObject $l10n */
+		/** @var IL10N | \PHPUnit\Framework\MockObject\MockObject $l10n */
 		$l10n = $this->createMock(IL10N::class);
 		$l10n
 			->method('t')

--- a/tests/unit/Rules/PasswordExpiredTest.php
+++ b/tests/unit/Rules/PasswordExpiredTest.php
@@ -33,13 +33,13 @@ use Test\TestCase;
 
 class PasswordExpiredTest extends TestCase {
 
-	/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ILogger | \PHPUnit\Framework\MockObject\MockObject */
 	protected $logger;
-	/** @var OldPasswordMapper | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var OldPasswordMapper | \PHPUnit\Framework\MockObject\MockObject */
 	protected $mapper;
-	/** @var IHasher | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IHasher | \PHPUnit\Framework\MockObject\MockObject */
 	protected $hasher;
-	/** @var ITimeFactory | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ITimeFactory | \PHPUnit\Framework\MockObject\MockObject */
 	protected $timeFactory;
 	/** @var PasswordExpired */
 	private $r;
@@ -47,7 +47,7 @@ class PasswordExpiredTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		/** @var IL10N | \PHPUnit_Framework_MockObject_MockObject $l10n */
+		/** @var IL10N | \PHPUnit\Framework\MockObject\MockObject $l10n */
 		$l10n = $this->createMock(IL10N::class);
 		$l10n
 			->method('t')

--- a/tests/unit/Rules/PasswordHistoryTest.php
+++ b/tests/unit/Rules/PasswordHistoryTest.php
@@ -90,6 +90,6 @@ class PasswordHistoryTest extends \PHPUnit\Framework\TestCase {
 	 * @throws \OCA\PasswordPolicy\Rules\PolicyException
 	 */
 	public function testSuccess() {
-		$this->r->verify('testpass3', 2, 'testuser');
+		$this->assertNull($this->r->verify('testpass3', 2, 'testuser'));
 	}
 }

--- a/tests/unit/Rules/PasswordHistoryTest.php
+++ b/tests/unit/Rules/PasswordHistoryTest.php
@@ -27,7 +27,7 @@ use OCA\PasswordPolicy\Db\OldPasswordMapper;
 use OCA\PasswordPolicy\Db\OldPassword;
 use OCP\IL10N;
 
-class PasswordHistoryTest extends \PHPUnit_Framework_TestCase {
+class PasswordHistoryTest extends \PHPUnit\Framework\TestCase {
 
 	/** @var PasswordHistory */
 	private $r;
@@ -35,7 +35,7 @@ class PasswordHistoryTest extends \PHPUnit_Framework_TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		/** @var IL10N | \PHPUnit_Framework_MockObject_MockObject $l10n */
+		/** @var IL10N | \PHPUnit\Framework\MockObject\MockObject $l10n */
 		$l10n = $this->createMock(IL10N::class);
 		$l10n
 			->method('t')
@@ -43,13 +43,13 @@ class PasswordHistoryTest extends \PHPUnit_Framework_TestCase {
 				return \vsprintf($text, $parameters);
 			}));
 
-		/** @var \OCA\PasswordPolicy\Db\OldPasswordMapper | \PHPUnit_Framework_MockObject_MockObject $mapper */
+		/** @var \OCA\PasswordPolicy\Db\OldPasswordMapper | \PHPUnit\Framework\MockObject\MockObject $mapper */
 		$mapper = $this->getMockBuilder(OldPasswordMapper::class)
 			->disableOriginalConstructor()->getMock();
-		/** @var \OCA\PasswordPolicy\Db\OldPassword | \PHPUnit_Framework_MockObject_MockObject $entity1 */
+		/** @var \OCA\PasswordPolicy\Db\OldPassword | \PHPUnit\Framework\MockObject\MockObject $entity1 */
 		$entity1 = $this->getMockBuilder(OldPassword::class)
 			->disableOriginalConstructor()->getMock();
-		/** @var \OCA\PasswordPolicy\Db\OldPassword | \PHPUnit_Framework_MockObject_MockObject $entity2 */
+		/** @var \OCA\PasswordPolicy\Db\OldPassword | \PHPUnit\Framework\MockObject\MockObject $entity2 */
 		$entity2 = $this->getMockBuilder(OldPassword::class)
 			->disableOriginalConstructor()->getMock();
 

--- a/tests/unit/Rules/SpecialTest.php
+++ b/tests/unit/Rules/SpecialTest.php
@@ -26,7 +26,7 @@ use OCA\PasswordPolicy\Rules\PolicyException;
 use OCA\PasswordPolicy\Rules\Special;
 use OCP\IL10N;
 
-class SpecialTest extends \PHPUnit_Framework_TestCase {
+class SpecialTest extends \PHPUnit\Framework\TestCase {
 
 	/** @var Special */
 	private $r;
@@ -34,7 +34,7 @@ class SpecialTest extends \PHPUnit_Framework_TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		/** @var IL10N | \PHPUnit_Framework_MockObject_MockObject $l10n */
+		/** @var IL10N | \PHPUnit\Framework\MockObject\MockObject $l10n */
 		$l10n = $this->createMock(IL10N::class);
 		$l10n
 			->method('t')

--- a/tests/unit/Rules/SpecialTest.php
+++ b/tests/unit/Rules/SpecialTest.php
@@ -70,7 +70,7 @@ class SpecialTest extends \PHPUnit\Framework\TestCase {
 	 * @throws PolicyException
 	 */
 	public function testOkay($password, $val, $allowedSpecialChars) {
-		$this->r->verify($password, $val, $allowedSpecialChars);
+		$this->assertNull($this->r->verify($password, $val, $allowedSpecialChars));
 	}
 
 	/**

--- a/tests/unit/Rules/UppercaseTest.php
+++ b/tests/unit/Rules/UppercaseTest.php
@@ -34,7 +34,7 @@ class UppercaseTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		/** @var IL10N | \PHPUnit_Framework_MockObject_MockObject $l10n */
+		/** @var IL10N | \PHPUnit\Framework\MockObject\MockObject $l10n */
 		$l10n = $this->createMock(IL10N::class);
 		$l10n
 			->method('t')

--- a/tests/unit/Rules/UppercaseTest.php
+++ b/tests/unit/Rules/UppercaseTest.php
@@ -74,7 +74,7 @@ class UppercaseTest extends TestCase {
 	 * @throws \OCA\PasswordPolicy\Rules\PolicyException
 	 */
 	public function testOkay() {
-		$this->r->verify('ABCFWA12345', 6);
+		$this->assertNull($this->r->verify('ABCFWA12345', 6));
 	}
 
 	/**
@@ -89,7 +89,7 @@ class UppercaseTest extends TestCase {
 	 * @throws \OCA\PasswordPolicy\Rules\PolicyException
 	 */
 	public function testSpecialUpperCaseOkay() {
-		$this->r->verify('ÑñÑñÑñÑñÑñ', 5);
+		$this->assertNull($this->r->verify('ÑñÑñÑñÑñÑñ', 5));
 	}
 
 	/**

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -25,8 +25,4 @@ require_once __DIR__ . '/../../../../lib/base.php';
 
 OC::$composerAutoloader->addPsr4('Test\\', OC::$SERVERROOT . '/tests/lib', true);
 
-if (!\class_exists('PHPUnit\Framework\TestCase')) {
-	require_once('PHPUnit/Autoload.php');
-}
-
 OC_Hook::clear();

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -25,7 +25,7 @@ require_once __DIR__ . '/../../../../lib/base.php';
 
 OC::$composerAutoloader->addPsr4('Test\\', OC::$SERVERROOT . '/tests/lib', true);
 
-if (!\class_exists('PHPUnit_Framework_TestCase')) {
+if (!\class_exists('PHPUnit\Framework\TestCase')) {
 	require_once('PHPUnit/Autoload.php');
 }
 


### PR DESCRIPTION
1) Adjust PHPUnit_Framework references
2) Remove outdated PHPUnit/Autoload.php
3) Adjust tests reported as "risky" so that they make assertions.

This works fine on PHPUnit5 (CI passing here) and on PHPUnit6 (demonstrated by PR #215 )