### PR TITLE
Implement drone.starlark

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -606,23 +606,17 @@ def acceptance():
 									print("Error: generated stage name of length", nameLength, "is not supported. The maximum length is " + str(maxLength) + ".", name)
 									errorFound = True
 
-							if isWebUI:
-								environment = {
-									'TEST_SERVER_URL': 'http://server',
-									'BEHAT_FILTER_TAGS': filterTags,
-									'BEHAT_SUITE': suite,
-									'SELENIUM_HOST': 'selenium',
-									'SELENIUM_PORT': '4444',
-									'BROWSER': browser,
-									'PLATFORM': 'Linux',
-								}
+							environment = {
+								'TEST_SERVER_URL': 'http://server',
+								'BEHAT_FILTER_TAGS': filterTags,
+								'BEHAT_SUITE': suite,
+							}
 
-							if isAPI or isCLI:
-								environment = {
-									'TEST_SERVER_URL': 'http://server',
-									'BEHAT_FILTER_TAGS': filterTags,
-									'BEHAT_SUITE': suite,
-								}
+							if isWebUI:
+								environment['SELENIUM_HOST'] = 'selenium'
+								environment['SELENIUM_PORT'] = '4444'
+								environment['BROWSER'] = browser
+								environment['PLATFORM'] = 'Linux'
 
 							if emailNeeded:
 								environment['MAILHOG_HOST'] = 'email'

--- a/.drone.starlark
+++ b/.drone.starlark
@@ -617,6 +617,13 @@ def acceptance():
 								environment['SELENIUM_PORT'] = '4444'
 								environment['BROWSER'] = browser
 								environment['PLATFORM'] = 'Linux'
+								makeParameter = 'test-acceptance-webui'
+
+							if isAPI:
+								makeParameter = 'test-acceptance-api'
+
+							if isCLI:
+								makeParameter = 'test-acceptance-cli'
 
 							if emailNeeded:
 								environment['MAILHOG_HOST'] = 'email'
@@ -671,29 +678,9 @@ def acceptance():
 											'touch /var/www/owncloud/saved-settings.sh',
 											'. /var/www/owncloud/saved-settings.sh',
 											'cd /var/www/owncloud/testrunner/apps/%s' % config['app'],
-											'make test-acceptance-webui'
+											'make %s' % makeParameter
 										]
-									} if isWebUI else None),
-									({
-										'name': 'acceptance-tests',
-										'image': 'owncloudci/php:%s' % phpVersion,
-										'pull': 'always',
-										'environment': environment,
-										'commands': [
-											'cd /var/www/owncloud/testrunner/apps/%s' % config['app'],
-											'make test-acceptance-api'
-										]
-									} if isAPI else None),
-									({
-										'name': 'acceptance-tests',
-										'image': 'owncloudci/php:%s' % phpVersion,
-										'pull': 'always',
-										'environment': environment,
-										'commands': [
-											'cd /var/www/owncloud/testrunner/apps/%s' % config['app'],
-											'make test-acceptance-cli'
-										]
-									} if isCLI else None),
+									}),
 								],
 								'services': databaseService(db)
 									+ browserService(browser)

--- a/.drone.starlark
+++ b/.drone.starlark
@@ -218,12 +218,15 @@ def phpstan():
 
 	default = {
 		'phpVersions': ['7.2'],
+		'logLevel': '2',
 	}
 
 	if 'defaults' in config:
 		if 'phpstan' in config['defaults']:
 			if 'phpVersions' in config['defaults']['phpstan']:
 				default['phpVersions'] = config['defaults']['phpstan']['phpVersions']
+			if 'logLevel' in config['defaults']['phpstan']:
+				default['logLevel'] = config['defaults']['phpstan']['logLevel']
 
 	phpstanConfig = config['phpstan']
 
@@ -240,6 +243,7 @@ def phpstan():
 
 	for category, matrix in phpstanConfig.items():
 		phpVersions = matrix['phpVersions'] if 'phpVersions' in matrix else default['phpVersions']
+		logLevel = matrix['logLevel'] if 'logLevel' in matrix else default['logLevel']
 
 		for phpVersion in phpVersions:
 			name = 'phpstan-php%s' % phpVersion
@@ -254,7 +258,7 @@ def phpstan():
 				},
 				'steps': [
 					installCore('daily-master-qa', 'sqlite'),
-					setupServerAndApp(phpVersion),
+					setupServerAndApp(phpVersion, logLevel),
 					{
 						'name': 'phpstan',
 						'image': 'owncloudci/php:%s' % phpVersion,
@@ -350,13 +354,30 @@ def phan():
 	return pipelines
 
 def javascript():
-	if 'javascript' in config:
-		doJavascript = config['javascript']
-	else:
-		doJavascript = False
+	pipelines = []
 
-	if doJavascript == False:
-		return []
+	if 'javascript' not in config:
+		return pipelines
+
+	default = {
+		'logLevel': '2',
+	}
+
+	if 'defaults' in config:
+		if 'javascript' in config['defaults']:
+			if 'logLevel' in config['defaults']['javascript']:
+				default['logLevel'] = config['defaults']['javascript']['logLevel']
+
+	javascriptConfig = config['javascript']
+
+	if type(javascriptConfig) == "bool":
+		if javascriptConfig:
+			# the config has 'javascript' true, so specify an empty dict that will get the defaults
+			javascriptConfig = {}
+		else:
+			return pipelines
+
+	logLevel = javascriptConfig['logLevel'] if 'logLevel' in javascriptConfig else default['logLevel']
 
 	result = {
 		'kind': 'pipeline',
@@ -368,7 +389,7 @@ def javascript():
 		},
 		'steps': [
 			installCore('daily-master-qa', 'sqlite'),
-			setupServerAndApp('7.0'),
+			setupServerAndApp('7.0', logLevel),
 			{
 				'name': 'javascript-tests',
 				'image': 'owncloudci/php:7.0',
@@ -404,6 +425,7 @@ def phpunit():
 			'sqlite', 'mariadb:10.2', 'mysql:5.5', 'mysql:5.7', 'postgres:9.4', 'oracle'
 		],
 		'coverage': True,
+		'logLevel': '2',
 	}
 
 	if 'defaults' in config:
@@ -412,6 +434,8 @@ def phpunit():
 				default['databases'] = config['defaults']['phpunit']['databases']
 			if 'coverage' in config['defaults']['phpunit']:
 				default['databases'] = config['defaults']['phpunit']['coverage']
+			if 'logLevel' in config['defaults']['phpunit']:
+				default['logLevel'] = config['defaults']['phpunit']['logLevel']
 
 	phpunitConfig = config['phpunit']
 
@@ -429,6 +453,7 @@ def phpunit():
 	for category, matrix in phpunitConfig.items():
 		databases = matrix['databases'] if 'databases' in matrix else default['databases']
 		coverage = matrix['coverage'] if 'coverage' in matrix else default['coverage']
+		logLevel = matrix['logLevel'] if 'logLevel' in matrix else default['logLevel']
 		phpVersions = matrix['phpVersions'] if 'phpVersions' in matrix else default['phpVersions']
 
 		for phpVersion in phpVersions:
@@ -449,7 +474,7 @@ def phpunit():
 					},
 					'steps': [
 						installCore('daily-master-qa', db),
-						setupServerAndApp(phpVersion),
+						setupServerAndApp(phpVersion, logLevel),
 						{
 							'name': 'phpunit-tests',
 							'image': 'owncloudci/php:%s' % phpVersion,
@@ -506,6 +531,7 @@ def acceptance():
 		'databases': ['mariadb:10.2'],
 		'federatedServerNeeded': False,
 		'filterTags': '',
+		'logLevel': '2',
 		'emailNeeded': False,
 		'extraSetup': None,
 		'extraServices': [],
@@ -515,17 +541,19 @@ def acceptance():
 	if 'defaults' in config:
 		if 'acceptance' in config['defaults']:
 			if 'servers' in config['defaults']['acceptance']:
-				default['databases'] = config['defaults']['acceptance']['servers']
+				default['servers'] = config['defaults']['acceptance']['servers']
 			if 'browsers' in config['defaults']['acceptance']:
-				default['databases'] = config['defaults']['acceptance']['browsers']
+				default['browsers'] = config['defaults']['acceptance']['browsers']
 			if 'phpVersions' in config['defaults']['acceptance']:
-				default['databases'] = config['defaults']['acceptance']['phpVersions']
+				default['phpVersions'] = config['defaults']['acceptance']['phpVersions']
 			if 'databases' in config['defaults']['acceptance']:
 				default['databases'] = config['defaults']['acceptance']['databases']
 			if 'federatedServerNeeded' in config['defaults']['acceptance']:
-				default['databases'] = config['defaults']['acceptance']['federatedServerNeeded']
+				default['federatedServerNeeded'] = config['defaults']['acceptance']['federatedServerNeeded']
 			if 'filterTags' in config['defaults']['acceptance']:
-				default['databases'] = config['defaults']['acceptance']['filterTags']
+				default['filterTags'] = config['defaults']['acceptance']['filterTags']
+			if 'logLevel' in config['defaults']['acceptance']:
+				default['logLevel'] = config['defaults']['acceptance']['logLevel']
 			if 'emailNeeded' in config['defaults']['acceptance']:
 				default['emailNeeded'] = config['defaults']['acceptance']['emailNeeded']
 			if 'extraSetup' in config['defaults']['acceptance']:
@@ -557,6 +585,7 @@ def acceptance():
 			databases = matrix['databases'] if 'databases' in matrix else default['databases']
 			federatedServerNeeded = matrix['federatedServerNeeded'] if 'federatedServerNeeded' in matrix else default['federatedServerNeeded']
 			filterTags = matrix['filterTags'] if 'filterTags' in matrix else default['filterTags']
+			logLevel = matrix['logLevel'] if 'logLevel' in matrix else default['logLevel']
 			emailNeeded = matrix['emailNeeded'] if 'emailNeeded' in matrix else default['emailNeeded']
 			extraSetup = matrix['extraSetup'] if 'extraSetup' in matrix else default['extraSetup']
 			extraServices = matrix['extraServices'] if 'extraServices' in matrix else default['extraServices']
@@ -635,7 +664,7 @@ def acceptance():
 										]
 									}
 								] if federatedServerNeeded else []) + [
-									setupServerAndApp(phpVersion),
+									setupServerAndApp(phpVersion, logLevel),
 									installExtraApps(phpVersion, extraApps),
 									extraSetup,
 									fixPermissions(phpVersion),
@@ -915,7 +944,7 @@ def installExtraApps(phpVersion, extraApps):
 		'commands': commandArray
 	}
 
-def setupServerAndApp(phpVersion):
+def setupServerAndApp(phpVersion, logLevel):
 	return {
 		'name': 'setup-server-%s' % config['app'],
 		'image': 'owncloudci/php:%s' % phpVersion,
@@ -928,7 +957,7 @@ def setupServerAndApp(phpVersion):
 			'php occ a:e testing',
 			'php occ a:l',
 			'php occ config:system:set trusted_domains 1 --value=server',
-			'php occ log:manage --level 0',
+			'php occ log:manage --level %s' % logLevel,
 		]
 	}
 

