### PR TITLE
Adjust skipOnOcV10.2 test scenarios

### DIFF
--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserLowercaseLetters.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserLowercaseLetters.feature
@@ -22,6 +22,8 @@ Feature: enforce the required number of lowercase letters in a password when cre
       | 3LCase                    |
       | moreThan3LowercaseLetters |
 
+  @skipOnOcV10.2
+  # The command output for errors is coming on stdout from core 10.3 onwards
   Scenario Outline: admin creates a user with a password that does not have enough lowercase letters
     When the administrator creates this user using the occ command:
       | username | password   |
@@ -29,6 +31,21 @@ Feature: enforce the required number of lowercase letters in a password when cre
     Then the command should have failed with exit code 1
     # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
     And the command output should contain the text 'The password contains too few lowercase letters. At least 3 lowercase'
+    And user "user1" should not exist
+    Examples:
+      | password   |
+      | 0LOWERCASE |
+      | 2lOWERcASE |
+
+  @skipOnOcV10.3
+  # The command output for errors comes on stderr in core 10.2
+  Scenario Outline: admin creates a user with a password that does not have enough lowercase letters
+    When the administrator creates this user using the occ command:
+      | username | password   |
+      | user1    | <password> |
+    Then the command should have failed with exit code 1
+    # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
+    And the command error output should contain the text 'The password contains too few lowercase letters. At least 3 lowercase'
     And user "user1" should not exist
     Examples:
       | password   |

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserLowercaseLetters.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserLowercaseLetters.feature
@@ -22,7 +22,6 @@ Feature: enforce the required number of lowercase letters in a password when cre
       | 3LCase                    |
       | moreThan3LowercaseLetters |
 
-  @skipOnOcV10.2
   Scenario Outline: admin creates a user with a password that does not have enough lowercase letters
     When the administrator creates this user using the occ command:
       | username | password   |

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserMinimumLength.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserMinimumLength.feature
@@ -9,7 +9,7 @@ Feature: enforce the minimum length of a password when creating a user
     Given the administrator has enabled the minimum characters password policy
     And the administrator has set the minimum characters required to "10"
 
-  Scenario Outline: admin creates a user with a password that has enough numbers
+  Scenario Outline: admin creates a user with a password that is long enough
     When the administrator creates this user using the occ command:
       | username | password   |
       | user1    | <password> |
@@ -22,7 +22,7 @@ Feature: enforce the minimum length of a password when creating a user
       | 10tenchars           |
       | morethan10characters |
 
-  Scenario Outline: admin creates a user with a password that does not have enough numbers
+  Scenario Outline: admin creates a user with a password that is not long enough
     When the administrator creates this user using the occ command:
       | username | password   |
       | user1    | <password> |

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserMinimumLength.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserMinimumLength.feature
@@ -22,7 +22,6 @@ Feature: enforce the minimum length of a password when creating a user
       | 10tenchars           |
       | morethan10characters |
 
-  @skipOnOcV10.2
   Scenario Outline: admin creates a user with a password that does not have enough numbers
     When the administrator creates this user using the occ command:
       | username | password   |

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserMinimumLength.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserMinimumLength.feature
@@ -22,12 +22,28 @@ Feature: enforce the minimum length of a password when creating a user
       | 10tenchars           |
       | morethan10characters |
 
+  @skipOnOcV10.2
+  # The command output for errors is coming on stdout from core 10.3 onwards
   Scenario Outline: admin creates a user with a password that is not long enough
     When the administrator creates this user using the occ command:
       | username | password   |
       | user1    | <password> |
     Then the command should have failed with exit code 1
     And the command output should contain the text 'The password is too short. At least 10 characters are required.'
+    And user "user1" should not exist
+    Examples:
+      | password  |
+      | A         |
+      | 123456789 |
+
+  @skipOnOcV10.3
+  # The command output for errors comes on stderr in core 10.2
+  Scenario Outline: admin creates a user with a password that is not long enough
+    When the administrator creates this user using the occ command:
+      | username | password   |
+      | user1    | <password> |
+    Then the command should have failed with exit code 1
+    And the command error output should contain the text 'The password is too short. At least 10 characters are required.'
     And user "user1" should not exist
     Examples:
       | password  |

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserNumbers.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserNumbers.feature
@@ -22,7 +22,6 @@ Feature: enforce the required number of numbers in a password when creating a us
       | 333Numbers      |
       | moreNumbers1234 |
 
