### PR TITLE
Increase width of numeric fields to display 3 digits

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -19,7 +19,7 @@
  */
 
 #password-policy input[type='number'] {
-	width: 30px;
+	width: 40px;
 }
 
 #password_policy .indented {


### PR DESCRIPTION
Issue #230 

![Screenshot_2019-06-27 Settings - ownCloud(1)](https://user-images.githubusercontent.com/1535615/60283598-457c6580-9929-11e9-87d7-838e5bc2dfb2.png)

I have been annoyed by this often enough, and was on this UI page today!