--- a/.drone.starlark
+++ b/.drone.starlark
@@ -1,0 +1,950 @@
+config = {
+	'app': 'password_policy',
+	'rocketchat': 'builds',
+
+	'branches': [
+		'master'
+	],
+
+	'codestyle': True,
+
+	'phpstan': False,
+
+	'phan': True,
+
+	'phpunit': {
+		'allDatabases' : {
+			'phpVersions': [
+				'7.0',
+			]
+		},
+		'reducedDatabases' : {
+			'phpVersions': [
+				'7.1',
+				'7.2',
+				'7.3',
+			],
+			'databases': [
+				'sqlite',
+				'mariadb:10.2',
+			],
+			'coverage': False
+		},
+	},
+
+	'acceptance': {
+		'webUIWithEmail': {
+			'suites': {
+				'webUIPasswordAddUser': 'webUIPwdAddUser',
+				'webUIPasswordAddUserSpecial': 'webUIPwdAddUsSp',
+				'webUIPasswordReset': 'webUIPwdReset',
+			},
+			'browsers': [
+				'chrome',
+				'firefox'
+			],
+			'emailNeeded': True
+		},
+		'webUIGuests': {
+			'suites': {
+				'webUIGuests': 'webUIGuests',
+			},
+			'servers': [
+				'daily-master-qa',
+				'10.3.0alpha'
+			],
+			'browsers': [
+				'chrome',
+				'firefox'
+			],
+			'extraApps': [
+				'guests'
+			],
+			'emailNeeded': True
+		},
+		'webUIOther': {
+			'suites': {
+				'webUIPasswordChange': 'webUIPwdChange',
+				'webUIPasswordChangeSpecial': 'webUIPwdChangeSp',
+				'webUIPasswordPolicySettings': 'webUIPwdPolSet',
+				'webUIPublicShareLink': 'webUIPublicShare',
+			},
+			'browsers': [
+				'chrome',
+				'firefox'
+			],
+		},
+		'apiGuests': {
+			'suites': [
+				'apiGuests',
+			],
+			'servers': [
+				'daily-master-qa',
+				'10.3.0alpha'
+			],
+			'databases': [
+				'mariadb:10.2', 'oracle'
+			],
+			'extraApps': [
+				'guests'
+			],
+			'emailNeeded': True
+		},
+		'apiOther': {
+			'suites': {
+				'apiPasswordAddUser': 'apiPwdAddUser',
+				'apiPasswordAddUserSpecial': 'apiPwdAddUserSpecial',
+				'apiPasswordChange': 'apiPwdChange',
+				'apiPasswordChangeSpecial': 'apiPwdChangeSpecial',
+				'apiUpdateShare': 'apiUpdateShare',
+			},
+			'databases': [
+				'mariadb:10.2', 'oracle'
+			],
+		},
+		'cli': {
+			'suites': [
+				'cliPasswordAddUser',
+				'cliPasswordChange',
+			],
+		},
+	},
+}
+
+def main(ctx):
+	before = beforePipelines()
+
+	stages = stagePipelines()
+	if (stages == False):
+		print('Errors detected. Review messages above.')
+		return []
+
+	dependsOn(before, stages)
+
+	after = afterPipelines()
+	dependsOn(stages, after)
+
+	return before + stages + after
+
+def beforePipelines():
+	return codestyle() + javascript() + phpstan() + phan()
+
+def stagePipelines():
+	phpunitPipelines = phpunit()
+	acceptancePipelines = acceptance()
+	if (phpunitPipelines == False) or (acceptancePipelines == False):
+		return False
+
+	return phpunitPipelines + acceptancePipelines
+
+def afterPipelines():
+	return [
+		notify()
+	]
+
+def codestyle():
+	pipelines = []
+
+	if 'codestyle' not in config:
+		return pipelines
+
+	default = {
+		'phpVersions': ['7.0'],
+	}
+
+	if 'defaults' in config:
+		if 'codestyle' in config['defaults']:
+			if 'phpVersions' in config['defaults']['codestyle']:
+				default['phpVersions'] = config['defaults']['codestyle']['phpVersions']
+
+	codestyleConfig = config['codestyle']
+
+	if type(codestyleConfig) == "bool":
+		if codestyleConfig:
+			# the config has 'codestyle' true, so specify an empty dict that will get the defaults
+			codestyleConfig = {}
+		else:
+			return pipelines
+
+	if len(codestyleConfig) == 0:
+		# 'codestyle' is an empty dict, so specify a single section that will get the defaults
+		codestyleConfig = {'doDefault': {}}
+
+	for category, matrix in codestyleConfig.items():
+		phpVersions = matrix['phpVersions'] if 'phpVersions' in matrix else default['phpVersions']
+
+		for phpVersion in phpVersions:
+			name = 'coding-standard-php%s' % phpVersion
+
+			result = {
+				'kind': 'pipeline',
+				'type': 'docker',
+				'name': name,
+				'workspace' : {
+					'base': '/var/www/owncloud',
+					'path': 'server/apps/%s' % config['app']
+				},
+				'steps': [
+					{
+						'name': 'coding-standard',
+						'image': 'owncloudci/php:%s' % phpVersion,
+						'pull': 'always',
+						'commands': [
+							'make test-php-style'
+						]
+					}
+				],
+				'depends_on': [],
+				'trigger': {
+					'ref': [
+						'refs/pull/**',
+						'refs/tags/**'
+					]
+				}
+			}
+
+			for branch in config['branches']:
+				result['trigger']['ref'].append('refs/heads/%s' % branch)
+
+			pipelines.append(result)
+
+	return pipelines
+
+def phpstan():
+	pipelines = []
+
+	if 'phpstan' not in config:
+		return pipelines
+
+	default = {
+		'phpVersions': ['7.2'],
+	}
+
+	if 'defaults' in config:
+		if 'phpstan' in config['defaults']:
+			if 'phpVersions' in config['defaults']['phpstan']:
+				default['phpVersions'] = config['defaults']['phpstan']['phpVersions']
+
+	phpstanConfig = config['phpstan']
+
+	if type(phpstanConfig) == "bool":
+		if phpstanConfig:
+			# the config has 'phpstan' true, so specify an empty dict that will get the defaults
+			phpstanConfig = {}
+		else:
+			return pipelines
+
+	if len(phpstanConfig) == 0:
+		# 'phpstan' is an empty dict, so specify a single section that will get the defaults
+		phpstanConfig = {'doDefault': {}}
+
+	for category, matrix in phpstanConfig.items():
+		phpVersions = matrix['phpVersions'] if 'phpVersions' in matrix else default['phpVersions']
+
+		for phpVersion in phpVersions:
+			name = 'phpstan-php%s' % phpVersion
+
+			result = {
+				'kind': 'pipeline',
+				'type': 'docker',
+				'name': name,
+				'workspace' : {
+					'base': '/var/www/owncloud',
+					'path': 'server/apps/%s' % config['app']
+				},
+				'steps': [
+					installCore('daily-master-qa', 'sqlite'),
+					setupServerAndApp(phpVersion),
+					{
+						'name': 'phpstan',
+						'image': 'owncloudci/php:%s' % phpVersion,
+						'pull': 'always',
+						'commands': [
+							'make test-php-phpstan'
+						]
+					}
+				],
+				'depends_on': [],
+				'trigger': {
+					'ref': [
+						'refs/pull/**',
+						'refs/tags/**'
+					]
+				}
+			}
+
+			for branch in config['branches']:
+				result['trigger']['ref'].append('refs/heads/%s' % branch)
+
+			pipelines.append(result)
+
+	return pipelines
+
+def phan():
+	pipelines = []
+
+	if 'phan' not in config:
+		return pipelines
+
+	default = {
+		'phpVersions': ['7.0', '7.1', '7.2', '7.3'],
+	}
+
+	if 'defaults' in config:
+		if 'phan' in config['defaults']:
+			if 'phpVersions' in config['defaults']['phan']:
+				default['phpVersions'] = config['defaults']['phan']['phpVersions']
+
+	phanConfig = config['phan']
+
+	if type(phanConfig) == "bool":
+		if phanConfig:
+			# the config has 'phan' true, so specify an empty dict that will get the defaults
+			phanConfig = {}
+		else:
+			return pipelines
+
+	if len(phanConfig) == 0:
+		# 'phan' is an empty dict, so specify a single section that will get the defaults
+		phanConfig = {'doDefault': {}}
+
+	for category, matrix in phanConfig.items():
+		phpVersions = matrix['phpVersions'] if 'phpVersions' in matrix else default['phpVersions']
+
+		for phpVersion in phpVersions:
+			name = 'phan-php%s' % phpVersion
+
+			result = {
+				'kind': 'pipeline',
+				'type': 'docker',
+				'name': name,
+				'workspace' : {
+					'base': '/var/www/owncloud',
+					'path': 'server/apps/%s' % config['app']
+				},
+				'steps': [
+					installCore('daily-master-qa', 'sqlite'),
+					{
+						'name': 'phan',
+						'image': 'owncloudci/php:%s' % phpVersion,
+						'pull': 'always',
+						'commands': [
+							'make test-php-phan'
+						]
+					}
+				],
+				'depends_on': [],
+				'trigger': {
+					'ref': [
+						'refs/pull/**',
+						'refs/tags/**'
+					]
+				}
+			}
+
+			for branch in config['branches']:
+				result['trigger']['ref'].append('refs/heads/%s' % branch)
+
+			pipelines.append(result)
+
+	return pipelines
+
+def javascript():
+	if 'javascript' in config:
+		doJavascript = config['javascript']
+	else:
+		doJavascript = False
+
+	if doJavascript == False:
+		return []
+
+	result = {
+		'kind': 'pipeline',
+		'type': 'docker',
+		'name': 'javascript-tests',
+		'workspace' : {
+			'base': '/var/www/owncloud',
+			'path': 'server/apps/%s' % config['app']
+		},
+		'steps': [
+			installCore('daily-master-qa', 'sqlite'),
+			setupServerAndApp('7.0'),
+			{
+				'name': 'javascript-tests',
+				'image': 'owncloudci/php:7.0',
+				'pull': 'always',
+				'commands': [
+					'make test-js'
+				]
+			}
+		],
+		'depends_on': [],
+		'trigger': {
+			'ref': [
+				'refs/pull/**',
+				'refs/tags/**'
+			]
+		}
+	}
+
+	for branch in config['branches']:
+		result['trigger']['ref'].append('refs/heads/%s' % branch)
+
+	return [result]
+
+def phpunit():
+	pipelines = []
+
+	if 'phpunit' not in config:
+		return pipelines
+
+	default = {
+		'phpVersions': ['7.0', '7.1', '7.2', '7.3'],
+		'databases': [
+			'sqlite', 'mariadb:10.2', 'mysql:5.5', 'mysql:5.7', 'postgres:9.4', 'oracle'
+		],
+		'coverage': True,
+	}
+
+	if 'defaults' in config:
+		if 'phpunit' in config['defaults']:
+			if 'databases' in config['defaults']['phpunit']:
+				default['databases'] = config['defaults']['phpunit']['databases']
+			if 'coverage' in config['defaults']['phpunit']:
+				default['databases'] = config['defaults']['phpunit']['coverage']
+
+	phpunitConfig = config['phpunit']
+
+	if type(phpunitConfig) == "bool":
+		if phpunitConfig:
+			# the config has 'phpunit' true, so specify an empty dict that will get the defaults
+			phpunitConfig = {}
+		else:
+			return pipelines
+
+	if len(phpunitConfig) == 0:
+		# 'phpunit' is an empty dict, so specify a single section that will get the defaults
+		phpunitConfig = {'doDefault': {}}
+
+	for category, matrix in phpunitConfig.items():
+		databases = matrix['databases'] if 'databases' in matrix else default['databases']
+		coverage = matrix['coverage'] if 'coverage' in matrix else default['coverage']
+		phpVersions = matrix['phpVersions'] if 'phpVersions' in matrix else default['phpVersions']
+
+		for phpVersion in phpVersions:
+
+			if coverage:
+				command = 'make test-php-unit-dbg'
+			else:
+				command = 'make test-php-unit'
+
+			for db in databases:
+				result = {
+					'kind': 'pipeline',
+					'type': 'docker',
+					'name': 'phpunit-php%s-%s' % (phpVersion, db.replace(":", "")),
+					'workspace' : {
+						'base': '/var/www/owncloud',
+						'path': 'server/apps/%s' % config['app']
+					},
+					'steps': [
+						installCore('daily-master-qa', db),
+						setupServerAndApp(phpVersion),
+						{
+							'name': 'phpunit-tests',
+							'image': 'owncloudci/php:%s' % phpVersion,
+							'pull': 'always',
+							'commands': [
+								command
+							]
+						}
+					],
+					'services': databaseService(db),
+					'depends_on': [],
+					'trigger': {
+						'ref': [
+							'refs/pull/**',
+							'refs/tags/**'
+						]
+					}
+				}
+
+				if coverage:
+					result['steps'].append({
+						'name': 'codecov-upload',
+						'image': 'plugins/codecov:2',
+						'pull': 'always',
+						'settings': {
+							'paths': [
+								'tests/output/clover.xml',
+							],
+							'token': {
+								'from_secret': 'codecov_token'
+							}
+						}
+					})
+
+				for branch in config['branches']:
+					result['trigger']['ref'].append('refs/heads/%s' % branch)
+
+				pipelines.append(result)
+
+	return pipelines
+
+def acceptance():
+	pipelines = []
+
+	if 'acceptance' not in config:
+		return pipelines
+
+	errorFound = False
+
+	default = {
+		'servers': ['daily-master-qa', '10.2.1'],
+		'browsers': ['chrome'],
+		'phpVersions': ['7.0'],
+		'databases': ['mariadb:10.2'],
+		'federatedServerNeeded': False,
+		'filterTags': '',
+		'emailNeeded': False,
+		'extraSetup': None,
+		'extraServices': [],
+		'extraApps': [],
+	}
+
+	if 'defaults' in config:
+		if 'acceptance' in config['defaults']:
+			if 'servers' in config['defaults']['acceptance']:
+				default['databases'] = config['defaults']['acceptance']['servers']
+			if 'browsers' in config['defaults']['acceptance']:
+				default['databases'] = config['defaults']['acceptance']['browsers']
+			if 'phpVersions' in config['defaults']['acceptance']:
+				default['databases'] = config['defaults']['acceptance']['phpVersions']
+			if 'databases' in config['defaults']['acceptance']:
+				default['databases'] = config['defaults']['acceptance']['databases']
+			if 'federatedServerNeeded' in config['defaults']['acceptance']:
+				default['databases'] = config['defaults']['acceptance']['federatedServerNeeded']
+			if 'filterTags' in config['defaults']['acceptance']:
+				default['databases'] = config['defaults']['acceptance']['filterTags']
+			if 'emailNeeded' in config['defaults']['acceptance']:
+				default['emailNeeded'] = config['defaults']['acceptance']['emailNeeded']
+			if 'extraSetup' in config['defaults']['acceptance']:
+				default['extraSetup'] = config['defaults']['acceptance']['extraSetup']
+			if 'extraServices' in config['defaults']['acceptance']:
+				default['extraServices'] = config['defaults']['acceptance']['extraServices']
+			if 'extraApps' in config['defaults']['acceptance']:
+				default['extraApps'] = config['defaults']['acceptance']['extraApps']
+
+	for category, matrix in config['acceptance'].items():
+		if type(matrix['suites']) == "list":
+			suites = {}
+			for suite in matrix['suites']:
+				suites[suite] = suite
+		else:
+			suites = matrix['suites']
+
+		for suite, shortSuiteName in suites.items():
+			isWebUI = suite.startswith('webUI')
+			isAPI = suite.startswith('api')
+			isCLI = suite.startswith('cli')
+
+			if isAPI or isCLI:
+				default['browsers'] = ['']
+
+			servers = matrix['servers'] if 'servers' in matrix else default['servers']
+			browsers = matrix['browsers'] if 'browsers' in matrix else default['browsers']
+			phpVersions = matrix['phpVersions'] if 'phpVersions' in matrix else default['phpVersions']
+			databases = matrix['databases'] if 'databases' in matrix else default['databases']
+			federatedServerNeeded = matrix['federatedServerNeeded'] if 'federatedServerNeeded' in matrix else default['federatedServerNeeded']
+			filterTags = matrix['filterTags'] if 'filterTags' in matrix else default['filterTags']
+			emailNeeded = matrix['emailNeeded'] if 'emailNeeded' in matrix else default['emailNeeded']
+			extraSetup = matrix['extraSetup'] if 'extraSetup' in matrix else default['extraSetup']
+			extraServices = matrix['extraServices'] if 'extraServices' in matrix else default['extraServices']
+			extraApps = matrix['extraApps'] if 'extraApps' in matrix else default['extraApps']
+
+			for server in servers:
+				for browser in browsers:
+					for phpVersion in phpVersions:
+						for db in databases:
+							name = 'unknown'
+
+							if isWebUI or isAPI or isCLI:
+								browserString = '' if browser == '' else '-' + browser
+								name = '%s-%s%s-%s-php%s' % (shortSuiteName, server.replace('daily-', '').replace('-qa', ''), browserString, db.replace(':', ''), phpVersion)
+								maxLength = 50
+								nameLength = len(name)
+								if nameLength > maxLength:
+									print("Error: generated stage name of length", nameLength, "is not supported. The maximum length is " + str(maxLength) + ".", name)
+									errorFound = True
+
+							if isWebUI:
+								environment = {
+									'TEST_SERVER_URL': 'http://server',
+									'BEHAT_FILTER_TAGS': filterTags,
+									'BEHAT_SUITE': suite,
+									'SELENIUM_HOST': 'selenium',
+									'SELENIUM_PORT': '4444',
+									'BROWSER': browser,
+									'PLATFORM': 'Linux',
+								}
+
+							if isAPI or isCLI:
+								environment = {
+									'TEST_SERVER_URL': 'http://server',
+									'BEHAT_FILTER_TAGS': filterTags,
+									'BEHAT_SUITE': suite,
+								}
+
+							if emailNeeded:
+								environment['MAILHOG_HOST'] = 'email'
+
+							result = {
+								'kind': 'pipeline',
+								'type': 'docker',
+								'name': name,
+								'workspace' : {
+									'base': '/var/www/owncloud',
+									'path': 'server/apps/%s' % config['app']
+								},
+								'steps': [
+									installCore(server, db),
+									installTestrunner(phpVersion)
+								] + ([
+									{
+										'name': 'install-federation',
+										'image': 'owncloudci/core',
+										'pull': 'always',
+										'settings': {
+											'version': server,
+											'core_path': '/var/www/owncloud/federated'
+										}
+									},
+									{
+										'name': 'configure-federation',
+										'image': 'owncloudci/php:%s' % phpVersion,
+										'pull': 'always',
+										'commands': [
+											'echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh',
+											'cd /var/www/owncloud/federated',
+											'php occ a:l',
+											'php occ a:e testing',
+											'php occ a:l',
+											'php occ config:system:set trusted_domains 1 --value=federated',
+											'php occ log:manage --level 0',
+											'php occ config:list'
+										]
+									}
+								] if federatedServerNeeded else []) + [
+									setupServerAndApp(phpVersion),
+									installExtraApps(phpVersion, extraApps),
+									extraSetup,
+									fixPermissions(phpVersion),
+									({
+										'name': 'acceptance-tests',
+										'image': 'owncloudci/php:%s' % phpVersion,
+										'pull': 'always',
+										'environment': environment,
+										'commands': [
+											'touch /var/www/owncloud/saved-settings.sh',
+											'. /var/www/owncloud/saved-settings.sh',
+											'cd /var/www/owncloud/testrunner/apps/%s' % config['app'],
+											'make test-acceptance-webui'
+										]
+									} if isWebUI else None),
+									({
+										'name': 'acceptance-tests',
+										'image': 'owncloudci/php:%s' % phpVersion,
+										'pull': 'always',
+										'environment': environment,
+										'commands': [
+											'cd /var/www/owncloud/testrunner/apps/%s' % config['app'],
+											'make test-acceptance-api'
+										]
+									} if isAPI else None),
+									({
+										'name': 'acceptance-tests',
+										'image': 'owncloudci/php:%s' % phpVersion,
+										'pull': 'always',
+										'environment': environment,
+										'commands': [
+											'cd /var/www/owncloud/testrunner/apps/%s' % config['app'],
+											'make test-acceptance-cli'
+										]
+									} if isCLI else None),
+								],
+								'services': databaseService(db)
+									+ browserService(browser)
+									+ emailService(emailNeeded)
+									+ extraServices
+									+ owncloudService(server, phpVersion, 'server', '/var/www/owncloud/server', False)
+									+ (owncloudService(server, phpVersion, 'federated', '/var/www/owncloud/federated', False) if federatedServerNeeded else []),
+								'depends_on': [],
+								'trigger': {
+									'ref': [
+										'refs/pull/**',
+										'refs/tags/**'
+									]
+								}
+							}
+
+							for branch in config['branches']:
+								result['trigger']['ref'].append('refs/heads/%s' % branch)
+
+							pipelines.append(result)
+
+	if errorFound:
+		return False
+
+	return pipelines
+
+def notify():
+	result = {
+		'kind': 'pipeline',
+		'type': 'docker',
+		'name': 'chat-notifications',
+		'clone': {
+			'disable': True
+		},
+		'steps': [
+			{
+				'name': 'notify-rocketchat',
+				'image': 'plugins/slack:1',
+				'pull': 'always',
+				'settings': {
+					'webhook': {
+						'from_secret': 'public_rocketchat'
+					},
+					'channel': config['rocketchat']
+				}
+			}
+		],
+		'depends_on': [],
+		'trigger': {
+			'ref': [
+				'refs/tags/**'
+			]
+		}
+	}
+
+	for branch in config['branches']:
+		result['trigger']['ref'].append('refs/heads/%s' % branch)
+
+	return result
+
+def databaseService(name):
+	if name.startswith('mariadb'):
+		return [{
+			'name': 'mariadb',
+			'image': name,
+			'pull': 'always',
+			'environment': {
+				'MYSQL_USER': 'owncloud',
+				'MYSQL_PASSWORD': 'owncloud',
+				'MYSQL_DATABASE': 'owncloud',
+				'MYSQL_ROOT_PASSWORD': 'owncloud'
+			}
+		}]
+
+	if name.startswith('mysql'):
+		return [{
+			'name': 'mysql',
+			'image': name,
+			'pull': 'always',
+			'environment': {
+				'MYSQL_USER': 'owncloud',
+				'MYSQL_PASSWORD': 'owncloud',
+				'MYSQL_DATABASE': 'owncloud',
+				'MYSQL_ROOT_PASSWORD': 'owncloud'
+			}
+		}]
+
+	if name.startswith('postgres'):
+		return [{
+			'name': 'postgres',
+			'image': name,
+			'pull': 'always',
+			'environment': {
+				'POSTGRES_USER': 'owncloud',
+				'POSTGRES_PASSWORD': 'owncloud',
+				'POSTGRES_DB': 'owncloud'
+			}
+		}]
+
+	if name.startswith('oracle'):
+		return [{
+			'name': 'oracle',
+			'image': 'deepdiver/docker-oracle-xe-11g:latest',
+			'pull': 'always',
+			'environment': {
+				'ORACLE_USER': 'system',
+				'ORACLE_PASSWORD': 'oracle',
+				'ORACLE_DB': 'XE',
+				'ORACLE_DISABLE_ASYNCH_IO': 'true',
+			}
+		}]
+
+	return []
+
+def browserService(name):
+	if name == 'chrome':
+		return [{
+			'name': 'selenium',
+			'image': 'selenium/standalone-chrome-debug:3.141.59-oxygen',
+			'pull': 'always',
+			'environment': {
+				'JAVA_OPTS': '-Dselenium.LOGGER.level=WARNING'
+			}
+		}]
+
+	if name == 'firefox':
+		return [{
+			'name': 'selenium',
+			'image': 'selenium/standalone-firefox-debug:3.8.1',
+			'pull': 'always',
+			'environment': {
+				'JAVA_OPTS': '-Dselenium.LOGGER.level=WARNING',
+				'SE_OPTS': '-enablePassThrough false'
+			}
+		}]
+
+	return []
+
+def emailService(emailNeeded):
+	if emailNeeded:
+		return [{
+			'name': 'email',
+			'image': 'mailhog/mailhog',
+			'pull': 'always',
+		}]
+
+	return []
+
+def owncloudService(version, phpVersion, name = 'server', path = '/var/www/owncloud/server', ssl = True):
+	if ssl:
+		environment = {
+			'APACHE_WEBROOT': path,
+			'APACHE_CONFIG_TEMPLATE': 'ssl',
+			'APACHE_SSL_CERT_CN': 'server',
+			'APACHE_SSL_CERT': '/var/www/owncloud/%s.crt' % name,
+			'APACHE_SSL_KEY': '/var/www/owncloud/%s.key' % name
+		}
+	else:
+		environment = {
+			'APACHE_WEBROOT': path
+		}
+
+	return [{
+		'name': name,
+		'image': 'owncloudci/php:%s' % phpVersion,
+		'pull': 'always',
+		'environment': environment,
+		'command': [
+			'/usr/local/bin/apachectl',
+			'-e',
+			'debug',
+			'-D',
+			'FOREGROUND'
+		]
+	}]
+
+def installCore(version, db):
+	host = db.split(':')[0]
+	name = host
+
+	username = 'owncloud'
+	password = 'owncloud'
+	database = 'owncloud'
+
+	if name == 'mariadb':
+		name = 'mysql'
+
+	if name == 'postgres':
+		name = 'pgsql'
+
+	if name == 'oracle':
+		name = 'oci'
+		username = 'system'
+		password = 'oracle'
+		database = 'XE'
+
+	return {
+		'name': 'install-core',
+		'image': 'owncloudci/core',
+		'pull': 'always',
+		'settings': {
+			'version': version,
+			'core_path': '/var/www/owncloud/server',
+			'db_type': name,
+			'db_name': database,
+			'db_host': host,
+			'db_username': username,
+			'db_password': password
+		}
+	}
+
+def installTestrunner(phpVersion):
+	return {
+		'name': 'install-testrunner',
+		'image': 'owncloudci/php:%s' % phpVersion,
+		'pull': 'always',
+		'commands': [
+			'git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner',
+			'cp -r /var/www/owncloud/server/apps/%s /var/www/owncloud/testrunner/apps/' % config['app'],
+			'cd /var/www/owncloud/testrunner',
+			'make install-composer-deps vendor-bin-deps'
+		]
+	}
+
+def installExtraApps(phpVersion, extraApps):
+	if extraApps == []:
+		return None
+
+	commandArray = []
+	for app in extraApps:
+		commandArray.append('git clone https://github.com/owncloud/%s.git /var/www/owncloud/server/apps/%s' % (app, app))
+		commandArray.append('cp -r /var/www/owncloud/server/apps/%s /var/www/owncloud/testrunner/apps/' % app)
+		commandArray.append('cd /var/www/owncloud/server')
+		commandArray.append('php occ a:l')
+		commandArray.append('php occ a:e %s' % app)
+		commandArray.append('php occ a:l')
+
+	return {
+		'name': 'install-extra-apps',
+		'image': 'owncloudci/php:%s' % phpVersion,
+		'pull': 'always',
+		'commands': commandArray
+	}
+
+def setupServerAndApp(phpVersion):
+	return {
+		'name': 'setup-server-%s' % config['app'],
+		'image': 'owncloudci/php:%s' % phpVersion,
+		'pull': 'always',
+		'commands': [
+			config['appInstallCommand'] if 'appInstallCommand' in config else ':',
+			'cd /var/www/owncloud/server',
+			'php occ a:l',
+			'php occ a:e %s' % config['app'],
+			'php occ a:e testing',
+			'php occ a:l',
+			'php occ config:system:set trusted_domains 1 --value=server',
+			'php occ log:manage --level 0',
+		]
+	}
+
+def fixPermissions(phpVersion):
+	return {
+		'name': 'fix-permissions',
+		'image': 'owncloudci/php:%s' % phpVersion,
+		'pull': 'always',
+		'commands': [
+			'chown -R www-data /var/www/owncloud',
+			'chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload',
+			'chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh'
+		]
+	}
+
+def dependsOn(earlierStages, nextStages):
+	for earlierStage in earlierStages:
+		for nextStage in nextStages:
+			nextStage['depends_on'].append(earlierStage['name'])