-  @skipOnOcV10.2
   Scenario Outline: admin creates a user with a password that does not have enough numbers
     When the administrator creates this user using the occ command:
       | username | password   |

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserNumbers.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserNumbers.feature
@@ -22,12 +22,28 @@ Feature: enforce the required number of numbers in a password when creating a us
       | 333Numbers      |
       | moreNumbers1234 |
 
+  @skipOnOcV10.2
+  # The command output for errors is coming on stdout from core 10.3 onwards
   Scenario Outline: admin creates a user with a password that does not have enough numbers
     When the administrator creates this user using the occ command:
       | username | password   |
       | user1    | <password> |
     Then the command should have failed with exit code 1
     And the command output should contain the text 'The password contains too few numbers. At least 3 numbers are required.'
+    And user "user1" should not exist
+    Examples:
+      | password      |
+      | NoNumbers     |
+      | Only22Numbers |
+
+  @skipOnOcV10.3
+  # The command output for errors comes on stderr in core 10.2
+  Scenario Outline: admin creates a user with a password that does not have enough numbers
+    When the administrator creates this user using the occ command:
+      | username | password   |
+      | user1    | <password> |
+    Then the command should have failed with exit code 1
+    And the command error output should contain the text 'The password contains too few numbers. At least 3 numbers are required.'
     And user "user1" should not exist
     Examples:
       | password      |

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserRequirementCombinations.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserRequirementCombinations.feature
@@ -30,12 +30,35 @@ Feature: enforce combinations of password policies when creating a user
       | 15***UPPloweZZZ           |
       | More%Than$15!Characters-0 |
 
+  @skipOnOcV10.2
+  # The command output for errors is coming on stdout from core 10.3 onwards
   Scenario Outline: admin creates a user with a password that does not meet the password policy
     When the administrator creates this user using the occ command:
       | username | password   |
       | user1    | <password> |
     Then the command should have failed with exit code 1
     And the command output should contain the text '<message>'
+    And user "user1" should not exist
+    Examples:
+      | password                       | message                                                                   |
+        # where just one of the requirements is not met
+      | aA1!bB2#cC&d                   | The password is too short. At least 15 characters are required.           |
+      | aA1!bB2#cNOT&ENOUGH#LOWERCASE  | The password contains too few lowercase letters. At least 4 lowercase     |
+      | aA1!bB2#cnot&enough#uppercase  | The password contains too few uppercase letters. At least 3 uppercase     |
+      | Not&Enough#Numbers=1           | The password contains too few numbers. At least 2 numbers are required.   |
+      | Not&Enough#Special8Characters2 | The password contains too few special characters. At least 3 special char |
+        # where multiple requirements are not met, only the first error message is shown to the user
+      | aA!1                           | The password is too short. At least 15 characters are required.           |
+      | aA!123456789012345             | The password contains too few lowercase letters. At least 4 lowercase     |
+
+  @skipOnOcV10.3
+  # The command output for errors comes on stderr in core 10.2
+  Scenario Outline: admin creates a user with a password that does not meet the password policy
+    When the administrator creates this user using the occ command:
+      | username | password   |
+      | user1    | <password> |
+    Then the command should have failed with exit code 1
+    And the command error output should contain the text '<message>'
     And user "user1" should not exist
     Examples:
       | password                       | message                                                                   |
@@ -63,6 +86,8 @@ Feature: enforce combinations of password policies when creating a user
       | 15%&*UPPloweZZZ           |
       | More^Than$15&Characters*0 |
 
+  @skipOnOcV10.2
+  # The command output for errors is coming on stdout from core 10.3 onwards
   Scenario Outline: admin creates a user with a password that has invalid restricted special characters
     Given the administrator has enabled the restrict to these special characters password policy
     And the administrator has set the restricted special characters required to "$%^&*"
@@ -71,6 +96,24 @@ Feature: enforce combinations of password policies when creating a user
       | user1    | <password> |
     Then the command should have failed with exit code 1
     And the command output should contain the text '<message>'
