### PR TITLE
Adjust acceptance tests for new core public WebDav step formats

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -934,6 +934,8 @@ matrix:
       USE_EMAIL: true
 
     # Acceptance test against release 10.2.1 tarball
+    # Note: do not run apiGuests because the guests app now requires core 10.3
+
     - PHP_VERSION: 7.0
       OC_VERSION: 10.2.1
       TEST_SUITE: api-acceptance

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -47,6 +47,7 @@ default:
         - PasswordPolicyContext:
         - OccContext:
         - FeatureContext: *common_feature_context_params
+        - PublicWebDavContext:
 
     apiGuests:
       paths:
@@ -56,6 +57,7 @@ default:
         - FeatureContext: *common_feature_context_params
         - EmailContext:
         - GuestsContext:
+        - PublicWebDavContext:
 
     cliPasswordAddUser:
       paths:

--- a/tests/acceptance/features/apiGuests/guests.feature
+++ b/tests/acceptance/features/apiGuests/guests.feature
@@ -79,7 +79,7 @@ Feature: Guests
       | 2lOWERcASE | 1               | 403        | 200         | OK                 |
       | 2lOWERcASE | 2               | 403        | 403         | Forbidden          |
 
-  @mailhog
+  @mailhog @skipOnOcV10.2
   Scenario Outline: A guest user creates a public link share with a password that has enough lowercase letters
     Given using OCS API version "<ocs-api-version>"
     And the administrator has created guest user "guest" with email "guest@example.com"
@@ -102,7 +102,30 @@ Feature: Guests
       | moreThan3LowercaseLetters | 1               | 100        |
       | moreThan3LowercaseLetters | 2               | 200        |
 
-  @mailhog
+  @mailhog @skipOnOcV10.3
+  # This scenario repeats the one above, but without checking the new public WebDAV API.
+  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
+  Scenario Outline: A guest user creates a public link share with a password that has enough lowercase letters
+    Given using OCS API version "<ocs-api-version>"
+    And the administrator has created guest user "guest" with email "guest@example.com"
+    And user "user0" has uploaded file with content "user0 file" to "/randomfile.txt"
+    And user "user0" has shared file "/randomfile.txt" with user "guest@example.com"
+    And guest user "guest" has registered and set password to "enoughLowerCase"
+    When user "guest@example.com" creates a public link share using the sharing API with settings
+      | path     | randomfile.txt |
+      | password | <password>     |
+    Then the OCS status code should be "<ocs-status>"
+    And the HTTP status code should be "200"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "<password>" and the content should be "user0 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "%regular%" should fail with HTTP status code "401"
+    Examples:
+      | password                  | ocs-api-version | ocs-status |
+      | 3LCase                    | 1               | 100        |
+      | 3LCase                    | 2               | 200        |
+      | moreThan3LowercaseLetters | 1               | 100        |
+      | moreThan3LowercaseLetters | 2               | 200        |
+
+  @mailhog @skipOnOcV10.2
   Scenario Outline: A guest user creates a public link share with a password that does not have enough lowercase letters
     Given using OCS API version "<ocs-api-version>"
     And the administrator has created guest user "guest" with email "guest@example.com"