--- a/.drone.starlark
+++ b/.drone.starlark
@@ -741,54 +741,42 @@ def notify():
 
 	return result
 
-def databaseService(name):
-	if name.startswith('mariadb'):
+def databaseService(db):
+	dbName = getDbName(db)
+	if (dbName == 'mariadb') or (dbName == 'mysql'):
 		return [{
-			'name': 'mariadb',
-			'image': name,
+			'name': dbName,
+			'image': db,
 			'pull': 'always',
 			'environment': {
-				'MYSQL_USER': 'owncloud',
-				'MYSQL_PASSWORD': 'owncloud',
-				'MYSQL_DATABASE': 'owncloud',
-				'MYSQL_ROOT_PASSWORD': 'owncloud'
+				'MYSQL_USER': getDbUsername(db),
+				'MYSQL_PASSWORD': getDbPassword(db),
+				'MYSQL_DATABASE': getDbDatabase(db),
+				'MYSQL_ROOT_PASSWORD': getDbRootPassword()
 			}
 		}]
 
-	if name.startswith('mysql'):
+	if dbName == 'postgres':
 		return [{
-			'name': 'mysql',
-			'image': name,
+			'name': dbName,
+			'image': db,
 			'pull': 'always',
 			'environment': {
-				'MYSQL_USER': 'owncloud',
-				'MYSQL_PASSWORD': 'owncloud',
-				'MYSQL_DATABASE': 'owncloud',
-				'MYSQL_ROOT_PASSWORD': 'owncloud'
+				'POSTGRES_USER': getDbUsername(db),
+				'POSTGRES_PASSWORD': getDbPassword(db),
+				'POSTGRES_DB': getDbDatabase(db)
 			}
 		}]
 