+    And user "user1" should not exist
+    Examples:
+      | password        | message                                                                   |
+      | 15#!!UPPloweZZZ | The password contains invalid special characters. Only $%^&* are allowed. |
+      | 15&%!UPPloweZZZ | The password contains invalid special characters. Only $%^&* are allowed. |
+        # where multiple requirements are not met, only the first error message is shown to the user
+      | 15&%!UPPlowZZZZ | The password contains too few lowercase letters. At least 4 lowercase     |
+
+  @skipOnOcV10.3
+  # The command output for errors comes on stderr in core 10.2
+  Scenario Outline: admin creates a user with a password that has invalid restricted special characters
+    Given the administrator has enabled the restrict to these special characters password policy
+    And the administrator has set the restricted special characters required to "$%^&*"
+    When the administrator creates this user using the occ command:
+      | username | password   |
+      | user1    | <password> |
+    Then the command should have failed with exit code 1
+    And the command error output should contain the text '<message>'
     And user "user1" should not exist
     Examples:
       | password        | message                                                                   |

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserRequirementCombinations.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserRequirementCombinations.feature
@@ -30,7 +30,6 @@ Feature: enforce combinations of password policies when creating a user
       | 15***UPPloweZZZ           |
       | More%Than$15!Characters-0 |
 
-  @skipOnOcV10.2
   Scenario Outline: admin creates a user with a password that does not meet the password policy
     When the administrator creates this user using the occ command:
       | username | password   |
@@ -64,7 +63,6 @@ Feature: enforce combinations of password policies when creating a user
       | 15%&*UPPloweZZZ           |
       | More^Than$15&Characters*0 |
 
-  @skipOnOcV10.2
   Scenario Outline: admin creates a user with a password that has invalid restricted special characters
     Given the administrator has enabled the restrict to these special characters password policy
     And the administrator has set the restricted special characters required to "$%^&*"

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserSpecialCharacters.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserSpecialCharacters.feature
@@ -22,6 +22,8 @@ Feature: enforce the required number of special characters in a password when cr
       | 3#Special$Characters! |
       | 1!2@3#4$5%6^7&8*      |
 
+  @skipOnOcV10.2
+  # The command output for errors is coming on stdout from core 10.3 onwards
   Scenario Outline: admin creates a user with a password that does not have enough special characters
     When the administrator creates this user using the occ command:
       | username | password   |
@@ -29,6 +31,21 @@ Feature: enforce the required number of special characters in a password when cr
     Then the command should have failed with exit code 1
     # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
     And the command output should contain the text 'The password contains too few special characters. At least 3 special char'
+    And user "user1" should not exist
+    Examples:
+      | password                 |
+      | NoSpecialCharacters123   |
+      | Only2$Special!Characters |
+
+  @skipOnOcV10.3
+  # The command output for errors comes on stderr in core 10.2
+  Scenario Outline: admin creates a user with a password that does not have enough special characters
+    When the administrator creates this user using the occ command:
+      | username | password   |
+      | user1    | <password> |
+    Then the command should have failed with exit code 1
+    # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
+    And the command error output should contain the text 'The password contains too few special characters. At least 3 special char'
     And user "user1" should not exist
     Examples:
       | password                 |

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserSpecialCharacters.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserSpecialCharacters.feature
@@ -22,7 +22,6 @@ Feature: enforce the required number of special characters in a password when cr
       | 3#Special$Characters! |
       | 1!2@3#4$5%6^7&8*      |
 
-  @skipOnOcV10.2
   Scenario Outline: admin creates a user with a password that does not have enough special characters
     When the administrator creates this user using the occ command:
       | username | password   |

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserSpecialCharactersRestrictions.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserSpecialCharactersRestrictions.feature
@@ -24,6 +24,8 @@ Feature: enforce the restricted special characters in a password when creating a
       | 3$Special%Characters^ |
       | 1*2&3^4%5$6           |
 
+  @skipOnOcV10.2
+  # The command output for errors is coming on stdout from core 10.3 onwards
   Scenario Outline: admin creates a user with a password that does not have enough restricted special characters
     When the administrator creates this user using the occ command:
       | username | password   |
@@ -37,6 +39,23 @@ Feature: enforce the restricted special characters in a password when creating a
       | NoSpecialCharacters123   |
       | Only2$Special&Characters |
 