@@ -120,6 +143,32 @@ Feature: Guests
       """
     And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
     And the public download of the last publicly shared file using the new public WebDAV API with password "<password>" should fail with HTTP status code "401"
+    Examples:
+       | password   | ocs-api-version | ocs-status | http-status | http-reason-phrase |
+       | 0LOWERCASE | 1               | 403        | 200         | OK                 |
+       | 0LOWERCASE | 2               | 403        | 403         | Forbidden          |
+       | 2lOWERcASE | 1               | 403        | 200         | OK                 |
+       | 2lOWERcASE | 2               | 403        | 403         | Forbidden          |
+
+  @mailhog @skipOnOcV10.3
+  # This scenario repeats the one above, but without checking the new public WebDAV API.
+  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
+  Scenario Outline: A guest user creates a public link share with a password that does not have enough lowercase letters
+    Given using OCS API version "<ocs-api-version>"
+    And the administrator has created guest user "guest" with email "guest@example.com"
+    And user "user0" has shared file "/textfile1.txt" with user "guest@example.com"
+    Given guest user "guest" has registered and set password to "enoughLowerCase"
+    When user "guest@example.com" creates a public link share using the sharing API with settings
+      | path     | textfile1.txt |
+      | password | <password>    |
+    Then the HTTP status code should be "<http-status>"
+    And the HTTP reason phrase should be "<http-reason-phrase>"
+    And the OCS status code should be "<ocs-status>"
+    And the OCS status message should be:
+      """
+      The password contains too few lowercase letters. At least 3 lowercase letters are required.
+      """
+    And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
     Examples:
        | password   | ocs-api-version | ocs-status | http-status | http-reason-phrase |
        | 0LOWERCASE | 1               | 403        | 200         | OK                 |

--- a/tests/acceptance/features/apiGuests/guests.feature
+++ b/tests/acceptance/features/apiGuests/guests.feature
@@ -83,15 +83,18 @@ Feature: Guests
   Scenario Outline: A guest user creates a public link share with a password that has enough lowercase letters
     Given using OCS API version "<ocs-api-version>"
     And the administrator has created guest user "guest" with email "guest@example.com"
-    And user "user0" has shared file "/textfile1.txt" with user "guest@example.com"
-    Given guest user "guest" has registered and set password to "enoughLowerCase"
+    And user "user0" has uploaded file with content "user0 file" to "/randomfile.txt"
+    And user "user0" has shared file "/randomfile.txt" with user "guest@example.com"
+    And guest user "guest" has registered and set password to "enoughLowerCase"
     When user "guest@example.com" creates a public link share using the sharing API with settings
-      | path     | textfile1.txt |
-      | password | <password>    |
+      | path     | randomfile.txt |
+      | password | <password>     |
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
-    And the last public shared file should be able to be downloaded with password "<password>"
-    And the last public shared file should not be able to be downloaded with password "ABCabc1234"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "<password>" and the content should be "user0 file"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API with password "<password>" and the content should be "user0 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "%regular%" should fail with HTTP status code "401"
+    And the public download of the last publicly shared file using the new public WebDAV API with password "%regular%" should fail with HTTP status code "401"
     Examples:
       | password                  | ocs-api-version | ocs-status |
       | 3LCase                    | 1               | 100        |
@@ -115,7 +118,8 @@ Feature: Guests
       """
       The password contains too few lowercase letters. At least 3 lowercase letters are required.
       """
-    And the last public shared file should not be able to be downloaded with password "<password>"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
+    And the public download of the last publicly shared file using the new public WebDAV API with password "<password>" should fail with HTTP status code "401"
     Examples:
        | password   | ocs-api-version | ocs-status | http-status | http-reason-phrase |
        | 0LOWERCASE | 1               | 403        | 200         | OK                 |

--- a/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateLowercaseLetters.feature
+++ b/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateLowercaseLetters.feature
@@ -11,17 +11,20 @@ Feature: enforce the required number of lowercase letters on public share links
     And these users have been created with default attributes and skeleton files:
       | username | password   |
       | user1    | abcABC1234 |
+    And user "user1" has uploaded file with content "user1 file" to "/randomfile.txt"
     And user "user1" has created a public link share with settings
-      | path     | welcome.txt |
-      | password | ABCabc1234  |
+      | path     | randomfile.txt |
+      | password | ABCabc1234     |
 
   Scenario Outline: user updates the public share link password to a string with enough lowercase letters
     When user "user1" updates the last share using the sharing API with
       | password | <password> |
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
-    And the last public shared file should be able to be downloaded with password "<password>"
-    And the last public shared file should not be able to be downloaded with password "ABCabc1234"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "<password>" and the content should be "user1 file"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API with password "<password>" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "ABCabc1234" should fail with HTTP status code "401"
+    And the public download of the last publicly shared file using the new public WebDAV API with password "ABCabc1234" should fail with HTTP status code "401"
     Examples:
       | password                  |
       | 3LCase                    |
@@ -32,8 +35,10 @@ Feature: enforce the required number of lowercase letters on public share links
       | password | <password> |
     Then the OCS status message should be "The password contains too few lowercase letters. At least 3 lowercase letters are required."
     And the OCS status code should be "400"
-    And the last public shared file should be able to be downloaded with password "ABCabc1234"
-    And the last public shared file should not be able to be downloaded with password "<password>"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "ABCabc1234" and the content should be "user1 file"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API with password "ABCabc1234" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
+    And the public download of the last publicly shared file using the new public WebDAV API with password "<password>" should fail with HTTP status code "401"
     Examples:
       | password   |
       | 0LOWERCASE |

--- a/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateLowercaseLetters.feature
+++ b/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateLowercaseLetters.feature
@@ -16,6 +16,7 @@ Feature: enforce the required number of lowercase letters on public share links
       | path     | randomfile.txt |
       | password | ABCabc1234     |
 
+  @skipOnOcV10.2
   Scenario Outline: user updates the public share link password to a string with enough lowercase letters
     When user "user1" updates the last share using the sharing API with
       | password | <password> |
@@ -30,6 +31,22 @@ Feature: enforce the required number of lowercase letters on public share links
       | 3LCase                    |
       | moreThan3LowercaseLetters |
 
+  @skipOnOcV10.3
+  # This scenario repeats the one above, but without checking the new public WebDAV API.
+  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
+  Scenario Outline: user updates the public share link password to a string with enough lowercase letters
+    When user "user1" updates the last share using the sharing API with
+      | password | <password> |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "<password>" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "ABCabc1234" should fail with HTTP status code "401"
+    Examples:
+      | password                  |
+      | 3LCase                    |
+      | moreThan3LowercaseLetters |
+
+  @skipOnOcV10.2
   Scenario Outline: user tries to update the public share link password to a string with not enough lowercase letters
     When user "user1" tries to update the last share using the sharing API with
       | password | <password> |
@@ -39,6 +56,21 @@ Feature: enforce the required number of lowercase letters on public share links
     And the public should be able to download the last publicly shared file using the new public WebDAV API with password "ABCabc1234" and the content should be "user1 file"
     And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
     And the public download of the last publicly shared file using the new public WebDAV API with password "<password>" should fail with HTTP status code "401"
+    Examples:
+      | password   |
+      | 0LOWERCASE |
+      | 2lOWERcASE |
+
+  @skipOnOcV10.3
+  # This scenario repeats the one above, but without checking the new public WebDAV API.
+  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
+  Scenario Outline: user tries to update the public share link password to a string with not enough lowercase letters
+    When user "user1" tries to update the last share using the sharing API with
+      | password | <password> |
+    Then the OCS status message should be "The password contains too few lowercase letters. At least 3 lowercase letters are required."
+    And the OCS status code should be "400"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "ABCabc1234" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
     Examples:
       | password   |
       | 0LOWERCASE |

--- a/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateMinimumLength.feature
+++ b/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateMinimumLength.feature
@@ -11,17 +11,20 @@ Feature: enforce the minimum length of a password on public share links
     And these users have been created with default attributes and skeleton files:
       | username | password   |
       | user1    | 1234567890 |
+    And user "user1" has uploaded file with content "user1 file" to "/randomfile.txt"
     And user "user1" has created a public link share with settings
-      | path     | welcome.txt |
-      | password | ABCabc1234  |
+      | path     | randomfile.txt |
+      | password | ABCabc1234     |
 
   Scenario Outline: user updates the public share link password a long-enough string
     When user "user1" updates the last share using the sharing API with
       | password | <password> |
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
-    And the last public shared file should be able to be downloaded with password "<password>"
-    And the last public shared file should not be able to be downloaded with password "ABCabc1234"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "<password>" and the content should be "user1 file"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API with password "<password>" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "ABCabc1234" should fail with HTTP status code "401"
+    And the public download of the last publicly shared file using the new public WebDAV API with password "ABCabc1234" should fail with HTTP status code "401"
     Examples:
       | password             |
       | 10tenchars           |
@@ -32,8 +35,10 @@ Feature: enforce the minimum length of a password on public share links
       | password | <password> |
     Then the OCS status message should be "The password is too short. At least 10 characters are required."
     And the OCS status code should be "400"
-    And the last public shared file should be able to be downloaded with password "ABCabc1234"
-    And the last public shared file should not be able to be downloaded with password "<password>"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "ABCabc1234" and the content should be "user1 file"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API with password "ABCabc1234" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
+    And the public download of the last publicly shared file using the new public WebDAV API with password "<password>" should fail with HTTP status code "401"
     Examples:
       | password  |
       | A         |

--- a/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateMinimumLength.feature
+++ b/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateMinimumLength.feature
@@ -16,6 +16,7 @@ Feature: enforce the minimum length of a password on public share links
       | path     | randomfile.txt |
       | password | ABCabc1234     |
 
+  @skipOnOcV10.2
   Scenario Outline: user updates the public share link password a long-enough string
     When user "user1" updates the last share using the sharing API with
       | password | <password> |
@@ -30,6 +31,22 @@ Feature: enforce the minimum length of a password on public share links
       | 10tenchars           |
       | morethan10characters |
 
+  @skipOnOcV10.3
+  # This scenario repeats the one above, but without checking the new public WebDAV API.
+  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
+  Scenario Outline: user updates the public share link password a long-enough string
+    When user "user1" updates the last share using the sharing API with
+      | password | <password> |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "<password>" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "ABCabc1234" should fail with HTTP status code "401"
+    Examples:
+      | password             |
+      | 10tenchars           |
+      | morethan10characters |
+
+  @skipOnOcV10.2
   Scenario Outline: user tries to update the public share link password to a string that is too short
     When user "user1" tries to update the last share using the sharing API with
       | password | <password> |
@@ -39,6 +56,21 @@ Feature: enforce the minimum length of a password on public share links
     And the public should be able to download the last publicly shared file using the new public WebDAV API with password "ABCabc1234" and the content should be "user1 file"
     And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
     And the public download of the last publicly shared file using the new public WebDAV API with password "<password>" should fail with HTTP status code "401"
+    Examples:
+      | password  |
+      | A         |
+      | 123456789 |
+
+  @skipOnOcV10.3
+  # This scenario repeats the one above, but without checking the new public WebDAV API.
+  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
+  Scenario Outline: user tries to update the public share link password to a string that is too short
+    When user "user1" tries to update the last share using the sharing API with
+      | password | <password> |
+    Then the OCS status message should be "The password is too short. At least 10 characters are required."
+    And the OCS status code should be "400"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "ABCabc1234" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
     Examples:
       | password  |
       | A         |

--- a/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateNumbers.feature
+++ b/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateNumbers.feature
@@ -16,6 +16,7 @@ Feature: enforce the required number of numbers in a password on public share li
       | path     | randomfile.txt |
       | password | ABCabc1234     |
 
+  @skipOnOcV10.2
   Scenario Outline: user updates the public share link password to a string with enough numbers
     When user "user1" updates the last share using the sharing API with
       | password | <password> |
@@ -30,6 +31,22 @@ Feature: enforce the required number of numbers in a password on public share li
       | 333Numbers      |
       | moreNumbers1234 |
 
+  @skipOnOcV10.3
+  # This scenario repeats the one above, but without checking the new public WebDAV API.
+  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
+  Scenario Outline: user updates the public share link password to a string with enough numbers
+    When user "user1" updates the last share using the sharing API with
+      | password | <password> |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "<password>" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "ABCabc1234" should fail with HTTP status code "401"
+    Examples:
+      | password        |
+      | 333Numbers      |
+      | moreNumbers1234 |
+
+  @skipOnOcV10.2
   Scenario Outline: user tries to update the public share link password to a string that has too few numbers
     When user "user1" tries to update the last share using the sharing API with
       | password | <password> |
@@ -39,6 +56,21 @@ Feature: enforce the required number of numbers in a password on public share li
     And the public should be able to download the last publicly shared file using the new public WebDAV API with password "ABCabc1234" and the content should be "user1 file"
     And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
     And the public download of the last publicly shared file using the new public WebDAV API with password "<password>" should fail with HTTP status code "401"
+    Examples:
+      | password      |
+      | NoNumbers     |
+      | Only22Numbers |
+
+  @skipOnOcV10.3
+  # This scenario repeats the one above, but without checking the new public WebDAV API.
+  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
+  Scenario Outline: user tries to update the public share link password to a string that has too few numbers
+    When user "user1" tries to update the last share using the sharing API with
+      | password | <password> |
+    Then the OCS status message should be "The password contains too few numbers. At least 3 numbers are required."
+    And the OCS status code should be "400"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "ABCabc1234" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
     Examples:
       | password      |
       | NoNumbers     |

--- a/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateNumbers.feature
+++ b/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateNumbers.feature
@@ -11,17 +11,20 @@ Feature: enforce the required number of numbers in a password on public share li
     And these users have been created with default attributes and skeleton files:
       | username | password   |
       | user1    | abcABC1234 |
+    And user "user1" has uploaded file with content "user1 file" to "/randomfile.txt"
     And user "user1" has created a public link share with settings
-      | path     | welcome.txt |
-      | password | ABCabc1234  |
+      | path     | randomfile.txt |
+      | password | ABCabc1234     |
 
   Scenario Outline: user updates the public share link password to a string with enough numbers
     When user "user1" updates the last share using the sharing API with
       | password | <password> |
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
-    And the last public shared file should be able to be downloaded with password "<password>"
-    And the last public shared file should not be able to be downloaded with password "ABCabc1234"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "<password>" and the content should be "user1 file"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API with password "<password>" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "ABCabc1234" should fail with HTTP status code "401"
+    And the public download of the last publicly shared file using the new public WebDAV API with password "ABCabc1234" should fail with HTTP status code "401"
     Examples:
       | password        |
       | 333Numbers      |
@@ -32,8 +35,10 @@ Feature: enforce the required number of numbers in a password on public share li
       | password | <password> |
     Then the OCS status message should be "The password contains too few numbers. At least 3 numbers are required."
     And the OCS status code should be "400"
-    And the last public shared file should be able to be downloaded with password "ABCabc1234"
-    And the last public shared file should not be able to be downloaded with password "<password>"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "ABCabc1234" and the content should be "user1 file"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API with password "ABCabc1234" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
+    And the public download of the last publicly shared file using the new public WebDAV API with password "<password>" should fail with HTTP status code "401"
     Examples:
       | password      |
       | NoNumbers     |

--- a/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateRequirementCombinations.feature
+++ b/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateRequirementCombinations.feature
@@ -19,8 +19,9 @@ Feature: enforce combinations of password policies on public share links
     And these users have been created with default attributes and skeleton files:
       | username | password        |
       | user1    | aA1!bB2#cC&deee |
+    And user "user1" has uploaded file with content "user1 file" to "/randomfile.txt"
     And user "user1" has created a public link share with settings
-      | path     | welcome.txt     |
+      | path     | randomfile.txt  |
       | password | zA1@bB2#cC&deee |
 
   Scenario Outline: user updates the public share link password to a valid string
@@ -28,8 +29,10 @@ Feature: enforce combinations of password policies on public share links
       | password | <password> |
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
-    And the last public shared file should be able to be downloaded with password "<password>"
-    And the last public shared file should not be able to be downloaded with password "zA1@bB2#cC&deee"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "<password>" and the content should be "user1 file"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API with password "<password>" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "zA1@bB2#cC&deee" should fail with HTTP status code "401"
+    And the public download of the last publicly shared file using the new public WebDAV API with password "zA1@bB2#cC&deee" should fail with HTTP status code "401"
     Examples:
       | password                  |
       | 15***UPPloweZZZ           |
@@ -40,8 +43,10 @@ Feature: enforce combinations of password policies on public share links
       | password | <password> |
     Then the OCS status message should be "<message>"
     And the OCS status code should be "400"
-    And the last public shared file should be able to be downloaded with password "zA1@bB2#cC&deee"
-    And the last public shared file should not be able to be downloaded with password "<password>"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "zA1@bB2#cC&deee" and the content should be "user1 file"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API with password "zA1@bB2#cC&deee" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
+    And the public download of the last publicly shared file using the new public WebDAV API with password "<password>" should fail with HTTP status code "401"
     Examples:
       | password                       | message                                                                                       |
       # where just one of the requirements is not met
@@ -61,8 +66,10 @@ Feature: enforce combinations of password policies on public share links
       | password | <password> |
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
-    And the last public shared file should be able to be downloaded with password "<password>"
-    And the last public shared file should not be able to be downloaded with password "zA1@bB2#cC&deee"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "<password>" and the content should be "user1 file"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API with password "<password>" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "zA1@bB2#cC&deee" should fail with HTTP status code "401"
+    And the public download of the last publicly shared file using the new public WebDAV API with password "zA1@bB2#cC&deee" should fail with HTTP status code "401"
     Examples:
       | password                  |
       | 15%&*UPPloweZZZ           |
@@ -75,8 +82,10 @@ Feature: enforce combinations of password policies on public share links
       | password | <password> |
     Then the OCS status message should be "<message>"
     And the OCS status code should be "400"
-    And the last public shared file should be able to be downloaded with password "zA1@bB2#cC&deee"
-    And the last public shared file should not be able to be downloaded with password "<password>"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "zA1@bB2#cC&deee" and the content should be "user1 file"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API with password "zA1@bB2#cC&deee" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
+    And the public download of the last publicly shared file using the new public WebDAV API with password "<password>" should fail with HTTP status code "401"
     Examples:
       | password        | message                                                                                     |
       | 15#!!UPPloweZZZ | The password contains invalid special characters. Only $%^&* are allowed.                   |

--- a/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateRequirementCombinations.feature
+++ b/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateRequirementCombinations.feature
@@ -24,6 +24,7 @@ Feature: enforce combinations of password policies on public share links
       | path     | randomfile.txt  |
       | password | zA1@bB2#cC&deee |
 
+  @skipOnOcV10.2
   Scenario Outline: user updates the public share link password to a valid string
     When user "user1" updates the last share using the sharing API with
       | password | <password> |
@@ -38,6 +39,22 @@ Feature: enforce combinations of password policies on public share links
       | 15***UPPloweZZZ           |
       | More%Than$15!Characters-0 |
 
+  @skipOnOcV10.3
+  # This scenario repeats the one above, but without checking the new public WebDAV API.
+  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
+  Scenario Outline: user updates the public share link password to a valid string
+    When user "user1" updates the last share using the sharing API with
+      | password | <password> |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "<password>" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "zA1@bB2#cC&deee" should fail with HTTP status code "401"
+    Examples:
+      | password                  |
+      | 15***UPPloweZZZ           |
+      | More%Than$15!Characters-0 |
+
+  @skipOnOcV10.2
   Scenario Outline: user tries to update the public share link password to an invalid string
     When user "user1" tries to update the last share using the sharing API with
       | password | <password> |
@@ -59,6 +76,29 @@ Feature: enforce combinations of password policies on public share links
       | aA!1                           | The password is too short. At least 15 characters are required.                               |
       | aA!123456789012345             | The password contains too few lowercase letters. At least 4 lowercase letters are required.   |
 
+  @skipOnOcV10.3
+  # This scenario repeats the one above, but without checking the new public WebDAV API.
+  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
+  Scenario Outline: user tries to update the public share link password to an invalid string
+    When user "user1" tries to update the last share using the sharing API with
+      | password | <password> |
+    Then the OCS status message should be "<message>"
+    And the OCS status code should be "400"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "zA1@bB2#cC&deee" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
+    Examples:
+      | password                       | message                                                                                       |
+      # where just one of the requirements is not met
+      | aA1!bB2#cC&d                   | The password is too short. At least 15 characters are required.                               |
+      | aA1!bB2#cNOT&ENOUGH#LOWERCASE  | The password contains too few lowercase letters. At least 4 lowercase letters are required.   |
+      | aA1!bB2#cnot&enough#uppercase  | The password contains too few uppercase letters. At least 3 uppercase letters are required.   |
+      | Not&Enough#Numbers=1           | The password contains too few numbers. At least 2 numbers are required.                       |
+      | Not&Enough#Special8Characters2 | The password contains too few special characters. At least 3 special characters are required. |
+      # where multiple requirements are not met, only the first error message is shown to the user
+      | aA!1                           | The password is too short. At least 15 characters are required.                               |
+      | aA!123456789012345             | The password contains too few lowercase letters. At least 4 lowercase letters are required.   |
+
+  @skipOnOcV10.2
   Scenario Outline: user updates the public share link password to valid restricted special characters
     Given the administrator has enabled the restrict to these special characters password policy
     And the administrator has set the restricted special characters required to "$%^&*"
@@ -75,6 +115,24 @@ Feature: enforce combinations of password policies on public share links
       | 15%&*UPPloweZZZ           |
       | More^Than$15&Characters*0 |
 
+  @skipOnOcV10.3
+  # This scenario repeats the one above, but without checking the new public WebDAV API.
+  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
+  Scenario Outline: user updates the public share link password to valid restricted special characters
+    Given the administrator has enabled the restrict to these special characters password policy
+    And the administrator has set the restricted special characters required to "$%^&*"
+    When user "user1" updates the last share using the sharing API with
+      | password | <password> |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "<password>" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "zA1@bB2#cC&deee" should fail with HTTP status code "401"
+    Examples:
+      | password                  |
+      | 15%&*UPPloweZZZ           |
+      | More^Than$15&Characters*0 |
+
+  @skipOnOcV10.2
   Scenario Outline: user tries to update the public share link password to invalid restricted special characters
     Given the administrator has enabled the restrict to these special characters password policy
     And the administrator has set the restricted special characters required to "$%^&*"
@@ -86,6 +144,25 @@ Feature: enforce combinations of password policies on public share links
     And the public should be able to download the last publicly shared file using the new public WebDAV API with password "zA1@bB2#cC&deee" and the content should be "user1 file"
     And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
     And the public download of the last publicly shared file using the new public WebDAV API with password "<password>" should fail with HTTP status code "401"
+    Examples:
+      | password        | message                                                                                     |
+      | 15#!!UPPloweZZZ | The password contains invalid special characters. Only $%^&* are allowed.                   |
+      | 15&%!UPPloweZZZ | The password contains invalid special characters. Only $%^&* are allowed.                   |
+      # where multiple requirements are not met, only the first error message is shown to the user
+      | 15&%!UPPlowZZZZ | The password contains too few lowercase letters. At least 4 lowercase letters are required. |
+
+  @skipOnOcV10.3
+  # This scenario repeats the one above, but without checking the new public WebDAV API.
+  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
+  Scenario Outline: user tries to update the public share link password to invalid restricted special characters
+    Given the administrator has enabled the restrict to these special characters password policy
+    And the administrator has set the restricted special characters required to "$%^&*"
+    When user "user1" tries to update the last share using the sharing API with
+      | password | <password> |
+    Then the OCS status message should be "<message>"
+    And the OCS status code should be "400"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "zA1@bB2#cC&deee" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
     Examples:
       | password        | message                                                                                     |
       | 15#!!UPPloweZZZ | The password contains invalid special characters. Only $%^&* are allowed.                   |

--- a/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateSpecialCharacters.feature
+++ b/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateSpecialCharacters.feature
@@ -16,6 +16,7 @@ Feature: enforce the required number of special characters in a password on publ
       | path     | randomfile.txt |
       | password | g@b#c!1234     |
 
+  @skipOnOcV10.2
   Scenario Outline: user updates the public share link password to a string with enough special characters
     When user "user1" updates the last share using the sharing API with
       | password | <password> |
@@ -30,6 +31,22 @@ Feature: enforce the required number of special characters in a password on publ
       | 3#Special$Characters! |
       | 1!2@3#4$5%6^7&8*      |
 
+  @skipOnOcV10.3
+  # This scenario repeats the one above, but without checking the new public WebDAV API.
+  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
+  Scenario Outline: user updates the public share link password to a string with enough special characters
+    When user "user1" updates the last share using the sharing API with
+      | password | <password> |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "<password>" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "g@b#c!1234" should fail with HTTP status code "401"
+    Examples:
+      | password              |
+      | 3#Special$Characters! |
+      | 1!2@3#4$5%6^7&8*      |
+
+  @skipOnOcV10.2
   Scenario Outline: user tries to update the public share link password to a string that has too few special characters
     When user "user1" tries to update the last share using the sharing API with
       | password | <password> |
@@ -39,6 +56,21 @@ Feature: enforce the required number of special characters in a password on publ
     And the public should be able to download the last publicly shared file using the new public WebDAV API with password "g@b#c!1234" and the content should be "user1 file"
     And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
     And the public download of the last publicly shared file using the new public WebDAV API with password "<password>" should fail with HTTP status code "401"
+    Examples:
+      | password                 |
+      | NoSpecialCharacters123   |
+      | Only2$Special!Characters |
+
+  @skipOnOcV10.3
+  # This scenario repeats the one above, but without checking the new public WebDAV API.
+  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
+  Scenario Outline: user tries to update the public share link password to a string that has too few special characters
+    When user "user1" tries to update the last share using the sharing API with
+      | password | <password> |
+    Then the OCS status message should be "The password contains too few special characters. At least 3 special characters are required."
+    And the OCS status code should be "400"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "g@b#c!1234" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
     Examples:
       | password                 |
       | NoSpecialCharacters123   |

--- a/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateSpecialCharacters.feature
+++ b/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateSpecialCharacters.feature
@@ -11,17 +11,20 @@ Feature: enforce the required number of special characters in a password on publ
     And these users have been created with default attributes and skeleton files:
       | username | password   |
       | user1    | a!b@c#1234 |
+    And user "user1" has uploaded file with content "user1 file" to "/randomfile.txt"
     And user "user1" has created a public link share with settings
-      | path     | welcome.txt |
-      | password | g@b#c!1234  |
+      | path     | randomfile.txt |
+      | password | g@b#c!1234     |
 
   Scenario Outline: user updates the public share link password to a string with enough special characters
     When user "user1" updates the last share using the sharing API with
       | password | <password> |
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
-    And the last public shared file should be able to be downloaded with password "<password>"
-    And the last public shared file should not be able to be downloaded with password "g@b#c!1234"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "<password>" and the content should be "user1 file"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API with password "<password>" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "g@b#c!1234" should fail with HTTP status code "401"
+    And the public download of the last publicly shared file using the new public WebDAV API with password "g@b#c!1234" should fail with HTTP status code "401"
     Examples:
       | password              |
       | 3#Special$Characters! |
@@ -32,8 +35,10 @@ Feature: enforce the required number of special characters in a password on publ
       | password | <password> |
     Then the OCS status message should be "The password contains too few special characters. At least 3 special characters are required."
     And the OCS status code should be "400"
-    And the last public shared file should be able to be downloaded with password "g@b#c!1234"
-    And the last public shared file should not be able to be downloaded with password "<password>"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "g@b#c!1234" and the content should be "user1 file"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API with password "g@b#c!1234" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
+    And the public download of the last publicly shared file using the new public WebDAV API with password "<password>" should fail with HTTP status code "401"
     Examples:
       | password                 |
       | NoSpecialCharacters123   |

--- a/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateSpecialCharactersRestrictions.feature
+++ b/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateSpecialCharactersRestrictions.feature
@@ -13,17 +13,20 @@ Feature: enforce the restricted special characters in a password on public share
     And these users have been created with default attributes and skeleton files:
       | username | password   |
       | user1    | a$b%c^1234 |
+    And user "user1" has uploaded file with content "user1 file" to "/randomfile.txt"
     And user "user1" has created a public link share with settings
-      | path     | welcome.txt   |
-      | password | a324$b%c^1234 |
+      | path     | randomfile.txt |
+      | password | a324$b%c^1234  |
 
   Scenario Outline: user updates the public share link password to a string with enough restricted special characters
     When user "user1" updates the last share using the sharing API with
       | password | <password> |
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
-    And the last public shared file should be able to be downloaded with password "<password>"
-    And the last public shared file should not be able to be downloaded with password "a324$b%c^1234"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "<password>" and the content should be "user1 file"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API with password "<password>" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "a324$b%c^1234" should fail with HTTP status code "401"
+    And the public download of the last publicly shared file using the new public WebDAV API with password "a324$b%c^1234" should fail with HTTP status code "401"
     Examples:
       | password              |
       | 3$Special%Characters^ |
@@ -34,8 +37,10 @@ Feature: enforce the restricted special characters in a password on public share
       | password | <password> |
     Then the OCS status message should be "The password contains too few special characters. At least 3 special characters ($%^&*) are required."
     And the OCS status code should be "400"
-    And the last public shared file should be able to be downloaded with password "a324$b%c^1234"
-    And the last public shared file should not be able to be downloaded with password "<password>"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "a324$b%c^1234" and the content should be "user1 file"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API with password "a324$b%c^1234" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
+    And the public download of the last publicly shared file using the new public WebDAV API with password "<password>" should fail with HTTP status code "401"
     Examples:
       | password                 |
       | NoSpecialCharacters123   |
@@ -46,8 +51,10 @@ Feature: enforce the restricted special characters in a password on public share
       | password | <password> |
     Then the OCS status message should be "The password contains invalid special characters. Only $%^&* are allowed."
     And the OCS status code should be "400"
-    And the last public shared file should be able to be downloaded with password "a324$b%c^1234"
-    And the last public shared file should not be able to be downloaded with password "<password>"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "a324$b%c^1234" and the content should be "user1 file"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API with password "a324$b%c^1234" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
+    And the public download of the last publicly shared file using the new public WebDAV API with password "<password>" should fail with HTTP status code "401"
     Examples:
       | password                                 |
       | Only#Invalid!Special@Characters          |

--- a/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateSpecialCharactersRestrictions.feature
+++ b/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateSpecialCharactersRestrictions.feature
@@ -18,6 +18,7 @@ Feature: enforce the restricted special characters in a password on public share
       | path     | randomfile.txt |
       | password | a324$b%c^1234  |
 
+  @skipOnOcV10.2
   Scenario Outline: user updates the public share link password to a string with enough restricted special characters
     When user "user1" updates the last share using the sharing API with
       | password | <password> |
@@ -32,6 +33,22 @@ Feature: enforce the restricted special characters in a password on public share
       | 3$Special%Characters^ |
       | 1*2&3^4%5$6           |
 
+  @skipOnOcV10.3
+  # This scenario repeats the one above, but without checking the new public WebDAV API.
+  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
+  Scenario Outline: user updates the public share link password to a string with enough restricted special characters
+    When user "user1" updates the last share using the sharing API with
+      | password | <password> |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "<password>" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "a324$b%c^1234" should fail with HTTP status code "401"
+    Examples:
+      | password              |
+      | 3$Special%Characters^ |
+      | 1*2&3^4%5$6           |
+
+  @skipOnOcV10.2
   Scenario Outline: user tries to update the public share link password to a string that has too few restricted special characters
     When user "user1" tries to update the last share using the sharing API with
       | password | <password> |
@@ -46,6 +63,22 @@ Feature: enforce the restricted special characters in a password on public share
       | NoSpecialCharacters123   |
       | Only2$Special&Characters |
 
+  @skipOnOcV10.3
+  # This scenario repeats the one above, but without checking the new public WebDAV API.
+  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
+  Scenario Outline: user tries to update the public share link password to a string that has too few restricted special characters
+    When user "user1" tries to update the last share using the sharing API with
+      | password | <password> |
+    Then the OCS status message should be "The password contains too few special characters. At least 3 special characters ($%^&*) are required."
+    And the OCS status code should be "400"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "a324$b%c^1234" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
+    Examples:
+      | password                 |
+      | NoSpecialCharacters123   |
+      | Only2$Special&Characters |
+
+  @skipOnOcV10.2
   Scenario Outline: user tries to update the public share link password to a string that has invalid special characters
     When user "user1" tries to update the last share using the sharing API with
       | password | <password> |
@@ -55,6 +88,21 @@ Feature: enforce the restricted special characters in a password on public share
     And the public should be able to download the last publicly shared file using the new public WebDAV API with password "a324$b%c^1234" and the content should be "user1 file"
     And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
     And the public download of the last publicly shared file using the new public WebDAV API with password "<password>" should fail with HTTP status code "401"
+    Examples:
+      | password                                 |
+      | Only#Invalid!Special@Characters          |
+      | 1*2&3^4%5$6andInvalidSpecialCharacters#! |
+
+  @skipOnOcV10.3
+  # This scenario repeats the one above, but without checking the new public WebDAV API.
+  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
+  Scenario Outline: user tries to update the public share link password to a string that has invalid special characters
+    When user "user1" tries to update the last share using the sharing API with
+      | password | <password> |
+    Then the OCS status message should be "The password contains invalid special characters. Only $%^&* are allowed."
+    And the OCS status code should be "400"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "a324$b%c^1234" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
     Examples:
       | password                                 |
       | Only#Invalid!Special@Characters          |

--- a/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateUppercaseLetters.feature
+++ b/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateUppercaseLetters.feature
@@ -11,17 +11,20 @@ Feature: enforce the required number of uppercase letters in a password on publi
     And these users have been created with default attributes and skeleton files:
       | username | password   |
       | user1    | abcABC1234 |
+    And user "user1" has uploaded file with content "user1 file" to "/randomfile.txt"
     And user "user1" has created a public link share with settings
-      | path     | welcome.txt |
-      | password | ABCabc1234  |
+      | path     | randomfile.txt |
+      | password | ABCabc1234     |
 
   Scenario Outline: user updates the public share link password to a string with enough uppercase letters
     When user "user1" updates the last share using the sharing API with
       | password | <password> |
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
-    And the last public shared file should be able to be downloaded with password "<password>"
-    And the last public shared file should not be able to be downloaded with password "ABCabc1234"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "<password>" and the content should be "user1 file"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API with password "<password>" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "ABCabc1234" should fail with HTTP status code "401"
+    And the public download of the last publicly shared file using the new public WebDAV API with password "ABCabc1234" should fail with HTTP status code "401"
     Examples:
       | password                  |
       | 3UpperCaseLetters         |
@@ -32,8 +35,10 @@ Feature: enforce the required number of uppercase letters in a password on publi
       | password | <password> |
     Then the OCS status message should be "The password contains too few uppercase letters. At least 3 uppercase letters are required."
     And the OCS status code should be "400"
-    And the last public shared file should be able to be downloaded with password "ABCabc1234"
-    And the last public shared file should not be able to be downloaded with password "<password>"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "ABCabc1234" and the content should be "user1 file"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API with password "ABCabc1234" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
+    And the public download of the last publicly shared file using the new public WebDAV API with password "<password>" should fail with HTTP status code "401"
     Examples:
       | password       |
       | 0uppercase     |

--- a/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateUppercaseLetters.feature
+++ b/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateUppercaseLetters.feature
@@ -16,6 +16,7 @@ Feature: enforce the required number of uppercase letters in a password on publi
       | path     | randomfile.txt |
       | password | ABCabc1234     |
 
+  @skipOnOcV10.2
   Scenario Outline: user updates the public share link password to a string with enough uppercase letters
     When user "user1" updates the last share using the sharing API with
       | password | <password> |
@@ -30,6 +31,22 @@ Feature: enforce the required number of uppercase letters in a password on publi
       | 3UpperCaseLetters         |
       | MoreThan3UpperCaseLetters |
 
+  @skipOnOcV10.3
+  # This scenario repeats the one above, but without checking the new public WebDAV API.
+  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
+  Scenario Outline: user updates the public share link password to a string with enough uppercase letters
+    When user "user1" updates the last share using the sharing API with
+      | password | <password> |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "<password>" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "ABCabc1234" should fail with HTTP status code "401"
+    Examples:
+      | password                  |
+      | 3UpperCaseLetters         |
+      | MoreThan3UpperCaseLetters |
+
+  @skipOnOcV10.2
   Scenario Outline: user tries to update the public share link password to a string that has too few uppercase letters
     When user "user1" tries to update the last share using the sharing API with
       | password | <password> |
@@ -39,6 +56,21 @@ Feature: enforce the required number of uppercase letters in a password on publi
     And the public should be able to download the last publicly shared file using the new public WebDAV API with password "ABCabc1234" and the content should be "user1 file"
     And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
     And the public download of the last publicly shared file using the new public WebDAV API with password "<password>" should fail with HTTP status code "401"
+    Examples:
+      | password       |
+      | 0uppercase     |
+      | Only2Uppercase |
+
+  @skipOnOcV10.3
+  # This scenario repeats the one above, but without checking the new public WebDAV API.
+  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
+  Scenario Outline: user tries to update the public share link password to a string that has too few uppercase letters
+    When user "user1" tries to update the last share using the sharing API with
+      | password | <password> |
+    Then the OCS status message should be "The password contains too few uppercase letters. At least 3 uppercase letters are required."
+    And the OCS status code should be "400"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "ABCabc1234" and the content should be "user1 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
     Examples:
       | password       |
       | 0uppercase     |


### PR DESCRIPTION
1) that were added in core PR https://github.com/owncloud/core/pull/36081

2) the new public WebDAV API  does not exist in core 10.2. So skip those scenarios on core 10.2, and add scenarios for 10.2 that do not have new public WebDAV API checks.

3) `apiGuests`  suite was not being run against 10.2.1, so add that to the test matrix.