### PR TITLE
Revert "Fix expected text of password messages"

### DIFF
--- a/tests/acceptance/features/apiPasswordAddUser/provisioningAddUserLowercaseLetters.feature
+++ b/tests/acceptance/features/apiPasswordAddUser/provisioningAddUserLowercaseLetters.feature
@@ -24,29 +24,6 @@ Feature: enforce the required number of lowercase letters in a password when cre
       | moreThan3LowercaseLetters | 1               | 100        |
       | moreThan3LowercaseLetters | 2               | 200        |
 
-  @skipOnOcV10.2
-  # This has the new full OCS status message from core 10.3 onwards
-  Scenario Outline: admin creates a user with a password that does not have enough lowercase letters
-    Given using OCS API version "<ocs-api-version>"
-    And user "brand-new-user" has been deleted
-    When the administrator sends a user creation request for user "brand-new-user" password "<password>" using the provisioning API
-    Then the HTTP status code should be "<http-status>"
-    And the HTTP reason phrase should be "<http-reason-phrase>"
-    And the OCS status code should be "<ocs-status>"
-    And the OCS status message should be:
-      """
-      Unable to create user: The password contains too few lowercase letters. At least 3 lowercase letters are required.
-      """
-    And user "brand-new-user" should not exist
-    Examples:
-      | password   | ocs-api-version | ocs-status | http-status | http-reason-phrase |
-      | 0LOWERCASE | 1               | 101        | 200         | OK                 |
-      | 0LOWERCASE | 2               | 400        | 400         | Bad Request        |
-      | 2lOWERcASE | 1               | 101        | 200         | OK                 |
-      | 2lOWERcASE | 2               | 400        | 400         | Bad Request        |
-
-  @skipOnOcV10.3
-  # This has the OCS status message as it was with core 10.2.*
   Scenario Outline: admin creates a user with a password that does not have enough lowercase letters
     Given using OCS API version "<ocs-api-version>"
     And user "brand-new-user" has been deleted

--- a/tests/acceptance/features/apiPasswordAddUser/provisioningAddUserMinimumLength.feature
+++ b/tests/acceptance/features/apiPasswordAddUser/provisioningAddUserMinimumLength.feature
@@ -24,29 +24,6 @@ Feature: enforce the minimum length of a password when creating a user
       | morethan10characters | 1               | 100        |
       | morethan10characters | 2               | 200        |
 
-  @skipOnOcV10.2
-  # This has the new full OCS status message from core 10.3 onwards
-  Scenario Outline: admin creates a user with a password that is not long enough
-    Given using OCS API version "<ocs-api-version>"
-    And user "brand-new-user" has been deleted
-    When the administrator sends a user creation request for user "brand-new-user" password "<password>" using the provisioning API
-    Then the HTTP status code should be "<http-status>"
-    And the HTTP reason phrase should be "<http-reason-phrase>"
-    And the OCS status code should be "<ocs-status>"
-    And the OCS status message should be:
-      """
-      Unable to create user: The password is too short. At least 10 characters are required.
-      """
-    And user "brand-new-user" should not exist
-    Examples:
-      | password  | ocs-api-version | ocs-status | http-status | http-reason-phrase |
-      | A         | 1               | 101        | 200         | OK                 |
-      | A         | 2               | 400        | 400         | Bad Request        |
-      | 123456789 | 1               | 101        | 200         | OK                 |
-      | 123456789 | 2               | 400        | 400         | Bad Request        |
-
-  @skipOnOcV10.3
-  # This has the OCS status message as it was with core 10.2.*
   Scenario Outline: admin creates a user with a password that is not long enough
     Given using OCS API version "<ocs-api-version>"
     And user "brand-new-user" has been deleted

--- a/tests/acceptance/features/apiPasswordAddUser/provisioningAddUserNumbers.feature
+++ b/tests/acceptance/features/apiPasswordAddUser/provisioningAddUserNumbers.feature
@@ -24,29 +24,6 @@ Feature: enforce the required number of numbers in a password when creating a us
       | moreNumbers1234 | 1               | 100        |
       | moreNumbers1234 | 2               | 200        |
 
