### PR TITLE
Drop PHP 7.0 from drone CI

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -18,12 +18,11 @@ config = {
 	'phpunit': {
 		'allDatabases' : {
 			'phpVersions': [
-				'7.0',
+				'7.1',
 			]
 		},
 		'reducedDatabases' : {
 			'phpVersions': [
-				'7.1',
 				'7.2',
 				'7.3',
 			],
@@ -155,7 +154,7 @@ def codestyle():
 		return pipelines
 
 	default = {
-		'phpVersions': ['7.0'],
+		'phpVersions': ['7.1'],
 	}
 
 	if 'defaults' in config:
@@ -344,7 +343,7 @@ def phan():
 		return pipelines
 
 	default = {
-		'phpVersions': ['7.0', '7.1', '7.2', '7.3'],
+		'phpVersions': ['7.1', '7.2', '7.3'],
 	}
 
 	if 'defaults' in config:
@@ -416,7 +415,7 @@ def build():
 		return pipelines
 
 	default = {
-		'phpVersions': ['7.0'],
+		'phpVersions': ['7.1'],
 		'commands': [
 			'make dist'
 		],
@@ -541,13 +540,13 @@ def javascript():
 		},
 		'steps':
 			installCore('daily-master-qa', 'sqlite', False) +
-			installApp('7.0') +
-			setupServerAndApp('7.0', params['logLevel']) +
+			installApp('7.1') +
+			setupServerAndApp('7.1', params['logLevel']) +
 			params['extraSetup'] +
 		[
 			{
 				'name': 'js-tests',
-				'image': 'owncloudci/php:7.0',
+				'image': 'owncloudci/php:7.1',
 				'pull': 'always',
 				'environment': params['extraEnvironment'],
 				'commands': params['extraCommandsBeforeTestRun'] + [
@@ -594,7 +593,7 @@ def phptests(testType):
 	errorFound = False
 
 	default = {
-		'phpVersions': ['7.0', '7.1', '7.2', '7.3'],
+		'phpVersions': ['7.1', '7.2', '7.3'],
 		'databases': [
 			'sqlite', 'mariadb:10.2', 'mysql:5.5', 'mysql:5.7', 'postgres:9.4', 'oracle'
 		],
@@ -761,7 +760,7 @@ def acceptance():
 	default = {
 		'servers': ['daily-master-qa', 'latest'],
 		'browsers': ['chrome'],
-		'phpVersions': ['7.0'],
+		'phpVersions': ['7.1'],
 		'databases': ['mariadb:10.2'],
 		'federatedServerNeeded': False,
 		'filterTags': '',
@@ -1338,7 +1337,7 @@ def setupCeph(serviceParams):
 
 	createFirstBucket = serviceParams['createFirstBucket'] if 'createFirstBucket' in serviceParams else True
 	setupCommands = serviceParams['setupCommands'] if 'setupCommands' in serviceParams else [
-		'wait-for-it -t 60 ceph:80',
+		'wait-for-it -t 120 ceph:80',
 		'cd /var/www/owncloud/server/apps/files_primary_s3',
 		'cp tests/drone/ceph.config.php /var/www/owncloud/server/config',
 		'cd /var/www/owncloud/server',
@@ -1346,7 +1345,7 @@ def setupCeph(serviceParams):
 
 	return [{
 		'name': 'setup-ceph',
-		'image': 'owncloudci/php:7.0',
+		'image': 'owncloudci/php:7.1',
 		'pull': 'always',
 		'commands': setupCommands + ([
 			'./apps/files_primary_s3/tests/drone/create-bucket.sh',
@@ -1366,7 +1365,7 @@ def setupScality(serviceParams):
 	createFirstBucket = serviceParams['createFirstBucket'] if 'createFirstBucket' in serviceParams else True
 	createExtraBuckets = serviceParams['createExtraBuckets'] if 'createExtraBuckets' in serviceParams else False
 	setupCommands = serviceParams['setupCommands'] if 'setupCommands' in serviceParams else [
-		'wait-for-it -t 60 scality:8000',
+		'wait-for-it -t 120 scality:8000',
 		'cd /var/www/owncloud/server/apps/files_primary_s3',
 		'cp tests/drone/%s /var/www/owncloud/server/config' % configFile,
 		'cd /var/www/owncloud/server'
@@ -1374,7 +1373,7 @@ def setupScality(serviceParams):
 
 	return [{
 		'name': 'setup-scality',
-		'image': 'owncloudci/php:7.0',
+		'image': 'owncloudci/php:7.1',
 		'pull': 'always',
 		'commands': setupCommands + ([
 			'php occ s3:create-bucket owncloud --accept-warning'

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 ---
 kind: pipeline
 type: docker
-name: coding-standard-php7.0
+name: coding-standard-php7.1
 
 platform:
   os: linux
@@ -14,48 +14,9 @@ workspace:
 steps:
 - name: coding-standard
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - make test-php-style
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
----
-kind: pipeline
-type: docker
-name: phan-php7.0
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: server/apps/password_policy
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: sqlite
-    db_name: owncloud
-    db_password: owncloud
-    db_type: sqlite
-    db_username: owncloud
-    exclude: apps/password_policy
-    version: daily-master-qa
-
-- name: phan
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - make test-php-phan
 
 trigger:
   ref:
@@ -183,457 +144,6 @@ trigger:
 ---
 kind: pipeline
 type: docker
-name: phpunit-php7.0-sqlite
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: server/apps/password_policy
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: sqlite
-    db_name: owncloud
-    db_password: owncloud
-    db_type: sqlite
-    db_username: owncloud
-    exclude: apps/password_policy
-    version: daily-master-qa
-
-- name: setup-server-password_policy
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e password_policy
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: phpunit-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - make test-php-unit-dbg
-
-- name: codecov-upload
-  pull: always
-  image: plugins/codecov:2
-  settings:
-    paths:
-    - tests/output/clover.xml
-    token:
-      from_secret: codecov_token
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
-
----
-kind: pipeline
-type: docker
-name: phpunit-php7.0-mariadb10.2
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: server/apps/password_policy
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: mariadb
-    db_name: owncloud
-    db_password: owncloud
-    db_type: mysql
-    db_username: owncloud
-    exclude: apps/password_policy
-    version: daily-master-qa
-
-- name: setup-server-password_policy
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e password_policy
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: phpunit-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - make test-php-unit-dbg
-
-- name: codecov-upload
-  pull: always
-  image: plugins/codecov:2
-  settings:
-    paths:
-    - tests/output/clover.xml
-    token:
-      from_secret: codecov_token
-
-services:
-- name: mariadb
-  pull: always
-  image: mariadb:10.2
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
-
----
-kind: pipeline
-type: docker
-name: phpunit-php7.0-mysql5.5
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: server/apps/password_policy
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: mysql
-    db_name: owncloud
-    db_password: owncloud
-    db_type: mysql
-    db_username: owncloud
-    exclude: apps/password_policy
-    version: daily-master-qa
-
-- name: setup-server-password_policy
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e password_policy
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: phpunit-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - make test-php-unit-dbg
-
-- name: codecov-upload
-  pull: always
-  image: plugins/codecov:2
-  settings:
-    paths:
-    - tests/output/clover.xml
-    token:
-      from_secret: codecov_token
-
-services:
-- name: mysql
-  pull: always
-  image: mysql:5.5
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
-
----
-kind: pipeline
-type: docker
-name: phpunit-php7.0-mysql5.7
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: server/apps/password_policy
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: mysql
-    db_name: owncloud
-    db_password: owncloud
-    db_type: mysql
-    db_username: owncloud
-    exclude: apps/password_policy
-    version: daily-master-qa
-
-- name: setup-server-password_policy
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e password_policy
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: phpunit-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - make test-php-unit-dbg
-
-- name: codecov-upload
-  pull: always
-  image: plugins/codecov:2
-  settings:
-    paths:
-    - tests/output/clover.xml
-    token:
-      from_secret: codecov_token
-
-services:
-- name: mysql
-  pull: always
-  image: mysql:5.7
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
-
----
-kind: pipeline
-type: docker
-name: phpunit-php7.0-postgres9.4
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: server/apps/password_policy
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: postgres
-    db_name: owncloud
-    db_password: owncloud
-    db_type: pgsql
-    db_username: owncloud
-    exclude: apps/password_policy
-    version: daily-master-qa
-
-- name: setup-server-password_policy
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e password_policy
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: phpunit-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - make test-php-unit-dbg
-
-- name: codecov-upload
-  pull: always
-  image: plugins/codecov:2
-  settings:
-    paths:
-    - tests/output/clover.xml
-    token:
-      from_secret: codecov_token
-
-services:
-- name: postgres
-  pull: always
-  image: postgres:9.4
-  environment:
-    POSTGRES_DB: owncloud
-    POSTGRES_PASSWORD: owncloud
-    POSTGRES_USER: owncloud
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
-
----
-kind: pipeline
-type: docker
-name: phpunit-php7.0-oracle
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: server/apps/password_policy
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: oracle
-    db_name: XE
-    db_password: oracle
-    db_type: oci
-    db_username: system
-    exclude: apps/password_policy
-    version: daily-master-qa
-
-- name: setup-server-password_policy
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e password_policy
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: phpunit-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - make test-php-unit-dbg
-
-- name: codecov-upload
-  pull: always
-  image: plugins/codecov:2
-  settings:
-    paths:
-    - tests/output/clover.xml
-    token:
-      from_secret: codecov_token
-
-services:
-- name: oracle
-  pull: always
-  image: deepdiver/docker-oracle-xe-11g:latest
-  environment:
-    ORACLE_DB: XE
-    ORACLE_DISABLE_ASYNCH_IO: true
-    ORACLE_PASSWORD: oracle
-    ORACLE_USER: system
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
-
----
-kind: pipeline
-type: docker
 name: phpunit-php7.1-sqlite
 
 platform:
@@ -674,7 +184,16 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - make test-php-unit
+  - make test-php-unit-dbg
+
+- name: codecov-upload
+  pull: always
+  image: plugins/codecov:2
+  settings:
+    paths:
+    - tests/output/clover.xml
+    token:
+      from_secret: codecov_token
 
 trigger:
   ref:
@@ -683,8 +202,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -732,7 +250,16 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - make test-php-unit
+  - make test-php-unit-dbg
+
+- name: codecov-upload
+  pull: always
+  image: plugins/codecov:2
+  settings:
+    paths:
+    - tests/output/clover.xml
+    token:
+      from_secret: codecov_token
 
 services:
 - name: mariadb
@@ -751,8 +278,310 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.1-mysql5.5
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/password_policy
+    version: daily-master-qa
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make test-php-unit-dbg
+
+- name: codecov-upload
+  pull: always
+  image: plugins/codecov:2
+  settings:
+    paths:
+    - tests/output/clover.xml
+    token:
+      from_secret: codecov_token
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.5
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.1
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.1-mysql5.7
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/password_policy
+    version: daily-master-qa
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make test-php-unit-dbg
+
+- name: codecov-upload
+  pull: always
+  image: plugins/codecov:2
+  settings:
+    paths:
+    - tests/output/clover.xml
+    token:
+      from_secret: codecov_token
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.1
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.1-postgres9.4
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: postgres
+    db_name: owncloud
+    db_password: owncloud
+    db_type: pgsql
+    db_username: owncloud
+    exclude: apps/password_policy
+    version: daily-master-qa
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make test-php-unit-dbg
+
+- name: codecov-upload
+  pull: always
+  image: plugins/codecov:2
+  settings:
+    paths:
+    - tests/output/clover.xml
+    token:
+      from_secret: codecov_token
+
+services:
+- name: postgres
+  pull: always
+  image: postgres:9.4
+  environment:
+    POSTGRES_DB: owncloud
+    POSTGRES_PASSWORD: owncloud
+    POSTGRES_USER: owncloud
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.1
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.1-oracle
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    exclude: apps/password_policy
+    version: daily-master-qa
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make test-php-unit-dbg
+
+- name: codecov-upload
+  pull: always
+  image: plugins/codecov:2
+  settings:
+    paths:
+    - tests/output/clover.xml
+    token:
+      from_secret: codecov_token
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -809,8 +638,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -877,8 +705,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -935,8 +762,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -1003,8 +829,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -1012,7 +837,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIPwdAddUser-master-chrome-mariadb10.2-php7.0
+name: webUIPwdAddUser-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -1038,7 +863,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -1049,7 +874,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -1068,13 +893,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -1110,7 +935,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -1127,8 +952,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -1136,7 +960,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIPwdAddUser-master-firefox-mariadb10.2-php7.0
+name: webUIPwdAddUser-master-firefox-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -1162,7 +986,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -1173,7 +997,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -1192,13 +1016,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -1235,7 +1059,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -1252,8 +1076,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -1261,7 +1084,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIPwdAddUser-latest-chrome-mariadb10.2-php7.0
+name: webUIPwdAddUser-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -1287,7 +1110,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -1298,7 +1121,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -1317,13 +1140,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -1359,7 +1182,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -1376,8 +1199,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -1385,7 +1207,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIPwdAddUser-latest-firefox-mariadb10.2-php7.0
+name: webUIPwdAddUser-latest-firefox-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -1411,7 +1233,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -1422,7 +1244,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -1441,13 +1263,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -1484,7 +1306,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -1501,8 +1323,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -1510,7 +1331,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIPwdAddUsSp-master-chrome-mariadb10.2-php7.0
+name: webUIPwdAddUsSp-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -1536,7 +1357,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -1547,7 +1368,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -1566,13 +1387,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -1608,7 +1429,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -1625,8 +1446,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -1634,7 +1454,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIPwdAddUsSp-master-firefox-mariadb10.2-php7.0
+name: webUIPwdAddUsSp-master-firefox-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -1660,7 +1480,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -1671,7 +1491,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -1690,13 +1510,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -1733,7 +1553,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -1750,8 +1570,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -1759,7 +1578,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIPwdAddUsSp-latest-chrome-mariadb10.2-php7.0
+name: webUIPwdAddUsSp-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -1785,7 +1604,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -1796,7 +1615,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -1815,13 +1634,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -1857,7 +1676,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -1874,8 +1693,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -1883,7 +1701,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIPwdAddUsSp-latest-firefox-mariadb10.2-php7.0
+name: webUIPwdAddUsSp-latest-firefox-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -1909,7 +1727,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -1920,7 +1738,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -1939,13 +1757,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -1982,7 +1800,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -1999,8 +1817,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -2008,7 +1825,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIPwdReset-master-chrome-mariadb10.2-php7.0
+name: webUIPwdReset-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -2034,7 +1851,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -2045,7 +1862,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -2064,13 +1881,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -2106,7 +1923,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2123,8 +1940,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -2132,7 +1948,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIPwdReset-master-firefox-mariadb10.2-php7.0
+name: webUIPwdReset-master-firefox-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -2158,7 +1974,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -2169,7 +1985,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -2188,13 +2004,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -2231,7 +2047,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2248,8 +2064,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -2257,7 +2072,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIPwdReset-latest-chrome-mariadb10.2-php7.0
+name: webUIPwdReset-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -2283,7 +2098,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -2294,7 +2109,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -2313,13 +2128,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -2355,7 +2170,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2372,8 +2187,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -2381,7 +2195,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIPwdReset-latest-firefox-mariadb10.2-php7.0
+name: webUIPwdReset-latest-firefox-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -2407,7 +2221,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -2418,7 +2232,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -2437,13 +2251,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -2480,7 +2294,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2497,8 +2311,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -2506,7 +2319,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIGuests-master-chrome-mariadb10.2-php7.0
+name: webUIGuests-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -2532,7 +2345,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -2543,7 +2356,7 @@ steps:
 
 - name: install-extra-apps
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - git clone https://github.com/owncloud/guests.git /var/www/owncloud/testrunner/apps/guests
   - cp -r /var/www/owncloud/testrunner/apps/guests /var/www/owncloud/server/apps/
@@ -2554,7 +2367,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -2573,13 +2386,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -2615,7 +2428,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2632,8 +2445,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -2641,7 +2453,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIGuests-master-firefox-mariadb10.2-php7.0
+name: webUIGuests-master-firefox-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -2667,7 +2479,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -2678,7 +2490,7 @@ steps:
 
 - name: install-extra-apps
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - git clone https://github.com/owncloud/guests.git /var/www/owncloud/testrunner/apps/guests
   - cp -r /var/www/owncloud/testrunner/apps/guests /var/www/owncloud/server/apps/
@@ -2689,7 +2501,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -2708,13 +2520,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -2751,7 +2563,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2768,8 +2580,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -2777,7 +2588,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIGuests-latest-chrome-mariadb10.2-php7.0
+name: webUIGuests-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -2803,7 +2614,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -2814,7 +2625,7 @@ steps:
 
 - name: install-extra-apps
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - git clone https://github.com/owncloud/guests.git /var/www/owncloud/testrunner/apps/guests
   - cp -r /var/www/owncloud/testrunner/apps/guests /var/www/owncloud/server/apps/
@@ -2825,7 +2636,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -2844,13 +2655,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -2886,7 +2697,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2903,8 +2714,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -2912,7 +2722,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIGuests-latest-firefox-mariadb10.2-php7.0
+name: webUIGuests-latest-firefox-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -2938,7 +2748,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -2949,7 +2759,7 @@ steps:
 
 - name: install-extra-apps
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - git clone https://github.com/owncloud/guests.git /var/www/owncloud/testrunner/apps/guests
   - cp -r /var/www/owncloud/testrunner/apps/guests /var/www/owncloud/server/apps/
@@ -2960,7 +2770,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -2979,13 +2789,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -3022,7 +2832,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3039,8 +2849,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -3048,7 +2857,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIPwdChange-master-chrome-mariadb10.2-php7.0
+name: webUIPwdChange-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -3074,7 +2883,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -3085,7 +2894,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -3104,13 +2913,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -3141,7 +2950,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3158,8 +2967,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -3167,7 +2975,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIPwdChange-master-firefox-mariadb10.2-php7.0
+name: webUIPwdChange-master-firefox-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -3193,7 +3001,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -3204,7 +3012,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -3223,13 +3031,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -3261,7 +3069,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3278,8 +3086,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -3287,7 +3094,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIPwdChange-latest-chrome-mariadb10.2-php7.0
+name: webUIPwdChange-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -3313,7 +3120,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -3324,7 +3131,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -3343,13 +3150,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -3380,7 +3187,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3397,8 +3204,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -3406,7 +3212,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIPwdChange-latest-firefox-mariadb10.2-php7.0
+name: webUIPwdChange-latest-firefox-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -3432,7 +3238,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -3443,7 +3249,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -3462,13 +3268,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -3500,7 +3306,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3517,8 +3323,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -3526,7 +3331,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIPwdChangeSp-master-chrome-mariadb10.2-php7.0
+name: webUIPwdChangeSp-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -3552,7 +3357,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -3563,7 +3368,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -3582,13 +3387,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -3619,7 +3424,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3636,8 +3441,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -3645,7 +3449,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIPwdChangeSp-master-firefox-mariadb10.2-php7.0
+name: webUIPwdChangeSp-master-firefox-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -3671,7 +3475,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -3682,7 +3486,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -3701,13 +3505,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -3739,7 +3543,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3756,8 +3560,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -3765,7 +3568,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIPwdChangeSp-latest-chrome-mariadb10.2-php7.0
+name: webUIPwdChangeSp-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -3791,7 +3594,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -3802,7 +3605,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -3821,13 +3624,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -3858,7 +3661,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3875,8 +3678,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -3884,7 +3686,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIPwdChangeSp-latest-firefox-mariadb10.2-php7.0
+name: webUIPwdChangeSp-latest-firefox-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -3910,7 +3712,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -3921,7 +3723,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -3940,13 +3742,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -3978,7 +3780,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3995,8 +3797,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -4004,7 +3805,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIPwdPolSet-master-chrome-mariadb10.2-php7.0
+name: webUIPwdPolSet-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -4030,7 +3831,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -4041,7 +3842,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -4060,13 +3861,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -4097,7 +3898,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -4114,8 +3915,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -4123,7 +3923,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIPwdPolSet-master-firefox-mariadb10.2-php7.0
+name: webUIPwdPolSet-master-firefox-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -4149,7 +3949,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -4160,7 +3960,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -4179,13 +3979,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -4217,7 +4017,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -4234,8 +4034,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -4243,7 +4042,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIPwdPolSet-latest-chrome-mariadb10.2-php7.0
+name: webUIPwdPolSet-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -4269,7 +4068,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -4280,7 +4079,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -4299,13 +4098,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -4336,7 +4135,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -4353,8 +4152,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -4362,7 +4160,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIPwdPolSet-latest-firefox-mariadb10.2-php7.0
+name: webUIPwdPolSet-latest-firefox-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -4388,7 +4186,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -4399,7 +4197,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -4418,13 +4216,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -4456,7 +4254,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -4473,8 +4271,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -4482,7 +4279,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIPublicShare-master-chrome-mariadb10.2-php7.0
+name: webUIPublicShare-master-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -4508,7 +4305,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -4519,7 +4316,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -4538,13 +4335,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -4575,7 +4372,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -4592,8 +4389,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -4601,7 +4397,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIPublicShare-master-firefox-mariadb10.2-php7.0
+name: webUIPublicShare-master-firefox-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -4627,7 +4423,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -4638,7 +4434,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -4657,13 +4453,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -4695,7 +4491,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -4712,8 +4508,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -4721,7 +4516,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIPublicShare-latest-chrome-mariadb10.2-php7.0
+name: webUIPublicShare-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -4747,7 +4542,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -4758,7 +4553,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -4777,13 +4572,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -4814,7 +4609,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -4831,8 +4626,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -4840,7 +4634,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIPublicShare-latest-firefox-mariadb10.2-php7.0
+name: webUIPublicShare-latest-firefox-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -4866,7 +4660,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -4877,7 +4671,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -4896,13 +4690,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -4934,7 +4728,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -4951,8 +4745,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -4960,7 +4753,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiGuests-master-mariadb10.2-php7.0
+name: apiGuests-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -4986,7 +4779,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -4997,7 +4790,7 @@ steps:
 
 - name: install-extra-apps
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - git clone https://github.com/owncloud/guests.git /var/www/owncloud/testrunner/apps/guests
   - cp -r /var/www/owncloud/testrunner/apps/guests /var/www/owncloud/server/apps/
@@ -5008,7 +4801,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -5027,13 +4820,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -5059,7 +4852,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5076,8 +4869,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -5085,7 +4877,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiGuests-master-oracle-php7.0
+name: apiGuests-master-oracle-php7.1
 
 platform:
   os: linux
@@ -5111,7 +4903,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -5122,7 +4914,7 @@ steps:
 
 - name: install-extra-apps
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - git clone https://github.com/owncloud/guests.git /var/www/owncloud/testrunner/apps/guests
   - cp -r /var/www/owncloud/testrunner/apps/guests /var/www/owncloud/server/apps/
@@ -5133,7 +4925,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -5152,13 +4944,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -5184,7 +4976,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5201,8 +4993,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -5210,7 +5001,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiGuests-latest-mariadb10.2-php7.0
+name: apiGuests-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -5236,7 +5027,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -5247,7 +5038,7 @@ steps:
 
 - name: install-extra-apps
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - git clone https://github.com/owncloud/guests.git /var/www/owncloud/testrunner/apps/guests
   - cp -r /var/www/owncloud/testrunner/apps/guests /var/www/owncloud/server/apps/
@@ -5258,7 +5049,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -5277,13 +5068,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -5309,7 +5100,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5326,8 +5117,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -5335,7 +5125,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiGuests-latest-oracle-php7.0
+name: apiGuests-latest-oracle-php7.1
 
 platform:
   os: linux
@@ -5361,7 +5151,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -5372,7 +5162,7 @@ steps:
 
 - name: install-extra-apps
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - git clone https://github.com/owncloud/guests.git /var/www/owncloud/testrunner/apps/guests
   - cp -r /var/www/owncloud/testrunner/apps/guests /var/www/owncloud/server/apps/
@@ -5383,7 +5173,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -5402,13 +5192,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -5434,7 +5224,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5451,8 +5241,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -5460,7 +5249,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiPwdAddUser-master-mariadb10.2-php7.0
+name: apiPwdAddUser-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -5486,7 +5275,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -5497,7 +5286,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -5516,13 +5305,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -5543,7 +5332,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5560,8 +5349,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -5569,7 +5357,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiPwdAddUser-master-oracle-php7.0
+name: apiPwdAddUser-master-oracle-php7.1
 
 platform:
   os: linux
@@ -5595,7 +5383,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -5606,7 +5394,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -5625,13 +5413,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -5652,7 +5440,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5669,8 +5457,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -5678,7 +5465,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiPwdAddUser-latest-mariadb10.2-php7.0
+name: apiPwdAddUser-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -5704,7 +5491,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -5715,7 +5502,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -5734,13 +5521,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -5761,7 +5548,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5778,8 +5565,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -5787,7 +5573,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiPwdAddUser-latest-oracle-php7.0
+name: apiPwdAddUser-latest-oracle-php7.1
 
 platform:
   os: linux
@@ -5813,7 +5599,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -5824,7 +5610,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -5843,13 +5629,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -5870,7 +5656,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5887,8 +5673,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -5896,7 +5681,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiPwdAddUserSpecial-master-mariadb10.2-php7.0
+name: apiPwdAddUserSpecial-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -5922,7 +5707,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -5933,7 +5718,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -5952,13 +5737,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -5979,7 +5764,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5996,8 +5781,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -6005,7 +5789,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiPwdAddUserSpecial-master-oracle-php7.0
+name: apiPwdAddUserSpecial-master-oracle-php7.1
 
 platform:
   os: linux
@@ -6031,7 +5815,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -6042,7 +5826,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -6061,13 +5845,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -6088,7 +5872,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6105,8 +5889,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -6114,7 +5897,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiPwdAddUserSpecial-latest-mariadb10.2-php7.0
+name: apiPwdAddUserSpecial-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -6140,7 +5923,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -6151,7 +5934,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -6170,13 +5953,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -6197,7 +5980,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6214,8 +5997,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -6223,7 +6005,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiPwdAddUserSpecial-latest-oracle-php7.0
+name: apiPwdAddUserSpecial-latest-oracle-php7.1
 
 platform:
   os: linux
@@ -6249,7 +6031,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -6260,7 +6042,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -6279,13 +6061,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -6306,7 +6088,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6323,8 +6105,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -6332,7 +6113,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiPwdChange-master-mariadb10.2-php7.0
+name: apiPwdChange-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -6358,7 +6139,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -6369,7 +6150,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -6388,13 +6169,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -6415,7 +6196,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6432,8 +6213,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -6441,7 +6221,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiPwdChange-master-oracle-php7.0
+name: apiPwdChange-master-oracle-php7.1
 
 platform:
   os: linux
@@ -6467,7 +6247,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -6478,7 +6258,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -6497,13 +6277,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -6524,7 +6304,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6541,8 +6321,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -6550,7 +6329,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiPwdChange-latest-mariadb10.2-php7.0
+name: apiPwdChange-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -6576,7 +6355,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -6587,7 +6366,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -6606,13 +6385,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -6633,7 +6412,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6650,8 +6429,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -6659,7 +6437,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiPwdChange-latest-oracle-php7.0
+name: apiPwdChange-latest-oracle-php7.1
 
 platform:
   os: linux
@@ -6685,7 +6463,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -6696,7 +6474,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -6715,13 +6493,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -6742,7 +6520,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6759,8 +6537,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -6768,7 +6545,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiPwdChangeSpecial-master-mariadb10.2-php7.0
+name: apiPwdChangeSpecial-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -6794,7 +6571,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -6805,7 +6582,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -6824,13 +6601,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -6851,7 +6628,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6868,8 +6645,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -6877,7 +6653,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiPwdChangeSpecial-master-oracle-php7.0
+name: apiPwdChangeSpecial-master-oracle-php7.1
 
 platform:
   os: linux
@@ -6903,7 +6679,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -6914,7 +6690,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -6933,13 +6709,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -6960,7 +6736,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6977,8 +6753,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -6986,7 +6761,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiPwdChangeSpecial-latest-mariadb10.2-php7.0
+name: apiPwdChangeSpecial-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -7012,7 +6787,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -7023,7 +6798,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -7042,13 +6817,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -7069,7 +6844,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -7086,8 +6861,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -7095,7 +6869,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiPwdChangeSpecial-latest-oracle-php7.0
+name: apiPwdChangeSpecial-latest-oracle-php7.1
 
 platform:
   os: linux
@@ -7121,7 +6895,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -7132,7 +6906,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -7151,13 +6925,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -7178,7 +6952,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -7195,8 +6969,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -7204,7 +6977,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiUpdateShare-master-mariadb10.2-php7.0
+name: apiUpdateShare-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -7230,7 +7003,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -7241,7 +7014,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -7260,13 +7033,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -7287,7 +7060,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -7304,8 +7077,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -7313,7 +7085,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiUpdateShare-master-oracle-php7.0
+name: apiUpdateShare-master-oracle-php7.1
 
 platform:
   os: linux
@@ -7339,7 +7111,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -7350,7 +7122,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -7369,13 +7141,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -7396,7 +7168,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -7413,8 +7185,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -7422,7 +7193,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiUpdateShare-latest-mariadb10.2-php7.0
+name: apiUpdateShare-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -7448,7 +7219,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -7459,7 +7230,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -7478,13 +7249,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -7505,7 +7276,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -7522,8 +7293,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -7531,7 +7301,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiUpdateShare-latest-oracle-php7.0
+name: apiUpdateShare-latest-oracle-php7.1
 
 platform:
   os: linux
@@ -7557,7 +7327,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -7568,7 +7338,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -7587,13 +7357,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -7614,7 +7384,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -7631,8 +7401,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -7640,7 +7409,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: cliPasswordAddUser-master-mariadb10.2-php7.0
+name: cliPasswordAddUser-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -7666,7 +7435,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -7677,7 +7446,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -7696,13 +7465,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -7723,7 +7492,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -7740,8 +7509,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -7749,7 +7517,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: cliPasswordAddUser-latest-mariadb10.2-php7.0
+name: cliPasswordAddUser-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -7775,7 +7543,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -7786,7 +7554,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -7805,13 +7573,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -7832,7 +7600,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -7849,8 +7617,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -7858,7 +7625,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: cliPasswordChange-master-mariadb10.2-php7.0
+name: cliPasswordChange-master-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -7884,7 +7651,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -7895,7 +7662,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -7914,13 +7681,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -7941,7 +7708,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -7958,8 +7725,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -7967,7 +7733,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: cliPasswordChange-latest-mariadb10.2-php7.0
+name: cliPasswordChange-latest-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -7993,7 +7759,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -8004,7 +7770,7 @@ steps:
 
 - name: setup-server-password_policy
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -8023,13 +7789,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -8050,7 +7816,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -8067,8 +7833,7 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- phan-php7.0
+- coding-standard-php7.1
 - phan-php7.1
 - phan-php7.2
 - phan-php7.3
@@ -8103,77 +7868,75 @@ trigger:
   - failure
 
 depends_on:
-- phpunit-php7.0-sqlite
-- phpunit-php7.0-mariadb10.2
-- phpunit-php7.0-mysql5.5
-- phpunit-php7.0-mysql5.7
-- phpunit-php7.0-postgres9.4
-- phpunit-php7.0-oracle
 - phpunit-php7.1-sqlite
 - phpunit-php7.1-mariadb10.2
+- phpunit-php7.1-mysql5.5
+- phpunit-php7.1-mysql5.7
+- phpunit-php7.1-postgres9.4
+- phpunit-php7.1-oracle
 - phpunit-php7.2-sqlite
 - phpunit-php7.2-mariadb10.2
 - phpunit-php7.3-sqlite
 - phpunit-php7.3-mariadb10.2
-- webUIPwdAddUser-master-chrome-mariadb10.2-php7.0
-- webUIPwdAddUser-master-firefox-mariadb10.2-php7.0
-- webUIPwdAddUser-latest-chrome-mariadb10.2-php7.0
-- webUIPwdAddUser-latest-firefox-mariadb10.2-php7.0
-- webUIPwdAddUsSp-master-chrome-mariadb10.2-php7.0
-- webUIPwdAddUsSp-master-firefox-mariadb10.2-php7.0
-- webUIPwdAddUsSp-latest-chrome-mariadb10.2-php7.0
-- webUIPwdAddUsSp-latest-firefox-mariadb10.2-php7.0
-- webUIPwdReset-master-chrome-mariadb10.2-php7.0
-- webUIPwdReset-master-firefox-mariadb10.2-php7.0
-- webUIPwdReset-latest-chrome-mariadb10.2-php7.0
-- webUIPwdReset-latest-firefox-mariadb10.2-php7.0
-- webUIGuests-master-chrome-mariadb10.2-php7.0
-- webUIGuests-master-firefox-mariadb10.2-php7.0
-- webUIGuests-latest-chrome-mariadb10.2-php7.0
-- webUIGuests-latest-firefox-mariadb10.2-php7.0
-- webUIPwdChange-master-chrome-mariadb10.2-php7.0
-- webUIPwdChange-master-firefox-mariadb10.2-php7.0
-- webUIPwdChange-latest-chrome-mariadb10.2-php7.0
-- webUIPwdChange-latest-firefox-mariadb10.2-php7.0
-- webUIPwdChangeSp-master-chrome-mariadb10.2-php7.0
-- webUIPwdChangeSp-master-firefox-mariadb10.2-php7.0
-- webUIPwdChangeSp-latest-chrome-mariadb10.2-php7.0
-- webUIPwdChangeSp-latest-firefox-mariadb10.2-php7.0
-- webUIPwdPolSet-master-chrome-mariadb10.2-php7.0
-- webUIPwdPolSet-master-firefox-mariadb10.2-php7.0
-- webUIPwdPolSet-latest-chrome-mariadb10.2-php7.0
-- webUIPwdPolSet-latest-firefox-mariadb10.2-php7.0
-- webUIPublicShare-master-chrome-mariadb10.2-php7.0
-- webUIPublicShare-master-firefox-mariadb10.2-php7.0
-- webUIPublicShare-latest-chrome-mariadb10.2-php7.0
-- webUIPublicShare-latest-firefox-mariadb10.2-php7.0
-- apiGuests-master-mariadb10.2-php7.0
-- apiGuests-master-oracle-php7.0
-- apiGuests-latest-mariadb10.2-php7.0
-- apiGuests-latest-oracle-php7.0
-- apiPwdAddUser-master-mariadb10.2-php7.0
-- apiPwdAddUser-master-oracle-php7.0
-- apiPwdAddUser-latest-mariadb10.2-php7.0
-- apiPwdAddUser-latest-oracle-php7.0
-- apiPwdAddUserSpecial-master-mariadb10.2-php7.0
-- apiPwdAddUserSpecial-master-oracle-php7.0
-- apiPwdAddUserSpecial-latest-mariadb10.2-php7.0
-- apiPwdAddUserSpecial-latest-oracle-php7.0
-- apiPwdChange-master-mariadb10.2-php7.0
-- apiPwdChange-master-oracle-php7.0
-- apiPwdChange-latest-mariadb10.2-php7.0
-- apiPwdChange-latest-oracle-php7.0
-- apiPwdChangeSpecial-master-mariadb10.2-php7.0
-- apiPwdChangeSpecial-master-oracle-php7.0
-- apiPwdChangeSpecial-latest-mariadb10.2-php7.0
-- apiPwdChangeSpecial-latest-oracle-php7.0
-- apiUpdateShare-master-mariadb10.2-php7.0
-- apiUpdateShare-master-oracle-php7.0
-- apiUpdateShare-latest-mariadb10.2-php7.0
-- apiUpdateShare-latest-oracle-php7.0
-- cliPasswordAddUser-master-mariadb10.2-php7.0
-- cliPasswordAddUser-latest-mariadb10.2-php7.0
-- cliPasswordChange-master-mariadb10.2-php7.0
-- cliPasswordChange-latest-mariadb10.2-php7.0
+- webUIPwdAddUser-master-chrome-mariadb10.2-php7.1
+- webUIPwdAddUser-master-firefox-mariadb10.2-php7.1
+- webUIPwdAddUser-latest-chrome-mariadb10.2-php7.1
+- webUIPwdAddUser-latest-firefox-mariadb10.2-php7.1
+- webUIPwdAddUsSp-master-chrome-mariadb10.2-php7.1
+- webUIPwdAddUsSp-master-firefox-mariadb10.2-php7.1
+- webUIPwdAddUsSp-latest-chrome-mariadb10.2-php7.1
+- webUIPwdAddUsSp-latest-firefox-mariadb10.2-php7.1
+- webUIPwdReset-master-chrome-mariadb10.2-php7.1
+- webUIPwdReset-master-firefox-mariadb10.2-php7.1
+- webUIPwdReset-latest-chrome-mariadb10.2-php7.1
+- webUIPwdReset-latest-firefox-mariadb10.2-php7.1
+- webUIGuests-master-chrome-mariadb10.2-php7.1
+- webUIGuests-master-firefox-mariadb10.2-php7.1
+- webUIGuests-latest-chrome-mariadb10.2-php7.1
+- webUIGuests-latest-firefox-mariadb10.2-php7.1
+- webUIPwdChange-master-chrome-mariadb10.2-php7.1
+- webUIPwdChange-master-firefox-mariadb10.2-php7.1
+- webUIPwdChange-latest-chrome-mariadb10.2-php7.1
+- webUIPwdChange-latest-firefox-mariadb10.2-php7.1
+- webUIPwdChangeSp-master-chrome-mariadb10.2-php7.1
+- webUIPwdChangeSp-master-firefox-mariadb10.2-php7.1
+- webUIPwdChangeSp-latest-chrome-mariadb10.2-php7.1
+- webUIPwdChangeSp-latest-firefox-mariadb10.2-php7.1
+- webUIPwdPolSet-master-chrome-mariadb10.2-php7.1
+- webUIPwdPolSet-master-firefox-mariadb10.2-php7.1
+- webUIPwdPolSet-latest-chrome-mariadb10.2-php7.1
+- webUIPwdPolSet-latest-firefox-mariadb10.2-php7.1
+- webUIPublicShare-master-chrome-mariadb10.2-php7.1
+- webUIPublicShare-master-firefox-mariadb10.2-php7.1
+- webUIPublicShare-latest-chrome-mariadb10.2-php7.1
+- webUIPublicShare-latest-firefox-mariadb10.2-php7.1
+- apiGuests-master-mariadb10.2-php7.1
+- apiGuests-master-oracle-php7.1
+- apiGuests-latest-mariadb10.2-php7.1
+- apiGuests-latest-oracle-php7.1
+- apiPwdAddUser-master-mariadb10.2-php7.1
+- apiPwdAddUser-master-oracle-php7.1
+- apiPwdAddUser-latest-mariadb10.2-php7.1
+- apiPwdAddUser-latest-oracle-php7.1
+- apiPwdAddUserSpecial-master-mariadb10.2-php7.1
+- apiPwdAddUserSpecial-master-oracle-php7.1
+- apiPwdAddUserSpecial-latest-mariadb10.2-php7.1
+- apiPwdAddUserSpecial-latest-oracle-php7.1
+- apiPwdChange-master-mariadb10.2-php7.1
+- apiPwdChange-master-oracle-php7.1
+- apiPwdChange-latest-mariadb10.2-php7.1
+- apiPwdChange-latest-oracle-php7.1
+- apiPwdChangeSpecial-master-mariadb10.2-php7.1
+- apiPwdChangeSpecial-master-oracle-php7.1
+- apiPwdChangeSpecial-latest-mariadb10.2-php7.1
+- apiPwdChangeSpecial-latest-oracle-php7.1
+- apiUpdateShare-master-mariadb10.2-php7.1
+- apiUpdateShare-master-oracle-php7.1
+- apiUpdateShare-latest-mariadb10.2-php7.1
+- apiUpdateShare-latest-oracle-php7.1
+- cliPasswordAddUser-master-mariadb10.2-php7.1
+- cliPasswordAddUser-latest-mariadb10.2-php7.1
+- cliPasswordChange-master-mariadb10.2-php7.1
+- cliPasswordChange-latest-mariadb10.2-php7.1
 
 ...


### PR DESCRIPTION
Because core has dropped PHP 7.0 support https://github.com/owncloud/core/pull/36290