+  @skipOnOcV10.3
+  # The command output for errors comes on stderr in core 10.2
+  Scenario Outline: admin creates a user with a password that does not have enough restricted special characters
+    When the administrator creates this user using the occ command:
+      | username | password   |
+      | user1    | <password> |
+    Then the command should have failed with exit code 1
+    # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
+    And the command error output should contain the text 'The password contains too few special characters. At least 3 special char'
+    And user "user1" should not exist
+    Examples:
+      | password                 |
+      | NoSpecialCharacters123   |
+      | Only2$Special&Characters |
+
+  @skipOnOcV10.2
+  # The command output for errors is coming on stdout from core 10.3 onwards
   Scenario Outline: admin creates a user with a password that has invalid special characters
     When the administrator creates this user using the occ command:
       | username | password   |
@@ -44,6 +63,21 @@ Feature: enforce the restricted special characters in a password when creating a
     Then the command should have failed with exit code 1
     # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
     And the command output should contain the text 'The password contains invalid special characters. Only $%^&* are allowed.'
+    And user "user1" should not exist
+    Examples:
+      | password                                 |
+      | Only#Invalid!Special@Characters          |
+      | 1*2&3^4%5$6andInvalidSpecialCharacters#! |
+
+  @skipOnOcV10.3
+  # The command output for errors comes on stderr in core 10.2
+  Scenario Outline: admin creates a user with a password that has invalid special characters
+    When the administrator creates this user using the occ command:
+      | username | password   |
+      | user1    | <password> |
+    Then the command should have failed with exit code 1
+    # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
+    And the command error output should contain the text 'The password contains invalid special characters. Only $%^&* are allowed.'
     And user "user1" should not exist
     Examples:
       | password                                 |

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserSpecialCharactersRestrictions.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserSpecialCharactersRestrictions.feature
@@ -24,7 +24,6 @@ Feature: enforce the restricted special characters in a password when creating a
       | 3$Special%Characters^ |
       | 1*2&3^4%5$6           |
 
-  @skipOnOcV10.2
   Scenario Outline: admin creates a user with a password that does not have enough restricted special characters
     When the administrator creates this user using the occ command:
       | username | password   |
@@ -38,7 +37,6 @@ Feature: enforce the restricted special characters in a password when creating a
       | NoSpecialCharacters123   |
       | Only2$Special&Characters |
 
-  @skipOnOcV10.2
   Scenario Outline: admin creates a user with a password that has invalid special characters
     When the administrator creates this user using the occ command:
       | username | password   |

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserUppercaseLetters.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserUppercaseLetters.feature
@@ -22,7 +22,6 @@ Feature: enforce the required number of uppercase letters in a password when cre
       | 3UpperCaseLetters         |
       | MoreThan3UpperCaseLetters |
 
-  @skipOnOcV10.2
   Scenario Outline: admin creates a user with a password that does not have enough uppercase letters
     When the administrator creates this user using the occ command:
       | username | password   |

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserUppercaseLetters.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserUppercaseLetters.feature
@@ -22,6 +22,8 @@ Feature: enforce the required number of uppercase letters in a password when cre
       | 3UpperCaseLetters         |
       | MoreThan3UpperCaseLetters |
 
+  @skipOnOcV10.2
+  # The command output for errors is coming on stdout from core 10.3 onwards
   Scenario Outline: admin creates a user with a password that does not have enough uppercase letters
     When the administrator creates this user using the occ command:
       | username | password   |
@@ -29,6 +31,21 @@ Feature: enforce the required number of uppercase letters in a password when cre
     Then the command should have failed with exit code 1
     # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
     And the command output should contain the text 'The password contains too few uppercase letters. At least 3 uppercase'
+    And user "user1" should not exist
+    Examples:
+      | password       |
+      | 0uppercase     |
+      | Only2Uppercase |
+
+  @skipOnOcV10.3
+  # The command output for errors comes on stderr in core 10.2
+  Scenario Outline: admin creates a user with a password that does not have enough uppercase letters
+    When the administrator creates this user using the occ command:
+      | username | password   |
+      | user1    | <password> |
+    Then the command should have failed with exit code 1
+    # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
+    And the command error output should contain the text 'The password contains too few uppercase letters. At least 3 uppercase'
     And user "user1" should not exist
     Examples:
       | password       |