-  @skipOnOcV10.2
-  # This has the new full OCS status message from core 10.3 onwards
-  Scenario Outline: admin creates a user with a password that does not have enough numbers
-    Given using OCS API version "<ocs-api-version>"
-    And user "brand-new-user" has been deleted
-    When the administrator sends a user creation request for user "brand-new-user" password "<password>" using the provisioning API
-    Then the HTTP status code should be "<http-status>"
-    And the HTTP reason phrase should be "<http-reason-phrase>"
-    And the OCS status code should be "<ocs-status>"
-    And the OCS status message should be:
-      """
-      Unable to create user: The password contains too few numbers. At least 3 numbers are required.
-      """
-    And user "brand-new-user" should not exist
-    Examples:
-      | password      | ocs-api-version | ocs-status | http-status | http-reason-phrase |
-      | NoNumbers     | 1               | 101        | 200         | OK                 |
-      | NoNumbers     | 2               | 400        | 400         | Bad Request        |
-      | Only22Numbers | 1               | 101        | 200         | OK                 |
-      | Only22Numbers | 2               | 400        | 400         | Bad Request        |
-
-  @skipOnOcV10.3
-  # This has the OCS status message as it was with core 10.2.*
   Scenario Outline: admin creates a user with a password that does not have enough numbers
     Given using OCS API version "<ocs-api-version>"
     And user "brand-new-user" has been deleted

--- a/tests/acceptance/features/apiPasswordAddUser/provisioningAddUserUppercaseLetters.feature
+++ b/tests/acceptance/features/apiPasswordAddUser/provisioningAddUserUppercaseLetters.feature
@@ -24,29 +24,6 @@ Feature: enforce the required number of uppercase letters in a password when cre
       | MoreThan3UpperCaseLetters | 1               | 100        |
       | MoreThan3UpperCaseLetters | 2               | 200        |
 
-  @skipOnOcV10.2
-  # This has the new full OCS status message from core 10.3 onwards
-  Scenario Outline: admin creates a user with a password that does not have enough uppercase letters
-    Given using OCS API version "<ocs-api-version>"
-    And user "brand-new-user" has been deleted
-    When the administrator sends a user creation request for user "brand-new-user" password "<password>" using the provisioning API
-    Then the HTTP status code should be "<http-status>"
-    And the HTTP reason phrase should be "<http-reason-phrase>"
-    And the OCS status code should be "<ocs-status>"
-    And the OCS status message should be:
-      """
-      Unable to create user: The password contains too few uppercase letters. At least 3 uppercase letters are required.
-      """
-    And user "brand-new-user" should not exist
-    Examples:
-      | password       | ocs-api-version | ocs-status | http-status | http-reason-phrase |
-      | 0uppercase     | 1               | 101        | 200         | OK                 |
-      | 0uppercase     | 2               | 400        | 400         | Bad Request        |
-      | Only2Uppercase | 1               | 101        | 200         | OK                 |
-      | Only2Uppercase | 2               | 400        | 400         | Bad Request        |
-
-  @skipOnOcV10.3
-  # This has the OCS status message as it was with core 10.2.*
   Scenario Outline: admin creates a user with a password that does not have enough uppercase letters
     Given using OCS API version "<ocs-api-version>"
     And user "brand-new-user" has been deleted

--- a/tests/acceptance/features/apiPasswordAddUserSpecial/provisioningAddUserRequirementCombinations.feature
+++ b/tests/acceptance/features/apiPasswordAddUserSpecial/provisioningAddUserRequirementCombinations.feature
@@ -32,38 +32,6 @@ Feature: enforce combinations of password policies when creating a user
       | More%Than$15!Characters-0 | 1               | 100        |
       | More%Than$15!Characters-0 | 2               | 200        |
 
