### PR TITLE
Cast times to int (phan warning)

### DIFF
--- a/lib/Notifier.php
+++ b/lib/Notifier.php
@@ -71,8 +71,8 @@ class Notifier implements INotifier {
 		$messageParams = $notification->getMessageParameters();
 		$currentTime = $this->timeFactory->getTime();
 		$currentDateTime = new \DateTime("@{$currentTime}");
-		$passwordTime = $messageParams[0];
-		$expirationTime = $messageParams[1];
+		$passwordTime = (int) $messageParams[0];
+		$expirationTime = (int) $messageParams[1];
 		$targetExpirationTime = $passwordTime + $expirationTime;
 		$expirationDateTime = new \DateTime("@{$targetExpirationTime}");
 		$interval = $currentDateTime->diff($expirationDateTime);

--- a/lib/Notifier.php
+++ b/lib/Notifier.php
@@ -71,6 +71,10 @@ class Notifier implements INotifier {
 		$messageParams = $notification->getMessageParameters();
 		$currentTime = $this->timeFactory->getTime();
 		$currentDateTime = new \DateTime("@{$currentTime}");
+		// getMessageParameters() returns strings. In this case the strings are
+		// decimal integers representing the time (in seconds) when the password
+		// was last set, and the number of seconds after which the password expires.
+		// Add them as integers.
 		$passwordTime = (int) $messageParams[0];
 		$expirationTime = (int) $messageParams[1];
 		$targetExpirationTime = $passwordTime + $expirationTime;


### PR DESCRIPTION
phan 1.3.0 started warning:
https://github.com/phan/phan/issues/2656
https://drone.owncloud.com/owncloud/password_policy/605/82
```
lib/Notifier.php:76 PhanTypeInvalidLeftOperandOfAdd Invalid operator: left operand of + is string (expected array or number)
lib/Notifier.php:76 PhanTypeInvalidRightOperandOfAdd Invalid operator: right operand of + is string (expected array or number)
Makefile:134: recipe for target 'test-php-phan' failed
make: *** [test-php-phan] Error 1
```

According to our PHPdoc `$notification->getMessageParameters()` returns an array of strings. We are taking elements from the array and adding them together as integers to calculate the expiration time (in integer seconds). So cast to `int` before adding.