--- a/tests/acceptance/features/cliPasswordChange/occResetPasswordLastPasswords.feature
+++ b/tests/acceptance/features/cliPasswordChange/occResetPasswordLastPasswords.feature
@@ -12,14 +12,12 @@ Feature: enforce the number of last passwords that must not be used when resetti
       | username | password |
       | user1    | Number1  |
 
-  @skipOnOcV10.2
   Scenario: admin resets the password of a user to the existing password
     When the administrator resets the password of user "user1" to "Number1" using the occ command
     Then the command should have failed with exit code 1
     And the command error output should contain the text 'The password must be different than your previous 3 passwords.'
     And the content of file "textfile0.txt" for user "user1" using password "Number1" should be "ownCloud test text file 0" plus end-of-line
 
-  @skipOnOcV10.2
   Scenario: admin resets the password of a user to the 1st of 2 passwords
     Given the administrator has reset the password of user "user1" to "Number2"
     When the administrator resets the password of user "user1" to "Number1" using the occ command
@@ -28,7 +26,6 @@ Feature: enforce the number of last passwords that must not be used when resetti
     And the content of file "textfile0.txt" for user "user1" using password "Number2" should be "ownCloud test text file 0" plus end-of-line
     But user "user1" using password "Number1" should not be able to download file "textfile0.txt"
 
-  @skipOnOcV10.2
   Scenario: admin resets the password of a user to the 2nd of 2 passwords
     Given the administrator has reset the password of user "user1" to "Number2"
     When the administrator resets the password of user "user1" to "Number2" using the occ command
@@ -37,7 +34,6 @@ Feature: enforce the number of last passwords that must not be used when resetti
     And the content of file "textfile0.txt" for user "user1" using password "Number2" should be "ownCloud test text file 0" plus end-of-line
     But user "user1" using password "Number1" should not be able to download file "textfile0.txt"
 
-  @skipOnOcV10.2
   Scenario: admin resets the password of a user to the 2nd of 3 passwords
     Given the administrator has reset the password of user "user1" to "Number2"
     And the administrator has reset the password of user "user1" to "Number3"
@@ -47,7 +43,6 @@ Feature: enforce the number of last passwords that must not be used when resetti
     And the content of file "textfile0.txt" for user "user1" using password "Number3" should be "ownCloud test text file 0" plus end-of-line
     But user "user1" using password "Number2" should not be able to download file "textfile0.txt"
 
-  @skipOnOcV10.2
   Scenario: admin resets the password of a user to the 2nd of 4 passwords
     Given the administrator has reset the password of user "user1" to "Number2"
     And the administrator has reset the password of user "user1" to "Number3"

--- a/tests/acceptance/features/cliPasswordChange/occResetPasswordLowercaseLetters.feature
+++ b/tests/acceptance/features/cliPasswordChange/occResetPasswordLowercaseLetters.feature
@@ -23,7 +23,6 @@ Feature: enforce the required number of lowercase letters in a password when res
       | 3LCase                    |
       | moreThan3LowercaseLetters |
 
-  @skipOnOcV10.2
   Scenario Outline: admin resets the password of a user with a password that does not have enough lowercase letters
     When the administrator resets the password of user "user1" to "<password>" using the occ command
     Then the command should have failed with exit code 1

--- a/tests/acceptance/features/cliPasswordChange/occResetPasswordMinimumLength.feature
+++ b/tests/acceptance/features/cliPasswordChange/occResetPasswordMinimumLength.feature
@@ -23,7 +23,6 @@ Feature: enforce the minimum length of a password when resetting the password us
       | 10tenchars           |
       | morethan10characters |
 
-  @skipOnOcV10.2
   Scenario Outline: admin resets the password of a user to one that is not long enough
     When the administrator resets the password of user "user1" to "<password>" using the occ command
     Then the command should have failed with exit code 1

--- a/tests/acceptance/features/cliPasswordChange/occResetPasswordNumbers.feature
+++ b/tests/acceptance/features/cliPasswordChange/occResetPasswordNumbers.feature
@@ -23,7 +23,6 @@ Feature: enforce the required number of numbers in a password when resetting the
       | 333Numbers      |
       | moreNumbers1234 |
 