-  @skipOnOcV10.2
-  # This has the new full OCS status message from core 10.3 onwards
-  Scenario Outline: admin creates a user with a password that does not meet the password policy
-    Given using OCS API version "<ocs-api-version>"
-    And user "brand-new-user" has been deleted
-    When the administrator sends a user creation request for user "brand-new-user" password "<password>" using the provisioning API
-    Then the HTTP status code should be "<http-status>"
-    And the HTTP reason phrase should be "<http-reason-phrase>"
-    And the OCS status code should be "<ocs-status>"
-    And the OCS status message should be "Unable to create user: <ocs-status-message>"
-    And user "brand-new-user" should not exist
-    Examples:
-      | password                       | ocs-api-version | ocs-status | http-status | http-reason-phrase | ocs-status-message                                                                            |
-        # just one of the requirements is not met
-      | aA1!bB2#cC&d                   | 1               | 101        | 200         | OK                 | The password is too short. At least 15 characters are required.                               |
-      | aA1!bB2#cC&d                   | 2               | 400        | 400         | Bad Request        | The password is too short. At least 15 characters are required.                               |
-      | aA1!bB2#cNOT&ENOUGH#LOWERCASE  | 1               | 101        | 200         | OK                 | The password contains too few lowercase letters. At least 4 lowercase letters are required.   |
-      | aA1!bB2#cNOT&ENOUGH#LOWERCASE  | 2               | 400        | 400         | Bad Request        | The password contains too few lowercase letters. At least 4 lowercase letters are required.   |
-      | aA1!bB2#cnot&enough#uppercase  | 1               | 101        | 200         | OK                 | The password contains too few uppercase letters. At least 3 uppercase letters are required.   |
-      | aA1!bB2#cnot&enough#uppercase  | 2               | 400        | 400         | Bad Request        | The password contains too few uppercase letters. At least 3 uppercase letters are required.   |
-      | Not&Enough#Numbers=1           | 1               | 101        | 200         | OK                 | The password contains too few numbers. At least 2 numbers are required.                       |
-      | Not&Enough#Numbers=1           | 2               | 400        | 400         | Bad Request        | The password contains too few numbers. At least 2 numbers are required.                       |
-      | Not&Enough#Special8Characters2 | 1               | 101        | 200         | OK                 | The password contains too few special characters. At least 3 special characters are required. |
-      | Not&Enough#Special8Characters2 | 2               | 400        | 400         | Bad Request        | The password contains too few special characters. At least 3 special characters are required. |
-        # multiple requirements are not met
-      | aA!1                           | 1               | 101        | 200         | OK                 | The password is too short. At least 15 characters are required.                               |
-      | aA!1                           | 2               | 400        | 400         | Bad Request        | The password is too short. At least 15 characters are required.                               |
-      | aA!123456789012345             | 1               | 101        | 200         | OK                 | The password contains too few lowercase letters. At least 4 lowercase letters are required.   |
-      | aA!123456789012345             | 2               | 400        | 400         | Bad Request        | The password contains too few lowercase letters. At least 4 lowercase letters are required.   |
-
-  @skipOnOcV10.3
-  # This has the OCS status message as it was with core 10.2.*
   Scenario Outline: admin creates a user with a password that does not meet the password policy
     Given using OCS API version "<ocs-api-version>"
     And user "brand-new-user" has been deleted
@@ -109,31 +77,6 @@ Feature: enforce combinations of password policies when creating a user
       | More^Than$15&Characters*0 | 1               | 100        |
       | More^Than$15&Characters*0 | 2               | 200        |
 
