### PR TITLE
Use CHAR_SYMBOLS to generate password when no special chars are specified

### DIFF
--- a/lib/Engine.php
+++ b/lib/Engine.php
@@ -92,6 +92,9 @@ class Engine {
 		if ($this->yes('spv_special_chars_checked')) {
 			$val = $this->configValues['spv_special_chars_value'];
 			$chars = $this->configValues['spv_def_special_chars_value'];
+			if ($chars == '') {
+				$chars = ISecureRandom::CHAR_SYMBOLS;
+			}
 			$password .= $this->random->generate($val + 1, $chars);
 		}
 

--- a/tests/unit/EngineTest.php
+++ b/tests/unit/EngineTest.php
@@ -166,6 +166,7 @@ class EngineTest extends TestCase {
 			[['spv_uppercase_checked' => true], 'A234567890'],
 			[['spv_numbers_checked' => true], '1234567890'],
 			[['spv_special_chars_checked' => true], '#234567890'],
+			[['spv_special_chars_checked' => true, 'spv_def_special_chars_checked' => true, 'spv_def_special_chars_value' => ''], '#234567890'],
 		];
 	}
 


### PR DESCRIPTION
Fixes core issue https://github.com/owncloud/core/issues/35743

When the administrator has some password policy settings in place, and a user is created by specifying the username and email address (and no password), then a "random" initial password is generated in the backend (and the user will have to set their password properly from the link in the email that they are sent). 

`generatePassword()` gets called to generate a "random" password that meets the password policy criteria. That is a convenience in this case, so that the generated password meets the policy (if a password validate check hook gets triggered in the code path)

If the "special characters" password policy is checked, and the "restrict to these special characters" text box is empty, then the "special characters" are supposed to be all non-alphanumeric characters. That works fine when the admin is specifying the new user password. However, when `generatePassword()` is called with this policy settings it crashes:

```
[Thu Jul  4 20:45:36 2019] Exception: {"Exception":"Error","Message":"Minimum value must be less than or equal to the maximum value","Code":0,"Trace":"#0 \/home\/phil\/git\/owncloud\/core\/lib\/private\/Security\/SecureRandom.php(78): random_int(0, -1)\n#1 \/home\/phil\/git\/owncloud\/core\/apps-external\/password_policy\/lib\/Engine.php(95): OC\\Security\\SecureRandom->generate(2, '')\n#2 \/home\/phil\/git\/owncloud\/core\/apps-external\/password_policy\/lib\/HooksHandler.php(137): OCA\\PasswordPolicy\\Engine->generatePassword()\n#3 \/home\/phil\/git\/owncloud\/core\/lib\/composer\/symfony\/event-dispatcher\/EventDispatcher.php(212): OCA\\PasswordPolicy\\HooksHandler->generatePassword(Object(Symfony\\Component\\EventDispatcher\\GenericEvent), 'OCP\\\\User::creat...', Object(Symfony\\Component\\EventDispatcher\\EventDispatcher))\n#4 \/home\/phil\/git\/owncloud\/core\/lib\/composer\/symfony\/event-dispatcher\/EventDispatcher.php(44): Symfony\\Component\\EventDispatcher\\EventDispatcher->doDispatch(Array, 'OCP\\\\User::creat...', Object(Symfony\\Component\\EventDispatcher\\GenericEvent))\n#5 \/home\/phil\/git\/owncloud\/core\/apps-external\/user_management\/lib\/Controller\/UsersController.php(454): Symfony\\Component\\EventDispatcher\\EventDispatcher->dispatch('OCP\\\\User::creat...', Object(Symfony\\Component\\EventDispatcher\\GenericEvent))\n#6 \/home\/phil\/git\/owncloud\/core\/lib\/private\/AppFramework\/Http\/Dispatcher.php(153): OCA\\UserManagement\\Controller\\UsersController->create('naya6', '', Array, 'n6@e.com')\n#7 \/home\/phil\/git\/owncloud\/core\/lib\/private\/AppFramework\/Http\/Dispatcher.php(85): OC\\AppFramework\\Http\\Dispatcher->executeController(Object(OCA\\UserManagement\\Controller\\UsersController), 'create')\n#8 \/home\/phil\/git\/owncloud\/core\/lib\/private\/AppFramework\/App.php(100): OC\\AppFramework\\Http\\Dispatcher->dispatch(Object(OCA\\UserManagement\\Controller\\UsersController), 'create')\n#9 \/home\/phil\/git\/owncloud\/core\/lib\/private\/AppFramework\/Routing\/RouteActionHandler.php(47): OC\\AppFramework\\App::main('OCA\\\\UserManagem...', 'create', Object(OC\\AppFramework\\DependencyInjection\\DIContainer), Array)\n#10 \/home\/phil\/git\/owncloud\/core\/lib\/private\/Route\/Router.php(342): OC\\AppFramework\\Routing\\RouteActionHandler->__invoke(Array)\n#11 \/home\/phil\/git\/owncloud\/core\/lib\/base.php(908): OC\\Route\\Router->match('\/apps\/user_mana...')\n#12 \/home\/phil\/git\/owncloud\/core\/index.php(54): OC::handleRequest()\n#13 {main}","File":"\/home\/phil\/git\/owncloud\/core\/lib\/private\/Security\/SecureRandom.php","Line":78}
[Thu Jul  4 20:45:36 2019] 10.49.210.15:46402 [500]: /index.php/apps/user_management/users
```
The code tries to generate a "random" special character from an empty list of special characters.

When generating a password with special characters, and no list is specified, then we can use any special characters that we like. So fix this problem by using characters from `ISecureRandom::CHAR_SYMBOLS`