-	if name.startswith('postgres'):
+	if dbName == 'oracle':
 		return [{
-			'name': 'postgres',
-			'image': name,
-			'pull': 'always',
-			'environment': {
-				'POSTGRES_USER': 'owncloud',
-				'POSTGRES_PASSWORD': 'owncloud',
-				'POSTGRES_DB': 'owncloud'
-			}
-		}]
-
-	if name.startswith('oracle'):
-		return [{
-			'name': 'oracle',
+			'name': dbName,
 			'image': 'deepdiver/docker-oracle-xe-11g:latest',
 			'pull': 'always',
 			'environment': {
-				'ORACLE_USER': 'system',
-				'ORACLE_PASSWORD': 'oracle',
-				'ORACLE_DB': 'XE',
+				'ORACLE_USER': getDbUsername(db),
+				'ORACLE_PASSWORD': getDbPassword(db),
+				'ORACLE_DB': getDbDatabase(db),
 				'ORACLE_DISABLE_ASYNCH_IO': 'true',
 			}
 		}]
@@ -857,25 +845,52 @@ def owncloudService(version, phpVersion, name = 'server', path = '/var/www/owncl
 		]
 	}]
 
-def installCore(version, db):
-	host = db.split(':')[0]
-	name = host
+def getDbName(db):
+	return db.split(':')[0]
 
-	username = 'owncloud'
-	password = 'owncloud'
-	database = 'owncloud'
-
-	if name == 'mariadb':
-		name = 'mysql'
-
-	if name == 'postgres':
-		name = 'pgsql'
+def getDbUsername(db):
+	name = getDbName(db)
 
 	if name == 'oracle':