-  @skipOnOcV10.2
-  # This has the new full OCS status message from core 10.3 onwards
-  Scenario Outline: admin creates a user with a password that has invalid restricted special characters
-    Given the administrator has enabled the restrict to these special characters password policy
-    And the administrator has set the restricted special characters required to "$%^&*"
-    And using OCS API version "<ocs-api-version>"
-    And user "brand-new-user" has been deleted
-    When the administrator sends a user creation request for user "brand-new-user" password "<password>" using the provisioning API
-    Then the HTTP status code should be "<http-status>"
-    And the HTTP reason phrase should be "<http-reason-phrase>"
-    And the OCS status code should be "<ocs-status>"
-    And the OCS status message should be "Unable to create user: <ocs-status-message>"
-    And user "brand-new-user" should not exist
-    Examples:
-      | password        | ocs-api-version | ocs-status | http-status | http-reason-phrase | ocs-status-message                                                                          |
-      | 15#!!UPPloweZZZ | 1               | 101        | 200         | OK                 | The password contains invalid special characters. Only $%^&* are allowed.                   |
-      | 15#!!UPPloweZZZ | 2               | 400        | 400         | Bad Request        | The password contains invalid special characters. Only $%^&* are allowed.                   |
-      | 15&%!UPPloweZZZ | 1               | 101        | 200         | OK                 | The password contains invalid special characters. Only $%^&* are allowed.                   |
-      | 15&%!UPPloweZZZ | 2               | 400        | 400         | Bad Request        | The password contains invalid special characters. Only $%^&* are allowed.                   |
-        # multiple requirements are not met
-      | 15&%!UPPlowZZZZ | 1               | 101        | 200         | OK                 | The password contains too few lowercase letters. At least 4 lowercase letters are required. |
-      | 15&%!UPPlowZZZZ | 2               | 400        | 400         | Bad Request        | The password contains too few lowercase letters. At least 4 lowercase letters are required. |
-
-  @skipOnOcV10.3
-  # This has the OCS status message as it was with core 10.2.*
   Scenario Outline: admin creates a user with a password that has invalid restricted special characters
     Given the administrator has enabled the restrict to these special characters password policy
     And the administrator has set the restricted special characters required to "$%^&*"

--- a/tests/acceptance/features/apiPasswordAddUserSpecial/provisioningAddUserSpecialCharacters.feature
+++ b/tests/acceptance/features/apiPasswordAddUserSpecial/provisioningAddUserSpecialCharacters.feature
@@ -24,29 +24,6 @@ Feature: enforce the required number of special characters in a password when cr
       | 1!2@3#4$5%6^7&8*      | 1               | 100        |
       | 1!2@3#4$5%6^7&8*      | 2               | 200        |
 
-  @skipOnOcV10.2
-  # This has the new full OCS status message from core 10.3 onwards
-  Scenario Outline: admin creates a user with a password that does not have enough special characters
-    Given using OCS API version "<ocs-api-version>"
-    And user "brand-new-user" has been deleted
-    When the administrator sends a user creation request for user "brand-new-user" password "<password>" using the provisioning API
-    Then the HTTP status code should be "<http-status>"
-    And the HTTP reason phrase should be "<http-reason-phrase>"
-    And the OCS status code should be "<ocs-status>"
-    And the OCS status message should be:
-      """
-      Unable to create user: The password contains too few special characters. At least 3 special characters are required.
-      """
-    And user "brand-new-user" should not exist
-    Examples:
-      | password                 | ocs-api-version | ocs-status | http-status | http-reason-phrase |
-      | NoSpecialCharacters123   | 1               | 101        | 200         | OK                 |
-      | NoSpecialCharacters123   | 2               | 400        | 400         | Bad Request        |
-      | Only2$Special!Characters | 1               | 101        | 200         | OK                 |
-      | Only2$Special!Characters | 2               | 400        | 400         | Bad Request        |
-
-  @skipOnOcV10.3
-  # This has the OCS status message as it was with core 10.2.*
   Scenario Outline: admin creates a user with a password that does not have enough special characters
     Given using OCS API version "<ocs-api-version>"
     And user "brand-new-user" has been deleted

