### PR TITLE
Adjust cli tests to no longer expect text in stderr

### DIFF
--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserLowercaseLetters.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserLowercaseLetters.feature
@@ -28,7 +28,7 @@ Feature: enforce the required number of lowercase letters in a password when cre
       | user1    | <password> |
     Then the command should have failed with exit code 1
     # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
-    And the command error output should contain the text 'The password contains too few lowercase letters. At least 3 lowercase'
+    And the command output should contain the text 'The password contains too few lowercase letters. At least 3 lowercase'
     And user "user1" should not exist
     Examples:
       | password   |

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserMinimumLength.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserMinimumLength.feature
@@ -27,7 +27,7 @@ Feature: enforce the minimum length of a password when creating a user
       | username | password   |
       | user1    | <password> |
     Then the command should have failed with exit code 1
-    And the command error output should contain the text 'The password is too short. At least 10 characters are required.'
+    And the command output should contain the text 'The password is too short. At least 10 characters are required.'
     And user "user1" should not exist
     Examples:
       | password  |

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserNumbers.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserNumbers.feature
@@ -27,7 +27,7 @@ Feature: enforce the required number of numbers in a password when creating a us
       | username | password   |
       | user1    | <password> |
     Then the command should have failed with exit code 1
-    And the command error output should contain the text 'The password contains too few numbers. At least 3 numbers are required.'
+    And the command output should contain the text 'The password contains too few numbers. At least 3 numbers are required.'
     And user "user1" should not exist
     Examples:
       | password      |

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserRequirementCombinations.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserRequirementCombinations.feature
@@ -35,7 +35,7 @@ Feature: enforce combinations of password policies when creating a user
       | username | password   |
       | user1    | <password> |
     Then the command should have failed with exit code 1
-    And the command error output should contain the text '<message>'
+    And the command output should contain the text '<message>'
     And user "user1" should not exist
     Examples:
       | password                       | message                                                                   |
@@ -70,7 +70,7 @@ Feature: enforce combinations of password policies when creating a user
       | username | password   |
       | user1    | <password> |
     Then the command should have failed with exit code 1
-    And the command error output should contain the text '<message>'
+    And the command output should contain the text '<message>'
     And user "user1" should not exist
     Examples:
       | password        | message                                                                   |

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserSpecialCharacters.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserSpecialCharacters.feature
@@ -28,7 +28,7 @@ Feature: enforce the required number of special characters in a password when cr
       | user1    | <password> |
     Then the command should have failed with exit code 1
     # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
-    And the command error output should contain the text 'The password contains too few special characters. At least 3 special char'
+    And the command output should contain the text 'The password contains too few special characters. At least 3 special char'
     And user "user1" should not exist
     Examples:
       | password                 |

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserSpecialCharactersRestrictions.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserSpecialCharactersRestrictions.feature
@@ -30,7 +30,7 @@ Feature: enforce the restricted special characters in a password when creating a
       | user1    | <password> |
     Then the command should have failed with exit code 1
     # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
-    And the command error output should contain the text 'The password contains too few special characters. At least 3 special char'
+    And the command output should contain the text 'The password contains too few special characters. At least 3 special char'
     And user "user1" should not exist
     Examples:
       | password                 |
@@ -43,7 +43,7 @@ Feature: enforce the restricted special characters in a password when creating a
       | user1    | <password> |
     Then the command should have failed with exit code 1
     # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
-    And the command error output should contain the text 'The password contains invalid special characters. Only $%^&* are allowed.'
+    And the command output should contain the text 'The password contains invalid special characters. Only $%^&* are allowed.'
     And user "user1" should not exist
     Examples:
       | password                                 |

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserUppercaseLetters.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserUppercaseLetters.feature
@@ -28,7 +28,7 @@ Feature: enforce the required number of uppercase letters in a password when cre
       | user1    | <password> |
     Then the command should have failed with exit code 1
     # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
-    And the command error output should contain the text 'The password contains too few uppercase letters. At least 3 uppercase'
+    And the command output should contain the text 'The password contains too few uppercase letters. At least 3 uppercase'
     And user "user1" should not exist
     Examples:
       | password       |

--- a/tests/acceptance/features/cliPasswordChange/occResetPasswordLastPasswords.feature
+++ b/tests/acceptance/features/cliPasswordChange/occResetPasswordLastPasswords.feature
@@ -15,14 +15,14 @@ Feature: enforce the number of last passwords that must not be used when resetti
   Scenario: admin resets the password of a user to the existing password
     When the administrator resets the password of user "user1" to "Number1" using the occ command
     Then the command should have failed with exit code 1
-    And the command error output should contain the text 'The password must be different than your previous 3 passwords.'
+    And the command output should contain the text 'The password must be different than your previous 3 passwords.'
     And the content of file "textfile0.txt" for user "user1" using password "Number1" should be "ownCloud test text file 0" plus end-of-line
 
   Scenario: admin resets the password of a user to the 1st of 2 passwords
     Given the administrator has reset the password of user "user1" to "Number2"
     When the administrator resets the password of user "user1" to "Number1" using the occ command
     Then the command should have failed with exit code 1