-		name = 'oci'
-		username = 'system'
-		password = 'oracle'
-		database = 'XE'
+		return 'system'
+
+	return 'owncloud'
+
+def getDbPassword(db):
+	name = getDbName(db)
+
+	if name == 'oracle':
+		return 'oracle'
+
+	return 'owncloud'
+
+def getDbRootPassword():
+	return 'owncloud'
+
+def getDbDatabase(db):
+	name = getDbName(db)
+
+	if name == 'oracle':
+		return 'XE'
+
+	return 'owncloud'
+
+def installCore(version, db):
+	host = getDbName(db)
+	dbType = host
+
+	username = getDbUsername(db)
+	password = getDbPassword(db)
+	database = getDbDatabase(db)
+
+	if host == 'mariadb':
+		dbType = 'mysql'
+
+	if host == 'postgres':
+		dbType = 'pgsql'
+
+	if host == 'oracle':
+		dbType = 'oci'
 
 	return {
 		'name': 'install-core',
@@ -884,7 +899,7 @@ def installCore(version, db):
 		'settings': {
 			'version': version,
 			'core_path': '/var/www/owncloud/server',
-			'db_type': name,
+			'db_type': dbType,
 			'db_name': database,
 			'db_host': host,
 			'db_username': username,

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,1265 +1,7756 @@
+---
+kind: pipeline
+type: docker
+name: coding-standard-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
 workspace:
   base: /var/www/owncloud
-  path: apps/password_policy
+  path: server/apps/password_policy
 
+steps:
+- name: coding-standard
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - make test-php-style
 
-pipeline:
-  install-core:
-    image: owncloudci/core
-    version: ${OC_VERSION}
-    pull: true
-    db_type: ${DB_TYPE}
-    db_name: ${DB_NAME}
-    db_host: ${DB_TYPE}
-    db_username: autotest
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+---
+kind: pipeline
+type: docker
+name: phan-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: sqlite
+    db_name: owncloud
     db_password: owncloud
-    when:
-      matrix:
-        NEED_CORE: true
+    db_type: sqlite
+    db_username: owncloud
+    version: daily-master-qa
 
-  install-testrunner:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    commands:
-      - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
-      - cp -r /var/www/owncloud/apps/password_policy /var/www/owncloud/testrunner/apps/
-      - cd /var/www/owncloud/testrunner
-      - make install-composer-deps
-      - make vendor-bin-deps
-    when:
-      matrix:
-        USE_RELEASE_TARBALL: true
+- name: phan
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - make test-php-phan
 
-  install-app:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    commands:
-      - cd /var/www/owncloud/
-      - php occ a:l
-      - php occ a:e password_policy
-      - php occ a:e testing
-      - php occ a:l
-      - php occ config:system:set trusted_domains 1 --value=owncloud
-      - php occ log:manage --level 0
-      - php occ config:system:set --value true --type boolean integrity.check.disabled
-    when:
-      matrix:
-        NEED_INSTALL_APP: true
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
-  prepare-guests-app:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    commands:
-      - git clone https://github.com/owncloud/guests.git /var/www/owncloud/apps/guests
-      - if [ "${USE_RELEASE_TARBALL}" = "true" ];
-        then
-        cp -r /var/www/owncloud/apps/guests /var/www/owncloud/testrunner/apps/;
-        fi
-      - cd /var/www/owncloud/
-      - php occ a:l
-      - php occ a:e guests
-      - php occ a:l
-    when:
-      matrix:
-        NEED_GUESTS_APP: true
+---
+kind: pipeline
+type: docker
+name: phan-php7.1
 
-  fix-permissions:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    commands:
-      - chown www-data /var/www/owncloud -R
-      - if [ "${USE_RELEASE_TARBALL}" = "true" ];
-        then
-        chmod 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload -R;
-        chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh;
-        else
-        chmod 777 /var/www/owncloud/tests/acceptance/filesForUpload -R;
-        chmod +x /var/www/owncloud/tests/acceptance/run.sh;
-        fi
-    when:
-      matrix:
-        NEED_SERVER: true
+platform:
+  os: linux
+  arch: amd64
 
-  owncloud-log:
-    image: owncloud/ubuntu:16.04
-    detach: true
-    pull: true
-    commands:
-      - tail -f /var/www/owncloud/data/owncloud.log
-    when:
-      matrix:
-        NEED_SERVER: true
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
 
-  owncloud-coding-standard:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    commands:
-      - make test-php-style
-    when:
-      matrix:
-        TEST_SUITE: owncloud-coding-standard
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: sqlite
+    db_name: owncloud
+    db_password: owncloud
+    db_type: sqlite
+    db_username: owncloud
+    version: daily-master-qa
 
-  phpstan:
-    # phpstan requires php7.1
-    image: owncloudci/php:7.1
-    pull: true
-    environment:
-      - COMPOSER_HOME=/var/www/owncloud/apps/password_policy/.cache/composer
-    commands:
-      - make test-php-phpstan
-    when:
-      matrix:
-        TEST_SUITE: phpstan
+- name: phan
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make test-php-phan
 
-  phan-70:
-    # phan requires a recent php-ast extension
-    image: owncloudci/php:7.0
-    pull: true
-    environment:
-      - COMPOSER_HOME=/var/www/owncloud/apps/password_policy/.cache/composer
-    commands:
-      - make test-php-phan
-    when:
-      matrix:
-        TEST_SUITE: phan-70
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
-  phan-71:
-    # phan requires a recent php-ast extension
-    image: owncloudci/php:7.1
-    pull: true
-    environment:
-      - COMPOSER_HOME=/var/www/owncloud/apps/password_policy/.cache/composer
-    commands:
-      - make test-php-phan
-    when:
-      matrix:
-        TEST_SUITE: phan
+---
+kind: pipeline
+type: docker
+name: phan-php7.2
 
-  phan-72:
-    # phan requires a recent php-ast extension
-    image: owncloudci/php:7.2
-    pull: true
-    environment:
-      - COMPOSER_HOME=/var/www/owncloud/apps/password_policy/.cache/composer
-    commands:
-      - make test-php-phan
-    when:
-      matrix:
-        TEST_SUITE: phan
+platform:
+  os: linux
+  arch: amd64
 
-  phan-73:
-    # phan requires a recent php-ast extension
-    image: owncloudci/php:7.3
-    pull: true
-    environment:
-      - COMPOSER_HOME=/var/www/owncloud/apps/password_policy/.cache/composer
-    commands:
-      - make test-php-phan
-    when:
-      matrix:
-        TEST_SUITE: phan
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
 
-  phpunit-tests:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    environment:
-      - COVERAGE=${COVERAGE}
-    commands:
-      - if [ -z "${COVERAGE}" ]; then make test-php-unit; fi
-      - if [ "${COVERAGE}" = "true" ]; then make test-php-unit-dbg; fi
-    when:
-      matrix:
-        TEST_SUITE: phpunit
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: sqlite
+    db_name: owncloud
+    db_password: owncloud
+    db_type: sqlite
+    db_username: owncloud
+    version: daily-master-qa
 
-  api-acceptance-tests:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    environment:
-      - TEST_SERVER_URL=http://owncloud
-      - PLATFORM=Linux
-      - MAILHOG_HOST=email
-      - BEHAT_SUITE=${BEHAT_SUITE}
-    commands:
-      - if [ "${USE_RELEASE_TARBALL}" = "true" ]; then cd /var/www/owncloud/testrunner/apps/password_policy; fi
-      - make test-acceptance-api
-    when:
-      matrix:
-        TEST_SUITE: api-acceptance
+- name: phan
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - make test-php-phan
 
-  cli-acceptance-tests:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    environment:
-      - TEST_SERVER_URL=http://owncloud
-      - PLATFORM=Linux
-      - BEHAT_SUITE=${BEHAT_SUITE}
-    commands:
-      - if [ "${USE_RELEASE_TARBALL}" = "true" ]; then cd /var/www/owncloud/testrunner/apps/password_policy; fi
-      - make test-acceptance-cli
-    when:
-      matrix:
-        TEST_SUITE: cli-acceptance
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
-  webui-acceptance-tests:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    environment:
-      - BROWSER=chrome
-      - SELENIUM_HOST=selenium
-      - SELENIUM_PORT=4444
-      - TEST_SERVER_URL=http://owncloud
-      - PLATFORM=Linux
-      - BEHAT_SUITE=${BEHAT_SUITE}
-      - MAILHOG_HOST=email
-    commands:
-      - if [ "${USE_RELEASE_TARBALL}" = "true" ]; then cd /var/www/owncloud/testrunner/apps/password_policy; fi
-      - make test-acceptance-webui
-    when:
-      matrix:
-        TEST_SUITE: web-acceptance
+---
+kind: pipeline
+type: docker
+name: phan-php7.3
 
-  codecov:
-    image: plugins/codecov:2
-    secrets: [codecov_token]
-    pull: true
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: sqlite
+    db_name: owncloud
+    db_password: owncloud
+    db_type: sqlite
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: phan
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - make test-php-phan
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.0-sqlite
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: sqlite
+    db_name: owncloud
+    db_password: owncloud
+    db_type: sqlite
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - make test-php-unit-dbg
+
+- name: codecov-upload
+  pull: always
+  image: plugins/codecov:2
+  settings:
     paths:
-      - tests/output/*.xml
-    when:
-      matrix:
-        COVERAGE: true
+    - tests/output/clover.xml
+    token:
+      from_secret: codecov_token
 
-  notify:
-    image: plugins/slack:1
-    pull: true
-    secrets: [slack_webhook]
-    channel: builds
-    when:
-      status: [failure, changed]
-      event: [push, tag]
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.0-mariadb10.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - make test-php-unit-dbg
+
+- name: codecov-upload
+  pull: always
+  image: plugins/codecov:2
+  settings:
+    paths:
+    - tests/output/clover.xml
+    token:
+      from_secret: codecov_token
 
 services:
-  mysql:
-    image: mysql:5.5
-    environment:
-      - MYSQL_USER=autotest
-      - MYSQL_PASSWORD=owncloud
-      - MYSQL_DATABASE=${DB_NAME}
-      - MYSQL_ROOT_PASSWORD=owncloud
-    when:
-      matrix:
-        DB_TYPE: mysql
-
-  pgsql:
-    image: postgres:9.4
-    environment:
-      - POSTGRES_USER=autotest
-      - POSTGRES_PASSWORD=owncloud
-      - POSTGRES_DB=${DB_NAME}
-    when:
-      matrix:
-        DB_TYPE: pgsql
-
-  oci:
-    image: deepdiver/docker-oracle-xe-11g
-    environment:
-      - ORACLE_USER=system
-      - ORACLE_PASSWORD=oracle
-      - ORACLE_DB=${DB_NAME}
-    when:
-      matrix:
-        DB_TYPE: oci
-
-  owncloud:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    environment:
-      - APACHE_WEBROOT=/var/www/owncloud/
-    command: ["/usr/local/bin/apachectl", "-e", "debug", "-D", "FOREGROUND"]
-    when:
-      matrix:
-        NEED_SERVER: true
-
-  selenium:
-    image: selenium/standalone-chrome-debug:3.141.59-oxygen
-    pull: true
-    when:
-      matrix:
-        TEST_SUITE: web-acceptance
-
-  email:
-    image: mailhog/mailhog
-    pull: true
-    when:
-      matrix:
-        USE_EMAIL: true
-
-matrix:
-  include:
-    # owncloud-coding-standard
-    - PHP_VERSION: 7.0
-      TEST_SUITE: owncloud-coding-standard
-
-    # phan
-    - PHP_VERSION: 7.0
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: phan-70
-      DB_TYPE: sqlite
-      DB_NAME: owncloud
-      NEED_CORE: true
-
-    - PHP_VERSION: 7.2
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: phan
-      DB_TYPE: sqlite
-      DB_NAME: owncloud
-      NEED_CORE: true
-
-    # Unit Tests
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: phpunit
-      DB_TYPE: sqlite
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: phpunit
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: phpunit
-      DB_TYPE: pgsql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: phpunit
-      DB_TYPE: oci
-      DB_NAME: XE
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.2
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: phpunit
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.3
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: phpunit
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: phpunit
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    #API acceptance tests
-    #PHP 7.0 with core master
-    - PHP_VERSION: 7.0
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiPasswordAddUser
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiPasswordAddUserSpecial
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiPasswordChange
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiPasswordChangeSpecial
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiUpdateShare
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiGuests
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      NEED_GUESTS_APP: true
-      USE_EMAIL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: cli-acceptance
-      BEHAT_SUITE: cliPasswordAddUser
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: cli-acceptance
-      BEHAT_SUITE: cliPasswordChange
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    #PHP 7.1 with core master
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiPasswordAddUser
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiPasswordAddUserSpecial
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiPasswordChange
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiPasswordChangeSpecial
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiUpdateShare
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiGuests
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      NEED_GUESTS_APP: true
-      USE_EMAIL: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: cli-acceptance
-      BEHAT_SUITE: cliPasswordAddUser
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: cli-acceptance
-      BEHAT_SUITE: cliPasswordChange
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    #PHP 7.1 with core master and Oracle
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiPasswordAddUser
-      DB_TYPE: oci
-      DB_NAME: XE
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiPasswordAddUserSpecial
-      DB_TYPE: oci
-      DB_NAME: XE
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiPasswordChange
-      DB_TYPE: oci
-      DB_NAME: XE
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiPasswordChangeSpecial
-      DB_TYPE: oci
-      DB_NAME: XE
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiUpdateShare
-      DB_TYPE: oci
-      DB_NAME: XE
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiGuests
-      DB_TYPE: oci
-      DB_NAME: XE
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      NEED_GUESTS_APP: true
-      USE_EMAIL: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: cli-acceptance
-      BEHAT_SUITE: cliPasswordAddUser
-      DB_TYPE: oci
-      DB_NAME: XE
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: cli-acceptance
-      BEHAT_SUITE: cliPasswordChange
-      DB_TYPE: oci
-      DB_NAME: XE
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    #PHP 7.2 with core master
-    - PHP_VERSION: 7.2
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiPasswordAddUser
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.2
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiPasswordAddUserSpecial
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.2
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiPasswordChange
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.2
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiPasswordChangeSpecial
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.2
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiUpdateShare
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.2
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiGuests
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      NEED_GUESTS_APP: true
-      USE_EMAIL: true
-
-    - PHP_VERSION: 7.2
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: cli-acceptance
-      BEHAT_SUITE: cliPasswordAddUser
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.2
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: cli-acceptance
-      BEHAT_SUITE: cliPasswordChange
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-
-    #webUI acceptance tests
-    #PHP 7.0 with core master
-    - PHP_VERSION: 7.0
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIPasswordAddUser
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_EMAIL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIPasswordAddUserSpecial
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_EMAIL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIPasswordChange
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIPasswordChangeSpecial
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIPasswordPolicySettings
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIPasswordReset
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_EMAIL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIPublicShareLink
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIGuests
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      NEED_GUESTS_APP: true
-      USE_EMAIL: true
-
-    #PHP 7.1 with core master
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIPasswordChange
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIPasswordChangeSpecial
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIPasswordPolicySettings
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIPasswordReset
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_EMAIL: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIPublicShareLink
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIGuests
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      NEED_GUESTS_APP: true
-      USE_EMAIL: true
-
-    #PHP 7.2 with core master
-    - PHP_VERSION: 7.2
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIPasswordChange
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.2
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIPasswordChangeSpecial
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.2
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIPasswordPolicySettings
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.2
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIPasswordReset
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_EMAIL: true
-
-    - PHP_VERSION: 7.2
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIPublicShareLink
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 7.2
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIGuests
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      NEED_GUESTS_APP: true
-      USE_EMAIL: true
-
-    # Acceptance test against release 10.2.1 tarball
-    # Note: do not run apiGuests because the guests app now requires core 10.3
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: 10.2.1
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiPasswordAddUser
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_RELEASE_TARBALL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: 10.2.1
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiPasswordAddUserSpecial
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_RELEASE_TARBALL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: 10.2.1
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiPasswordChange
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_RELEASE_TARBALL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: 10.2.1
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiPasswordChangeSpecial
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_RELEASE_TARBALL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: 10.2.1
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiUpdateShare
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_RELEASE_TARBALL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: 10.2.1
-      TEST_SUITE: cli-acceptance
-      BEHAT_SUITE: cliPasswordAddUser
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_RELEASE_TARBALL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: 10.2.1
-      TEST_SUITE: cli-acceptance
-      BEHAT_SUITE: cliPasswordChange
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_RELEASE_TARBALL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: 10.2.1
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIPasswordAddUser
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_EMAIL: true
-      USE_RELEASE_TARBALL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: 10.2.1
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIPasswordAddUserSpecial
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_EMAIL: true
-      USE_RELEASE_TARBALL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: 10.2.1
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIPasswordChange
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_RELEASE_TARBALL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: 10.2.1
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIPasswordChangeSpecial
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_RELEASE_TARBALL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: 10.2.1
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIPasswordPolicySettings
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_RELEASE_TARBALL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: 10.2.1
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIPasswordReset
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_EMAIL: true
-      USE_RELEASE_TARBALL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: 10.2.1
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIPublicShareLink
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_RELEASE_TARBALL: true
-
-    # Acceptance test against 10.3.0alpha tarball
-    - PHP_VERSION: 7.0
-      OC_VERSION: 10.3.0alpha
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiGuests
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      NEED_GUESTS_APP: true
-      USE_RELEASE_TARBALL: true
-      USE_EMAIL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: 10.3.0alpha
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiPasswordAddUser
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_RELEASE_TARBALL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: 10.3.0alpha
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiPasswordAddUserSpecial
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_RELEASE_TARBALL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: 10.3.0alpha
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiPasswordChange
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_RELEASE_TARBALL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: 10.3.0alpha
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiPasswordChangeSpecial
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_RELEASE_TARBALL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: 10.3.0alpha
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiUpdateShare
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_RELEASE_TARBALL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: 10.3.0alpha
-      TEST_SUITE: cli-acceptance
-      BEHAT_SUITE: cliPasswordAddUser
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_RELEASE_TARBALL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: 10.3.0alpha
-      TEST_SUITE: cli-acceptance
-      BEHAT_SUITE: cliPasswordChange
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_RELEASE_TARBALL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: 10.3.0alpha
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIGuests
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      NEED_GUESTS_APP: true
-      USE_RELEASE_TARBALL: true
-      USE_EMAIL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: 10.3.0alpha
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIPasswordAddUser
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_EMAIL: true
-      USE_RELEASE_TARBALL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: 10.3.0alpha
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIPasswordAddUserSpecial
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_EMAIL: true
-      USE_RELEASE_TARBALL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: 10.3.0alpha
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIPasswordChange
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_RELEASE_TARBALL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: 10.3.0alpha
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIPasswordChangeSpecial
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_RELEASE_TARBALL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: 10.3.0alpha
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIPasswordPolicySettings
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_RELEASE_TARBALL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: 10.3.0alpha
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIPasswordReset
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_EMAIL: true
-      USE_RELEASE_TARBALL: true
-
-    - PHP_VERSION: 7.0
-      OC_VERSION: 10.3.0alpha
-      TEST_SUITE: web-acceptance
-      BEHAT_SUITE: webUIPublicShareLink
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      USE_RELEASE_TARBALL: true
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.0-mysql5.5
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - make test-php-unit-dbg
+
+- name: codecov-upload
+  pull: always
+  image: plugins/codecov:2
+  settings:
+    paths:
+    - tests/output/clover.xml
+    token:
+      from_secret: codecov_token
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.5
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.0-mysql5.7
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - make test-php-unit-dbg
+
+- name: codecov-upload
+  pull: always
+  image: plugins/codecov:2
+  settings:
+    paths:
+    - tests/output/clover.xml
+    token:
+      from_secret: codecov_token
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.0-postgres9.4
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: postgres
+    db_name: owncloud
+    db_password: owncloud
+    db_type: pgsql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - make test-php-unit-dbg
+
+- name: codecov-upload
+  pull: always
+  image: plugins/codecov:2
+  settings:
+    paths:
+    - tests/output/clover.xml
+    token:
+      from_secret: codecov_token
+
+services:
+- name: postgres
+  pull: always
+  image: postgres:9.4
+  environment:
+    POSTGRES_DB: owncloud
+    POSTGRES_PASSWORD: owncloud
+    POSTGRES_USER: owncloud
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.0-oracle
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    version: daily-master-qa
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - make test-php-unit-dbg
+
+- name: codecov-upload
+  pull: always
+  image: plugins/codecov:2
+  settings:
+    paths:
+    - tests/output/clover.xml
+    token:
+      from_secret: codecov_token
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.1-sqlite
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: sqlite
+    db_name: owncloud
+    db_password: owncloud
+    db_type: sqlite
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make test-php-unit
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.1-mariadb10.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make test-php-unit
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.2-sqlite
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: sqlite
+    db_name: owncloud
+    db_password: owncloud
+    db_type: sqlite
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - make test-php-unit
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.2-mariadb10.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - make test-php-unit
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.3-sqlite
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: sqlite
+    db_name: owncloud
+    db_password: owncloud
+    db_type: sqlite
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - make test-php-unit
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.3-mariadb10.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - make test-php-unit
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPwdAddUser-master-chrome-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordAddUser
+    BROWSER: chrome
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPwdAddUser-master-firefox-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordAddUser
+    BROWSER: firefox
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-firefox-debug:3.8.1
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+    SE_OPTS: -enablePassThrough false
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPwdAddUser-10.2.1-chrome-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: 10.2.1
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordAddUser
+    BROWSER: chrome
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPwdAddUser-10.2.1-firefox-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: 10.2.1
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordAddUser
+    BROWSER: firefox
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-firefox-debug:3.8.1
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+    SE_OPTS: -enablePassThrough false
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPwdAddUsSp-master-chrome-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordAddUserSpecial
+    BROWSER: chrome
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPwdAddUsSp-master-firefox-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordAddUserSpecial
+    BROWSER: firefox
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-firefox-debug:3.8.1
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+    SE_OPTS: -enablePassThrough false
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPwdAddUsSp-10.2.1-chrome-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: 10.2.1
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordAddUserSpecial
+    BROWSER: chrome
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPwdAddUsSp-10.2.1-firefox-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: 10.2.1
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordAddUserSpecial
+    BROWSER: firefox
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-firefox-debug:3.8.1
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+    SE_OPTS: -enablePassThrough false
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPwdReset-master-chrome-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordReset
+    BROWSER: chrome
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPwdReset-master-firefox-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordReset
+    BROWSER: firefox
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-firefox-debug:3.8.1
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+    SE_OPTS: -enablePassThrough false
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPwdReset-10.2.1-chrome-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: 10.2.1
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordReset
+    BROWSER: chrome
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPwdReset-10.2.1-firefox-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: 10.2.1
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordReset
+    BROWSER: firefox
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-firefox-debug:3.8.1
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+    SE_OPTS: -enablePassThrough false
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIGuests-master-chrome-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: install-extra-apps
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone https://github.com/owncloud/guests.git /var/www/owncloud/server/apps/guests
+  - cp -r /var/www/owncloud/server/apps/guests /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e guests
+  - php occ a:l
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIGuests
+    BROWSER: chrome
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIGuests-master-firefox-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: install-extra-apps
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone https://github.com/owncloud/guests.git /var/www/owncloud/server/apps/guests
+  - cp -r /var/www/owncloud/server/apps/guests /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e guests
+  - php occ a:l
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIGuests
+    BROWSER: firefox
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-firefox-debug:3.8.1
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+    SE_OPTS: -enablePassThrough false
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIGuests-10.3.0alpha-chrome-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: 10.3.0alpha
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: install-extra-apps
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone https://github.com/owncloud/guests.git /var/www/owncloud/server/apps/guests
+  - cp -r /var/www/owncloud/server/apps/guests /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e guests
+  - php occ a:l
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIGuests
+    BROWSER: chrome
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIGuests-10.3.0alpha-firefox-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: 10.3.0alpha
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: install-extra-apps
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone https://github.com/owncloud/guests.git /var/www/owncloud/server/apps/guests
+  - cp -r /var/www/owncloud/server/apps/guests /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e guests
+  - php occ a:l
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIGuests
+    BROWSER: firefox
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-firefox-debug:3.8.1
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+    SE_OPTS: -enablePassThrough false
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPwdChange-master-chrome-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordChange
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPwdChange-master-firefox-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordChange
+    BROWSER: firefox
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-firefox-debug:3.8.1
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+    SE_OPTS: -enablePassThrough false
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPwdChange-10.2.1-chrome-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: 10.2.1
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordChange
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPwdChange-10.2.1-firefox-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: 10.2.1
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordChange
+    BROWSER: firefox
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-firefox-debug:3.8.1
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+    SE_OPTS: -enablePassThrough false
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPwdChangeSp-master-chrome-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordChangeSpecial
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPwdChangeSp-master-firefox-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordChangeSpecial
+    BROWSER: firefox
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-firefox-debug:3.8.1
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+    SE_OPTS: -enablePassThrough false
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPwdChangeSp-10.2.1-chrome-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: 10.2.1
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordChangeSpecial
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPwdChangeSp-10.2.1-firefox-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: 10.2.1
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordChangeSpecial
+    BROWSER: firefox
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-firefox-debug:3.8.1
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+    SE_OPTS: -enablePassThrough false
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPwdPolSet-master-chrome-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordPolicySettings
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPwdPolSet-master-firefox-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordPolicySettings
+    BROWSER: firefox
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-firefox-debug:3.8.1
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+    SE_OPTS: -enablePassThrough false
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPwdPolSet-10.2.1-chrome-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: 10.2.1
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordPolicySettings
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPwdPolSet-10.2.1-firefox-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: 10.2.1
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordPolicySettings
+    BROWSER: firefox
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-firefox-debug:3.8.1
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+    SE_OPTS: -enablePassThrough false
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPublicShare-master-chrome-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPublicShareLink
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPublicShare-master-firefox-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPublicShareLink
+    BROWSER: firefox
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-firefox-debug:3.8.1
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+    SE_OPTS: -enablePassThrough false
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPublicShare-10.2.1-chrome-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: 10.2.1
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPublicShareLink
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPublicShare-10.2.1-firefox-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: 10.2.1
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPublicShareLink
+    BROWSER: firefox
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-firefox-debug:3.8.1
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+    SE_OPTS: -enablePassThrough false
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiGuests-master-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: install-extra-apps
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone https://github.com/owncloud/guests.git /var/www/owncloud/server/apps/guests
+  - cp -r /var/www/owncloud/server/apps/guests /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e guests
+  - php occ a:l
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiGuests
+    MAILHOG_HOST: email
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiGuests-master-oracle-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: install-extra-apps
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone https://github.com/owncloud/guests.git /var/www/owncloud/server/apps/guests
+  - cp -r /var/www/owncloud/server/apps/guests /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e guests
+  - php occ a:l
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiGuests
+    MAILHOG_HOST: email
+    TEST_SERVER_URL: http://server
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiGuests-10.3.0alpha-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: 10.3.0alpha
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: install-extra-apps
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone https://github.com/owncloud/guests.git /var/www/owncloud/server/apps/guests
+  - cp -r /var/www/owncloud/server/apps/guests /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e guests
+  - php occ a:l
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiGuests
+    MAILHOG_HOST: email
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiGuests-10.3.0alpha-oracle-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    version: 10.3.0alpha
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: install-extra-apps
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone https://github.com/owncloud/guests.git /var/www/owncloud/server/apps/guests
+  - cp -r /var/www/owncloud/server/apps/guests /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e guests
+  - php occ a:l
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiGuests
+    MAILHOG_HOST: email
+    TEST_SERVER_URL: http://server
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiPwdAddUser-master-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiPasswordAddUser
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiPwdAddUser-master-oracle-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiPasswordAddUser
+    TEST_SERVER_URL: http://server
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiPwdAddUser-10.2.1-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: 10.2.1
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiPasswordAddUser
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiPwdAddUser-10.2.1-oracle-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    version: 10.2.1
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiPasswordAddUser
+    TEST_SERVER_URL: http://server
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiPwdAddUserSpecial-master-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiPasswordAddUserSpecial
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiPwdAddUserSpecial-master-oracle-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiPasswordAddUserSpecial
+    TEST_SERVER_URL: http://server
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiPwdAddUserSpecial-10.2.1-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: 10.2.1
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiPasswordAddUserSpecial
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiPwdAddUserSpecial-10.2.1-oracle-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    version: 10.2.1
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiPasswordAddUserSpecial
+    TEST_SERVER_URL: http://server
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiPwdChange-master-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiPasswordChange
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiPwdChange-master-oracle-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiPasswordChange
+    TEST_SERVER_URL: http://server
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiPwdChange-10.2.1-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: 10.2.1
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiPasswordChange
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiPwdChange-10.2.1-oracle-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    version: 10.2.1
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiPasswordChange
+    TEST_SERVER_URL: http://server
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiPwdChangeSpecial-master-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiPasswordChangeSpecial
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiPwdChangeSpecial-master-oracle-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiPasswordChangeSpecial
+    TEST_SERVER_URL: http://server
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiPwdChangeSpecial-10.2.1-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: 10.2.1
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiPasswordChangeSpecial
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiPwdChangeSpecial-10.2.1-oracle-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    version: 10.2.1
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiPasswordChangeSpecial
+    TEST_SERVER_URL: http://server
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUpdateShare-master-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUpdateShare
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUpdateShare-master-oracle-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUpdateShare
+    TEST_SERVER_URL: http://server
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUpdateShare-10.2.1-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: 10.2.1
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUpdateShare
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUpdateShare-10.2.1-oracle-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    version: 10.2.1
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUpdateShare
+    TEST_SERVER_URL: http://server
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: cliPasswordAddUser-master-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-cli
+  environment:
+    BEHAT_SUITE: cliPasswordAddUser
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: cliPasswordAddUser-10.2.1-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: 10.2.1
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-cli
+  environment:
+    BEHAT_SUITE: cliPasswordAddUser
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: cliPasswordChange-master-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-cli
+  environment:
+    BEHAT_SUITE: cliPasswordChange
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: cliPasswordChange-10.2.1-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: 10.2.1
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+  - cp -r /var/www/owncloud/server/apps/password_policy /var/www/owncloud/testrunner/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - ":"
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 0
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud
+  - chmod -R 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload
+  - chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/testrunner/apps/password_policy
+  - make test-acceptance-cli
+  environment:
+    BEHAT_SUITE: cliPasswordChange
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: chat-notifications
+
+platform:
+  os: linux
+  arch: amd64
+
+clone:
+  disable: true
+
+steps:
+- name: notify-rocketchat
+  pull: always
+  image: plugins/slack:1
+  settings:
+    channel: builds
+    webhook:
+      from_secret: public_rocketchat
+
+trigger:
+  ref:
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- phpunit-php7.0-sqlite
+- phpunit-php7.0-mariadb10.2
+- phpunit-php7.0-mysql5.5
+- phpunit-php7.0-mysql5.7
+- phpunit-php7.0-postgres9.4
+- phpunit-php7.0-oracle
+- phpunit-php7.1-sqlite
+- phpunit-php7.1-mariadb10.2
+- phpunit-php7.2-sqlite
+- phpunit-php7.2-mariadb10.2
+- phpunit-php7.3-sqlite
+- phpunit-php7.3-mariadb10.2
+- webUIPwdAddUser-master-chrome-mariadb10.2-php7.0
+- webUIPwdAddUser-master-firefox-mariadb10.2-php7.0
+- webUIPwdAddUser-10.2.1-chrome-mariadb10.2-php7.0
+- webUIPwdAddUser-10.2.1-firefox-mariadb10.2-php7.0
+- webUIPwdAddUsSp-master-chrome-mariadb10.2-php7.0
+- webUIPwdAddUsSp-master-firefox-mariadb10.2-php7.0
+- webUIPwdAddUsSp-10.2.1-chrome-mariadb10.2-php7.0
+- webUIPwdAddUsSp-10.2.1-firefox-mariadb10.2-php7.0
+- webUIPwdReset-master-chrome-mariadb10.2-php7.0
+- webUIPwdReset-master-firefox-mariadb10.2-php7.0
+- webUIPwdReset-10.2.1-chrome-mariadb10.2-php7.0
+- webUIPwdReset-10.2.1-firefox-mariadb10.2-php7.0
+- webUIGuests-master-chrome-mariadb10.2-php7.0
+- webUIGuests-master-firefox-mariadb10.2-php7.0
+- webUIGuests-10.3.0alpha-chrome-mariadb10.2-php7.0
+- webUIGuests-10.3.0alpha-firefox-mariadb10.2-php7.0
+- webUIPwdChange-master-chrome-mariadb10.2-php7.0
+- webUIPwdChange-master-firefox-mariadb10.2-php7.0
+- webUIPwdChange-10.2.1-chrome-mariadb10.2-php7.0
+- webUIPwdChange-10.2.1-firefox-mariadb10.2-php7.0
+- webUIPwdChangeSp-master-chrome-mariadb10.2-php7.0
+- webUIPwdChangeSp-master-firefox-mariadb10.2-php7.0
+- webUIPwdChangeSp-10.2.1-chrome-mariadb10.2-php7.0
+- webUIPwdChangeSp-10.2.1-firefox-mariadb10.2-php7.0
+- webUIPwdPolSet-master-chrome-mariadb10.2-php7.0
+- webUIPwdPolSet-master-firefox-mariadb10.2-php7.0
+- webUIPwdPolSet-10.2.1-chrome-mariadb10.2-php7.0
+- webUIPwdPolSet-10.2.1-firefox-mariadb10.2-php7.0
+- webUIPublicShare-master-chrome-mariadb10.2-php7.0
+- webUIPublicShare-master-firefox-mariadb10.2-php7.0
+- webUIPublicShare-10.2.1-chrome-mariadb10.2-php7.0
+- webUIPublicShare-10.2.1-firefox-mariadb10.2-php7.0
+- apiGuests-master-mariadb10.2-php7.0
+- apiGuests-master-oracle-php7.0
+- apiGuests-10.3.0alpha-mariadb10.2-php7.0
+- apiGuests-10.3.0alpha-oracle-php7.0
+- apiPwdAddUser-master-mariadb10.2-php7.0
+- apiPwdAddUser-master-oracle-php7.0
+- apiPwdAddUser-10.2.1-mariadb10.2-php7.0
+- apiPwdAddUser-10.2.1-oracle-php7.0
+- apiPwdAddUserSpecial-master-mariadb10.2-php7.0
+- apiPwdAddUserSpecial-master-oracle-php7.0
+- apiPwdAddUserSpecial-10.2.1-mariadb10.2-php7.0
+- apiPwdAddUserSpecial-10.2.1-oracle-php7.0
+- apiPwdChange-master-mariadb10.2-php7.0
+- apiPwdChange-master-oracle-php7.0
+- apiPwdChange-10.2.1-mariadb10.2-php7.0
+- apiPwdChange-10.2.1-oracle-php7.0
+- apiPwdChangeSpecial-master-mariadb10.2-php7.0
+- apiPwdChangeSpecial-master-oracle-php7.0
+- apiPwdChangeSpecial-10.2.1-mariadb10.2-php7.0
+- apiPwdChangeSpecial-10.2.1-oracle-php7.0
+- apiUpdateShare-master-mariadb10.2-php7.0
+- apiUpdateShare-master-oracle-php7.0
+- apiUpdateShare-10.2.1-mariadb10.2-php7.0
+- apiUpdateShare-10.2.1-oracle-php7.0
+- cliPasswordAddUser-master-mariadb10.2-php7.0
+- cliPasswordAddUser-10.2.1-mariadb10.2-php7.0
+- cliPasswordChange-master-mariadb10.2-php7.0
+- cliPasswordChange-10.2.1-mariadb10.2-php7.0
+
+...

--- a/.drone.yml
+++ b/.drone.yml
@@ -4832,6 +4832,8 @@ steps:
   pull: always
   image: owncloudci/php:7.0
   commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/testrunner/apps/password_policy
   - make test-acceptance-api
   environment:
@@ -4949,6 +4951,8 @@ steps:
   pull: always
   image: owncloudci/php:7.0
   commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/testrunner/apps/password_policy
   - make test-acceptance-api
   environment:
@@ -5066,6 +5070,8 @@ steps:
   pull: always
   image: owncloudci/php:7.0
   commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/testrunner/apps/password_policy
   - make test-acceptance-api
   environment:
@@ -5183,6 +5189,8 @@ steps:
   pull: always
   image: owncloudci/php:7.0
   commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/testrunner/apps/password_policy
   - make test-acceptance-api
   environment:
@@ -5289,6 +5297,8 @@ steps:
   pull: always
   image: owncloudci/php:7.0
   commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/testrunner/apps/password_policy
   - make test-acceptance-api
   environment:
@@ -5390,6 +5400,8 @@ steps:
   pull: always
   image: owncloudci/php:7.0
   commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/testrunner/apps/password_policy
   - make test-acceptance-api
   environment:
@@ -5491,6 +5503,8 @@ steps:
   pull: always
   image: owncloudci/php:7.0
   commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/testrunner/apps/password_policy
   - make test-acceptance-api
   environment:
@@ -5592,6 +5606,8 @@ steps:
   pull: always
   image: owncloudci/php:7.0
   commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/testrunner/apps/password_policy
   - make test-acceptance-api
   environment:
@@ -5693,6 +5709,8 @@ steps:
   pull: always
   image: owncloudci/php:7.0
   commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/testrunner/apps/password_policy
   - make test-acceptance-api
   environment:
@@ -5794,6 +5812,8 @@ steps:
   pull: always
   image: owncloudci/php:7.0
   commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/testrunner/apps/password_policy
   - make test-acceptance-api
   environment:
@@ -5895,6 +5915,8 @@ steps:
   pull: always
   image: owncloudci/php:7.0
   commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/testrunner/apps/password_policy
   - make test-acceptance-api
   environment:
@@ -5996,6 +6018,8 @@ steps:
   pull: always
   image: owncloudci/php:7.0
   commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/testrunner/apps/password_policy
   - make test-acceptance-api
   environment:
@@ -6097,6 +6121,8 @@ steps:
   pull: always
   image: owncloudci/php:7.0
   commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/testrunner/apps/password_policy
   - make test-acceptance-api
   environment:
@@ -6198,6 +6224,8 @@ steps:
   pull: always
   image: owncloudci/php:7.0
   commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/testrunner/apps/password_policy
   - make test-acceptance-api
   environment:
@@ -6299,6 +6327,8 @@ steps:
   pull: always
   image: owncloudci/php:7.0
   commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/testrunner/apps/password_policy
   - make test-acceptance-api
   environment:
@@ -6400,6 +6430,8 @@ steps:
   pull: always
   image: owncloudci/php:7.0
   commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/testrunner/apps/password_policy
   - make test-acceptance-api
   environment:
@@ -6501,6 +6533,8 @@ steps:
   pull: always
   image: owncloudci/php:7.0
   commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/testrunner/apps/password_policy
   - make test-acceptance-api
   environment:
@@ -6602,6 +6636,8 @@ steps:
   pull: always
   image: owncloudci/php:7.0
   commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/testrunner/apps/password_policy
   - make test-acceptance-api
   environment:
@@ -6703,6 +6739,8 @@ steps:
   pull: always
   image: owncloudci/php:7.0
   commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/testrunner/apps/password_policy
   - make test-acceptance-api
   environment:
@@ -6804,6 +6842,8 @@ steps:
   pull: always
   image: owncloudci/php:7.0
   commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/testrunner/apps/password_policy
   - make test-acceptance-api
   environment:
@@ -6905,6 +6945,8 @@ steps:
   pull: always
   image: owncloudci/php:7.0
   commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/testrunner/apps/password_policy
   - make test-acceptance-api
   environment:
@@ -7006,6 +7048,8 @@ steps:
   pull: always
   image: owncloudci/php:7.0
   commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/testrunner/apps/password_policy
   - make test-acceptance-api
   environment:
@@ -7107,6 +7151,8 @@ steps:
   pull: always
   image: owncloudci/php:7.0
   commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/testrunner/apps/password_policy
   - make test-acceptance-api
   environment:
@@ -7208,6 +7254,8 @@ steps:
   pull: always
   image: owncloudci/php:7.0
   commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/testrunner/apps/password_policy
   - make test-acceptance-api
   environment:
@@ -7309,6 +7357,8 @@ steps:
   pull: always
   image: owncloudci/php:7.0
   commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/testrunner/apps/password_policy
   - make test-acceptance-cli
   environment:
@@ -7410,6 +7460,8 @@ steps:
   pull: always
   image: owncloudci/php:7.0
   commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/testrunner/apps/password_policy
   - make test-acceptance-cli
   environment:
@@ -7511,6 +7563,8 @@ steps:
   pull: always
   image: owncloudci/php:7.0
   commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/testrunner/apps/password_policy
   - make test-acceptance-cli
   environment:
@@ -7612,6 +7666,8 @@ steps:
   pull: always
   image: owncloudci/php:7.0
   commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/testrunner/apps/password_policy
   - make test-acceptance-cli
   environment:

--- a/.drone.yml
+++ b/.drone.yml
@@ -213,7 +213,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: phpunit-tests
   pull: always
@@ -280,7 +280,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: phpunit-tests
   pull: always
@@ -357,7 +357,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: phpunit-tests
   pull: always
@@ -434,7 +434,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: phpunit-tests
   pull: always
@@ -511,7 +511,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: phpunit-tests
   pull: always
@@ -587,7 +587,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: phpunit-tests
   pull: always
@@ -664,7 +664,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: phpunit-tests
   pull: always
@@ -722,7 +722,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: phpunit-tests
   pull: always
@@ -790,7 +790,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: phpunit-tests
   pull: always
@@ -848,7 +848,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: phpunit-tests
   pull: always
@@ -916,7 +916,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: phpunit-tests
   pull: always
@@ -974,7 +974,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: phpunit-tests
   pull: always
@@ -1051,7 +1051,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -1169,7 +1169,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -1288,7 +1288,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -1406,7 +1406,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -1525,7 +1525,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -1643,7 +1643,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -1762,7 +1762,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -1880,7 +1880,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -1999,7 +1999,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -2117,7 +2117,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -2236,7 +2236,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -2354,7 +2354,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -2473,7 +2473,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: install-extra-apps
   pull: always
@@ -2602,7 +2602,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: install-extra-apps
   pull: always
@@ -2732,7 +2732,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: install-extra-apps
   pull: always
@@ -2861,7 +2861,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: install-extra-apps
   pull: always
@@ -2991,7 +2991,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -3104,7 +3104,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -3218,7 +3218,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -3331,7 +3331,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -3445,7 +3445,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -3558,7 +3558,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -3672,7 +3672,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -3785,7 +3785,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -3899,7 +3899,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -4012,7 +4012,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -4126,7 +4126,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -4239,7 +4239,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -4353,7 +4353,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -4466,7 +4466,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -4580,7 +4580,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -4693,7 +4693,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -4807,7 +4807,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: install-extra-apps
   pull: always
@@ -4924,7 +4924,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: install-extra-apps
   pull: always
@@ -5041,7 +5041,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: install-extra-apps
   pull: always
@@ -5158,7 +5158,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: install-extra-apps
   pull: always
@@ -5275,7 +5275,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -5376,7 +5376,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -5477,7 +5477,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -5578,7 +5578,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -5679,7 +5679,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -5780,7 +5780,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -5881,7 +5881,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -5982,7 +5982,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -6083,7 +6083,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -6184,7 +6184,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -6285,7 +6285,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -6386,7 +6386,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -6487,7 +6487,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -6588,7 +6588,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -6689,7 +6689,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -6790,7 +6790,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -6891,7 +6891,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -6992,7 +6992,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -7093,7 +7093,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -7194,7 +7194,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -7295,7 +7295,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -7396,7 +7396,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -7497,7 +7497,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always
@@ -7598,7 +7598,7 @@ steps:
   - php occ a:e testing
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 0
+  - php occ log:manage --level 2
 
 - name: fix-permissions
   pull: always


### PR DESCRIPTION
This is the proposed drone starlark script that can be used with most of the "ordinary" combinations of things that apps CI  does in drone.

The following things can be put in the `config` section and the script below that will generate `.drone.yml` with the command line `drone script --source .drone.starlark`

1) `app` - the name of the app repo
2) `rocketchat` - the channel to use in rocketchat when reporting failed builds
3) `codestyle` - set to `True` to run codestyle with the default PHP version(s). Or specify `phpVersions` to run codestyle with multiple PHP.
4) `phpstan` - set to `True` to run `phpstan` with the default PHP version(s). Or specify `phpVersions` to run `phpstan` with multiple PHP.
5) `phan` - set to `True` to run `phan` with the default PHP version(s). Or specify `phpVersions` to run `phan` with multiple PHP.
6) `javascript` - set to `True` to run `javascript` tests.
7) `phpunit` - set to `True` to run `phpunit` with the default PHP version(s) and database(s) and coverage. Or specify `phpVersions`, `databases` and/or `coverage` to run `phpunit` with different combinations.
8) `acceptance` - specify an array of `suites` to run those suites. They will get the default combinations of matrix entries for `servers` `browsers` `phpVersions` `databases` generated. Or you can specify any of those to generate a custom set of matrix entries. Also the following attributes of acceptance test jobs can be defined:
a) `federatedServerNeeded` - set to `True` to also configure and start a  federated server for testing.
b) `filterTags` - specify any tags to select a subset of tests, e.g. `SmokeTest`
c) `emailNeeded` - sset to `True` to start the `mailhog` email server, so that email functionality can be tested.
d) `extraSetup` - define extra commands needed to setup the system for this app (e.g. you might have to do some `occ` commands to define some app settings)
e) `extraServices` - define any extra service to be run. e.g. in `search_elastic` the elastic search service is needed.
f) `extraApps` - define any extra apps that need to be cloned and enabled. e.g. some apps have tests that also test that they work correctly with the `guests` app also installed.

9) `defaults` - you can specify the defaults for each type of test. That will override the hard-coded defaults that are embedded in the code. 

e.g. in `search_elastic` we can put a config like:
```
config = {
	'app': 'search_elastic',
	'rocketchat': 'builds',

	'branches': [
		'master'
	],

	'appInstallCommand': 'make',

	'codestyle': True,

	'phpstan': {
		'ordinary' : {
			'phpVersions': [
				'7.1',
				'7.2',
				'7.3',
			],
		},
	},

	'phan': True,

	'phpunit': {
		'allDatabases' : {
			'phpVersions': [
				'7.0',
			]
		},
		'reducedDatabases' : {
			'phpVersions': [
				'7.1',
				'7.2',
				'7.3',
			],
			'databases': [
				'sqlite',
				'mariadb:10.2',
			],
			'coverage': False
		},
	},

	'acceptance': {
		'webUI': {
			'suites': {
				'webUISearchElastic': 'webUISearchElastic',
			},
			'browsers': [
				'chrome',
				'firefox'
			],
		},
		'api': {
			'suites': [
				'apiLimitSearches',
				'apiSearchElastic'
			],
		},
	},

	'defaults': {
		'acceptance': {
			'databases': [
				'mysql:5.7'
			],
			'extraSetup': {
				'name': 'configure-app',
				'image': 'owncloudci/php:7.0',
				'pull': 'always',
				'commands': [
					'cd /var/www/owncloud/server',
					'php occ config:app:set search_elastic servers --value elasticsearch',
					'php occ search:index:reset --force'
				]
			},
			'extraServices': [
				{
					'name': 'elasticsearch',
					'image': 'owncloudci/elasticsearch',
					'pull': 'always',
				}
			]
		},
	}
}
```
That specifies various defaults that apply to all the `acceptance` tests. So we do not have to repeat those in each section/group of acceptance tests that need only minor differences.