--- a/tests/acceptance/features/apiPasswordAddUserSpecial/provisioningAddUserSpecialCharactersRestrictions.feature
+++ b/tests/acceptance/features/apiPasswordAddUserSpecial/provisioningAddUserSpecialCharactersRestrictions.feature
@@ -26,29 +26,6 @@ Feature: enforce the restricted special characters in a password when creating a
       | 1*2&3^4%5$6           | 1               | 100        |
       | 1*2&3^4%5$6           | 2               | 200        |
 
-  @skipOnOcV10.2
-  # This has the new full OCS status message from core 10.3 onwards
-  Scenario Outline: admin creates a user with a password that does not have enough restricted special characters
-    Given using OCS API version "<ocs-api-version>"
-    And user "brand-new-user" has been deleted
-    When the administrator sends a user creation request for user "brand-new-user" password "<password>" using the provisioning API
-    Then the HTTP status code should be "<http-status>"
-    And the HTTP reason phrase should be "<http-reason-phrase>"
-    And the OCS status code should be "<ocs-status>"
-    And the OCS status message should be:
-      """
-      Unable to create user: The password contains too few special characters. At least 3 special characters ($%^&*) are required.
-      """
-    And user "brand-new-user" should not exist
-    Examples:
-      | password                 | ocs-api-version | ocs-status | http-status | http-reason-phrase |
-      | NoSpecialCharacters123   | 1               | 101        | 200         | OK                 |
-      | NoSpecialCharacters123   | 2               | 400        | 400         | Bad Request        |
-      | Only2$Special&Characters | 1               | 101        | 200         | OK                 |
-      | Only2$Special&Characters | 2               | 400        | 400         | Bad Request        |
-
-  @skipOnOcV10.3
-  # This has the OCS status message as it was with core 10.2.*
   Scenario Outline: admin creates a user with a password that does not have enough restricted special characters
     Given using OCS API version "<ocs-api-version>"
     And user "brand-new-user" has been deleted
@@ -68,29 +45,6 @@ Feature: enforce the restricted special characters in a password when creating a
       | Only2$Special&Characters | 1               | 101        | 200         | OK                 |
       | Only2$Special&Characters | 2               | 400        | 400         | Bad Request        |
 
-  @skipOnOcV10.2
-  # This has the new full OCS status message from core 10.3 onwards
-  Scenario Outline: admin creates a user with a password that has invalid special characters
-    Given using OCS API version "<ocs-api-version>"
-    And user "brand-new-user" has been deleted
-    When the administrator sends a user creation request for user "brand-new-user" password "<password>" using the provisioning API
-    Then the HTTP status code should be "<http-status>"
-    And the HTTP reason phrase should be "<http-reason-phrase>"
-    And the OCS status code should be "<ocs-status>"
-    And the OCS status message should be:
-      """
-      Unable to create user: The password contains invalid special characters. Only $%^&* are allowed.
-      """
-    And user "brand-new-user" should not exist
-    Examples:
-      | password                                 | ocs-api-version | ocs-status | http-status | http-reason-phrase |
-      | Only#Invalid!Special@Characters          | 1               | 101        | 200         | OK                 |
-      | Only#Invalid!Special@Characters          | 2               | 400        | 400         | Bad Request        |
-      | 1*2&3^4%5$6andInvalidSpecialCharacters#! | 1               | 101        | 200         | OK                 |
-      | 1*2&3^4%5$6andInvalidSpecialCharacters#! | 2               | 400        | 400         | Bad Request        |
-
-  @skipOnOcV10.3
-  # This has the OCS status message as it was with core 10.2.*
   Scenario Outline: admin creates a user with a password that has invalid special characters
     Given using OCS API version "<ocs-api-version>"
     And user "brand-new-user" has been deleted

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserLowercaseLetters.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserLowercaseLetters.feature
@@ -30,7 +30,7 @@ Feature: enforce the required number of lowercase letters in a password when cre
       | user1    | <password> |
     Then the command should have failed with exit code 1
     # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