-    And the command error output should contain the text 'The password must be different than your previous 3 passwords.'
+    And the command output should contain the text 'The password must be different than your previous 3 passwords.'
     And the content of file "textfile0.txt" for user "user1" using password "Number2" should be "ownCloud test text file 0" plus end-of-line
     But user "user1" using password "Number1" should not be able to download file "textfile0.txt"
 
@@ -30,7 +30,7 @@ Feature: enforce the number of last passwords that must not be used when resetti
     Given the administrator has reset the password of user "user1" to "Number2"
     When the administrator resets the password of user "user1" to "Number2" using the occ command
     Then the command should have failed with exit code 1
-    And the command error output should contain the text 'The password must be different than your previous 3 passwords.'
+    And the command output should contain the text 'The password must be different than your previous 3 passwords.'
     And the content of file "textfile0.txt" for user "user1" using password "Number2" should be "ownCloud test text file 0" plus end-of-line
     But user "user1" using password "Number1" should not be able to download file "textfile0.txt"
 
@@ -39,7 +39,7 @@ Feature: enforce the number of last passwords that must not be used when resetti
     And the administrator has reset the password of user "user1" to "Number3"
     When the administrator resets the password of user "user1" to "Number2" using the occ command
     Then the command should have failed with exit code 1
-    And the command error output should contain the text 'The password must be different than your previous 3 passwords.'
+    And the command output should contain the text 'The password must be different than your previous 3 passwords.'
     And the content of file "textfile0.txt" for user "user1" using password "Number3" should be "ownCloud test text file 0" plus end-of-line
     But user "user1" using password "Number2" should not be able to download file "textfile0.txt"
 
@@ -49,7 +49,7 @@ Feature: enforce the number of last passwords that must not be used when resetti
     And the administrator has reset the password of user "user1" to "Number4"
     When the administrator resets the password of user "user1" to "Number2" using the occ command
     Then the command should have failed with exit code 1
-    And the command error output should contain the text 'The password must be different than your previous 3 passwords.'
+    And the command output should contain the text 'The password must be different than your previous 3 passwords.'
     And the content of file "textfile0.txt" for user "user1" using password "Number4" should be "ownCloud test text file 0" plus end-of-line
     But user "user1" using password "Number2" should not be able to download file "textfile0.txt"
 

--- a/tests/acceptance/features/cliPasswordChange/occResetPasswordLowercaseLetters.feature
+++ b/tests/acceptance/features/cliPasswordChange/occResetPasswordLowercaseLetters.feature
@@ -27,7 +27,7 @@ Feature: enforce the required number of lowercase letters in a password when res
     When the administrator resets the password of user "user1" to "<password>" using the occ command
     Then the command should have failed with exit code 1
     # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
-    And the command error output should contain the text 'The password contains too few lowercase letters. At least 3 lowercase'
+    And the command output should contain the text 'The password contains too few lowercase letters. At least 3 lowercase'
     And the content of file "textfile0.txt" for user "user1" using password "abcABC1234" should be "ownCloud test text file 0" plus end-of-line
     But user "user1" using password "<password>" should not be able to download file "textfile0.txt"
     Examples:

--- a/tests/acceptance/features/cliPasswordChange/occResetPasswordMinimumLength.feature
+++ b/tests/acceptance/features/cliPasswordChange/occResetPasswordMinimumLength.feature
@@ -26,7 +26,7 @@ Feature: enforce the minimum length of a password when resetting the password us
   Scenario Outline: admin resets the password of a user to one that is not long enough
     When the administrator resets the password of user "user1" to "<password>" using the occ command
     Then the command should have failed with exit code 1
-    And the command error output should contain the text 'The password is too short. At least 10 characters are required.'
+    And the command output should contain the text 'The password is too short. At least 10 characters are required.'
     And the content of file "textfile0.txt" for user "user1" using password "1234567890" should be "ownCloud test text file 0" plus end-of-line
     But user "user1" using password "<password>" should not be able to download file "textfile0.txt"
     Examples:

--- a/tests/acceptance/features/cliPasswordChange/occResetPasswordNumbers.feature
+++ b/tests/acceptance/features/cliPasswordChange/occResetPasswordNumbers.feature
@@ -26,7 +26,7 @@ Feature: enforce the required number of numbers in a password when resetting the
   Scenario Outline: admin resets the password of a user with a password that does not have enough numbers
     When the administrator resets the password of user "user1" to "<password>" using the occ command
     Then the command should have failed with exit code 1
-    And the command error output should contain the text 'The password contains too few numbers. At least 3 numbers are required.'
+    And the command output should contain the text 'The password contains too few numbers. At least 3 numbers are required.'
     And the content of file "textfile0.txt" for user "user1" using password "abcABC1234" should be "ownCloud test text file 0" plus end-of-line
     But user "user1" using password "<password>" should not be able to download file "textfile0.txt"
     Examples:

--- a/tests/acceptance/features/cliPasswordChange/occResetPasswordRequirementCombinations.feature
+++ b/tests/acceptance/features/cliPasswordChange/occResetPasswordRequirementCombinations.feature
@@ -34,7 +34,7 @@ Feature: enforce combinations of password policies when resetting a user passwor
   Scenario Outline: admin resets the password of a user with a password that does not meet the password policy
     When the administrator resets the password of user "user1" to "<password>" using the occ command
     Then the command should have failed with exit code 1
-    And the command error output should contain the text '<message>'
+    And the command output should contain the text '<message>'
     And the content of file "textfile0.txt" for user "user1" using password "aA1!bB2#cC&deee" should be "ownCloud test text file 0" plus end-of-line
     But user "user1" using password "<password>" should not be able to download file "textfile0.txt"
     Examples:
@@ -67,7 +67,7 @@ Feature: enforce combinations of password policies when resetting a user passwor
     And the administrator has set the restricted special characters required to "$%^&*"
     When the administrator resets the password of user "user1" to "<password>" using the occ command
     Then the command should have failed with exit code 1
-    And the command error output should contain the text '<message>'
+    And the command output should contain the text '<message>'
     And the content of file "textfile0.txt" for user "user1" using password "aA1!bB2#cC&deee" should be "ownCloud test text file 0" plus end-of-line
     But user "user1" using password "<password>" should not be able to download file "textfile0.txt"
     Examples:

--- a/tests/acceptance/features/cliPasswordChange/occResetPasswordSpecialCharacters.feature
+++ b/tests/acceptance/features/cliPasswordChange/occResetPasswordSpecialCharacters.feature
@@ -27,7 +27,7 @@ Feature: enforce the required number of special characters in a password when re
     When the administrator resets the password of user "user1" to "<password>" using the occ command
     Then the command should have failed with exit code 1
     # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
-    And the command error output should contain the text 'The password contains too few special characters. At least 3 special char'
+    And the command output should contain the text 'The password contains too few special characters. At least 3 special char'
     And the content of file "textfile0.txt" for user "user1" using password "a!b@c#1234" should be "ownCloud test text file 0" plus end-of-line
     But user "user1" using password "<password>" should not be able to download file "textfile0.txt"
     Examples:

--- a/tests/acceptance/features/cliPasswordChange/occResetPasswordSpecialCharactersRestrictions.feature
+++ b/tests/acceptance/features/cliPasswordChange/occResetPasswordSpecialCharactersRestrictions.feature
@@ -29,7 +29,7 @@ Feature: enforce the required number of restricted special characters in a passw
     When the administrator resets the password of user "user1" to "<password>" using the occ command
     Then the command should have failed with exit code 1
     # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
-    And the command error output should contain the text 'The password contains too few special characters. At least 3 special char'
+    And the command output should contain the text 'The password contains too few special characters. At least 3 special char'
     And the content of file "textfile0.txt" for user "user1" using password "a$b%c^1234" should be "ownCloud test text file 0" plus end-of-line
     But user "user1" using password "<password>" should not be able to download file "textfile0.txt"
     Examples:
@@ -41,7 +41,7 @@ Feature: enforce the required number of restricted special characters in a passw
     When the administrator resets the password of user "user1" to "<password>" using the occ command
     Then the command should have failed with exit code 1
     # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
-    And the command error output should contain the text 'The password contains invalid special characters. Only $%^&* are allowed.'
+    And the command output should contain the text 'The password contains invalid special characters. Only $%^&* are allowed.'
     And the content of file "textfile0.txt" for user "user1" using password "a$b%c^1234" should be "ownCloud test text file 0" plus end-of-line
     But user "user1" using password "<password>" should not be able to download file "textfile0.txt"
     Examples:

--- a/tests/acceptance/features/cliPasswordChange/occResetPasswordUppercaseLetters.feature
+++ b/tests/acceptance/features/cliPasswordChange/occResetPasswordUppercaseLetters.feature
@@ -27,7 +27,7 @@ Feature: enforce the required number of uppercase letters in a password when res
     When the administrator resets the password of user "user1" to "<password>" using the occ command
     Then the command should have failed with exit code 1
     # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
-    And the command error output should contain the text 'The password contains too few uppercase letters. At least 3 uppercase'
+    And the command output should contain the text 'The password contains too few uppercase letters. At least 3 uppercase'
     And the content of file "textfile0.txt" for user "user1" using password "abcABC1234" should be "ownCloud test text file 0" plus end-of-line
     But user "user1" using password "<password>" should not be able to download file "textfile0.txt"
     Examples:


### PR DESCRIPTION
core PR https://github.com/owncloud/core/pull/35362 seems to have changed the behavior of where `occ` command output goes when the command is reporting an error/problem. See comment https://github.com/owncloud/core/pull/35362#issuecomment-501582670

This PR adjusts the `password_policy` acceptance tests to no longer expect the error text to be on `stderr` - it now comes on `stdout`