-  @skipOnOcV10.2
   Scenario Outline: admin resets the password of a user with a password that does not have enough numbers
     When the administrator resets the password of user "user1" to "<password>" using the occ command
     Then the command should have failed with exit code 1

--- a/tests/acceptance/features/cliPasswordChange/occResetPasswordRequirementCombinations.feature
+++ b/tests/acceptance/features/cliPasswordChange/occResetPasswordRequirementCombinations.feature
@@ -31,7 +31,6 @@ Feature: enforce combinations of password policies when resetting a user passwor
       | 15***UPPloweZZZ           |
       | More%Than$15!Characters-0 |
 
-  @skipOnOcV10.2
   Scenario Outline: admin resets the password of a user with a password that does not meet the password policy
     When the administrator resets the password of user "user1" to "<password>" using the occ command
     Then the command should have failed with exit code 1
@@ -63,7 +62,6 @@ Feature: enforce combinations of password policies when resetting a user passwor
       | 15%&*UPPloweZZZ           |
       | More^Than$15&Characters*0 |
 
-  @skipOnOcV10.2
   Scenario Outline: admin resets the password of a user with a password that has invalid restricted special characters
     Given the administrator has enabled the restrict to these special characters password policy
     And the administrator has set the restricted special characters required to "$%^&*"

--- a/tests/acceptance/features/cliPasswordChange/occResetPasswordSpecialCharacters.feature
+++ b/tests/acceptance/features/cliPasswordChange/occResetPasswordSpecialCharacters.feature
@@ -23,7 +23,6 @@ Feature: enforce the required number of special characters in a password when re
       | 3#Special$Characters! |
       | 1!2@3#4$5%6^7&8*      |
 
-  @skipOnOcV10.2
   Scenario Outline: admin resets the password of a user with a password that does not have enough special characters
     When the administrator resets the password of user "user1" to "<password>" using the occ command
     Then the command should have failed with exit code 1

--- a/tests/acceptance/features/cliPasswordChange/occResetPasswordSpecialCharactersRestrictions.feature
+++ b/tests/acceptance/features/cliPasswordChange/occResetPasswordSpecialCharactersRestrictions.feature
@@ -25,7 +25,6 @@ Feature: enforce the required number of restricted special characters in a passw
       | 3$Special%Characters^ |
       | 1*2&3^4%5$6           |
 
-  @skipOnOcV10.2
   Scenario Outline: admin resets the password of a user with a password that does not have enough restricted special characters
     When the administrator resets the password of user "user1" to "<password>" using the occ command
     Then the command should have failed with exit code 1
@@ -38,7 +37,6 @@ Feature: enforce the required number of restricted special characters in a passw
       | NoSpecialCharacters123   |
       | Only2$Special&Characters |
 
-  @skipOnOcV10.2
   Scenario Outline: admin resets the password of a user with a password that has invalid special characters
     When the administrator resets the password of user "user1" to "<password>" using the occ command
     Then the command should have failed with exit code 1

--- a/tests/acceptance/features/cliPasswordChange/occResetPasswordUppercaseLetters.feature
+++ b/tests/acceptance/features/cliPasswordChange/occResetPasswordUppercaseLetters.feature
@@ -23,7 +23,6 @@ Feature: enforce the required number of uppercase letters in a password when res
       | 3UpperCaseLetters         |
       | MoreThan3UpperCaseLetters |
 
-  @skipOnOcV10.2
   Scenario Outline: admin resets the password of a user with a password that does not have enough uppercase letters
     When the administrator resets the password of user "user1" to "<password>" using the occ command
     Then the command should have failed with exit code 1


### PR DESCRIPTION
1) Remove the `skipOnOcV10.2` tags
2) Fixup scenario description in occAddUserMinimumLength.feature
3) Make separate scenarios for 10.2 and 10.3 occ command error output to demonstrate the different behaviour of the `occ` command error output in core `10.2` and `10.3`

This "documents" the different behaviour against core `10.2` and the current core `master` (upcoming `10.3`)

Issue https://github.com/owncloud/core/issues/36019 discusses the change in command error message output (among other things). After that is discussed and decided, then there might be further changes depending on what is finally decided for 10.3.