-    And the command output should contain the text 'The password contains too few lowercase letters. At least 3 lowercase'
+    And the command error output should contain the text 'The password contains too few lowercase letters. At least 3 lowercase'
     And user "user1" should not exist
     Examples:
       | password   |

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserMinimumLength.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserMinimumLength.feature
@@ -29,7 +29,7 @@ Feature: enforce the minimum length of a password when creating a user
       | username | password   |
       | user1    | <password> |
     Then the command should have failed with exit code 1
-    And the command output should contain the text 'The password is too short. At least 10 characters are required.'
+    And the command error output should contain the text 'The password is too short. At least 10 characters are required.'
     And user "user1" should not exist
     Examples:
       | password  |

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserNumbers.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserNumbers.feature
@@ -29,7 +29,7 @@ Feature: enforce the required number of numbers in a password when creating a us
       | username | password   |
       | user1    | <password> |
     Then the command should have failed with exit code 1
-    And the command output should contain the text 'The password contains too few numbers. At least 3 numbers are required.'
+    And the command error output should contain the text 'The password contains too few numbers. At least 3 numbers are required.'
     And user "user1" should not exist
     Examples:
       | password      |

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserRequirementCombinations.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserRequirementCombinations.feature
@@ -37,7 +37,7 @@ Feature: enforce combinations of password policies when creating a user
       | username | password   |
       | user1    | <password> |
     Then the command should have failed with exit code 1
-    And the command output should contain the text '<message>'
+    And the command error output should contain the text '<message>'
     And user "user1" should not exist
     Examples:
       | password                       | message                                                                   |
@@ -95,7 +95,7 @@ Feature: enforce combinations of password policies when creating a user
       | username | password   |
       | user1    | <password> |
     Then the command should have failed with exit code 1
-    And the command output should contain the text '<message>'
+    And the command error output should contain the text '<message>'
     And user "user1" should not exist
     Examples:
       | password        | message                                                                   |

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserSpecialCharacters.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserSpecialCharacters.feature
@@ -30,7 +30,7 @@ Feature: enforce the required number of special characters in a password when cr
       | user1    | <password> |
     Then the command should have failed with exit code 1
     # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
-    And the command output should contain the text 'The password contains too few special characters. At least 3 special char'
+    And the command error output should contain the text 'The password contains too few special characters. At least 3 special char'
     And user "user1" should not exist
     Examples:
       | password                 |

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserSpecialCharactersRestrictions.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserSpecialCharactersRestrictions.feature
@@ -32,7 +32,7 @@ Feature: enforce the restricted special characters in a password when creating a
       | user1    | <password> |
     Then the command should have failed with exit code 1
     # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
-    And the command output should contain the text 'The password contains too few special characters. At least 3 special char'
+    And the command error output should contain the text 'The password contains too few special characters. At least 3 special char'
     And user "user1" should not exist
     Examples:
       | password                 |
@@ -62,7 +62,7 @@ Feature: enforce the restricted special characters in a password when creating a
       | user1    | <password> |
     Then the command should have failed with exit code 1
     # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
-    And the command output should contain the text 'The password contains invalid special characters. Only $%^&* are allowed.'
+    And the command error output should contain the text 'The password contains invalid special characters. Only $%^&* are allowed.'
     And user "user1" should not exist
     Examples:
       | password                                 |

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserUppercaseLetters.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserUppercaseLetters.feature
@@ -30,7 +30,7 @@ Feature: enforce the required number of uppercase letters in a password when cre
       | user1    | <password> |
     Then the command should have failed with exit code 1
     # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
-    And the command output should contain the text 'The password contains too few uppercase letters. At least 3 uppercase'
+    And the command error output should contain the text 'The password contains too few uppercase letters. At least 3 uppercase'
     And user "user1" should not exist
     Examples:
       | password       |


### PR DESCRIPTION
Revert the changes which were part of https://github.com/owncloud/password_policy/pull/241. 