### PR TITLE
Add WebUI test for changing password from the users page when password policy is active

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -70,6 +70,9 @@ config = {
 				'webUIPasswordChangeSpecial': 'webUIPwdChangeSp',
 				'webUIPasswordPolicySettings': 'webUIPwdPolSet',
 				'webUIPublicShareLink': 'webUIPublicShare',
+				'webUIPasswordChangeUsersPage': 'webUIPwdChgUP',
+				'webUIPasswordChangeUsersPageSpecial': 'webUIPwdChgUPSp',
+
 			},
 			'browsers': [
 				'chrome',

--- a/.drone.yml
+++ b/.drone.yml
@@ -4689,6 +4689,938 @@ depends_on:
 ---
 kind: pipeline
 type: docker
+name: webUIPwdChgUP-master-chrome-mariadb10.2-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/password_policy
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/password_policy /var/www/owncloud/server/apps/
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordChangeUsersPage
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.1
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPwdChgUP-master-firefox-mariadb10.2-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/password_policy
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/password_policy /var/www/owncloud/server/apps/
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordChangeUsersPage
+    BROWSER: firefox
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-firefox-debug:3.8.1
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+    SE_OPTS: -enablePassThrough false
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.1
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPwdChgUP-latest-chrome-mariadb10.2-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/password_policy
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/password_policy /var/www/owncloud/server/apps/
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordChangeUsersPage
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.1
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPwdChgUP-latest-firefox-mariadb10.2-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/password_policy
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/password_policy /var/www/owncloud/server/apps/
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordChangeUsersPage
+    BROWSER: firefox
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-firefox-debug:3.8.1
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+    SE_OPTS: -enablePassThrough false
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.1
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPwdChgUPSp-master-chrome-mariadb10.2-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/password_policy
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/password_policy /var/www/owncloud/server/apps/
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordChangeUsersPageSpecial
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.1
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPwdChgUPSp-master-firefox-mariadb10.2-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/password_policy
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/password_policy /var/www/owncloud/server/apps/
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordChangeUsersPageSpecial
+    BROWSER: firefox
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-firefox-debug:3.8.1
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+    SE_OPTS: -enablePassThrough false
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.1
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPwdChgUPSp-latest-chrome-mariadb10.2-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/password_policy
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/password_policy /var/www/owncloud/server/apps/
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordChangeUsersPageSpecial
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.1
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIPwdChgUPSp-latest-firefox-mariadb10.2-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/password_policy
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/password_policy
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/password_policy /var/www/owncloud/server/apps/
+
+- name: setup-server-password_policy
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e password_policy
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIPasswordChangeUsersPageSpecial
+    BROWSER: firefox
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-firefox-debug:3.8.1
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+    SE_OPTS: -enablePassThrough false
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.1
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
 name: apiGuests-master-mariadb10.2-php7.1
 
 platform:
@@ -7790,6 +8722,14 @@ depends_on:
 - webUIPublicShare-master-firefox-mariadb10.2-php7.1
 - webUIPublicShare-latest-chrome-mariadb10.2-php7.1
 - webUIPublicShare-latest-firefox-mariadb10.2-php7.1
+- webUIPwdChgUP-master-chrome-mariadb10.2-php7.1
+- webUIPwdChgUP-master-firefox-mariadb10.2-php7.1
+- webUIPwdChgUP-latest-chrome-mariadb10.2-php7.1
+- webUIPwdChgUP-latest-firefox-mariadb10.2-php7.1
+- webUIPwdChgUPSp-master-chrome-mariadb10.2-php7.1
+- webUIPwdChgUPSp-master-firefox-mariadb10.2-php7.1
+- webUIPwdChgUPSp-latest-chrome-mariadb10.2-php7.1
+- webUIPwdChgUPSp-latest-firefox-mariadb10.2-php7.1
 - apiGuests-master-mariadb10.2-php7.1
 - apiGuests-master-oracle-php7.1
 - apiGuests-latest-mariadb10.2-php7.1

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -129,6 +129,30 @@ default:
         - WebUIPersonalGeneralSettingsContext:
         - FeatureContext: *common_feature_context_params
 
+    webUIPasswordChangeUsersPage:
+      paths:
+        - '%paths.base%/../features/webUIPasswordChangeUsersPage'
+      contexts:
+        - PasswordPolicyContext:
+        - WebUIPasswordPolicyContext:
+        - WebUIGeneralContext:
+        - WebUIUsersContext:
+        - WebUILoginContext:
+        - WebUIPersonalGeneralSettingsContext:
+        - FeatureContext: *common_feature_context_params
+
+    webUIPasswordChangeUsersPageSpecial:
+      paths:
+        - '%paths.base%/../features/webUIPasswordChangeUsersPageSpecial'
+      contexts:
+        - PasswordPolicyContext:
+        - WebUIPasswordPolicyContext:
+        - WebUIGeneralContext:
+        - WebUIUsersContext:
+        - WebUILoginContext:
+        - WebUIPersonalGeneralSettingsContext:
+        - FeatureContext: *common_feature_context_params
+
     webUIPasswordPolicySettings:
       paths:
         - '%paths.base%/../features/webUIPasswordPolicySettings'

--- a/tests/acceptance/features/webUIPasswordChangeUsersPage/passwordChangeLowercaseLetters.feature
+++ b/tests/acceptance/features/webUIPasswordChangeUsersPage/passwordChangeLowercaseLetters.feature
@@ -1,0 +1,35 @@
+@webUI @insulated @disablePreviews @skipOnFIREFOX
+Feature: enforce the required number of lowercase letters in a password on the password change from users page
+
+  As an administrator
+  I want user passwords to always contain a required number of lowercase letters
+  So that users cannot set passwords that are too easy to guess
+
+  Background:
+    Given the administrator has enabled the lowercase letters password policy
+    And the administrator has set the lowercase letters required to "3"
+    And these users have been created with default attributes and skeleton files:
+      | username | password   |
+      | user1    | abcABC1234 |
+    And the user has browsed to the login page
+    And user admin has logged in using the webUI
+    And the user has browsed to the users page
+
+  Scenario Outline: Admin changes user's password to a string with enough lowercase letters
+    When the administrator changes the password of user "user1" to "<password>" using the webUI
+    Then user "user1" should exist
+    And the content of file "textfile0.txt" for user "user1" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "abcABC1234" should not be able to download file "textfile0.txt"
+    Examples:
+      | password                  |
+      | 3LCase                    |
+      | moreThan3LowercaseLetters |
+
+  Scenario Outline: Admin tries to change user's password to a string that has too few lowercase letters
+    When the administrator changes the password of user "user1" to "<password>" using the webUI
+    Then notifications should be displayed on the webUI with the text
+      | The password contains too few lowercase letters. At least 3 lowercase letters are required. |
+    Examples:
+      | password   |
+      | 0LOWERCASE |
+      | 2lOWERcASE |

--- a/tests/acceptance/features/webUIPasswordChangeUsersPage/passwordChangeMinimumLength.feature
+++ b/tests/acceptance/features/webUIPasswordChangeUsersPage/passwordChangeMinimumLength.feature
@@ -1,0 +1,34 @@
+@webUI @insulated @disablePreviews @skipOnFIREFOX
+Feature: enforce the minimum length of a password on the password change from users page
+
+  As an administrator
+  I want user passwords to always be a certain minimum length
+  So that users cannot set passwords that are too short (easy to crack)
+
+  Background:
+    Given the administrator has enabled the minimum characters password policy
+    And the administrator has set the minimum characters required to "10"
+    And these users have been created with default attributes and skeleton files:
+      | username | password   |
+      | user1    | 1234567890 |
+    And the user has browsed to the login page
+    And user admin has logged in using the webUI
+    And the user has browsed to the users page
+
+  Scenario Outline: Admin changes user's their password to a long-enough string
+    When the administrator changes the password of user "user1" to "<password>" using the webUI
+    And the user re-logs in with username "user1" and password "<password>" using the webUI
+    Then the user should be redirected to a webUI page with the title "Files - ownCloud"
+    Examples:
+      | password             |
+      | 10tenchars           |
+      | morethan10characters |
+
+  Scenario Outline: Admin tries to change user's password to a string that is too short
+    When the administrator changes the password of user "user1" to "<password>" using the webUI
+    Then notifications should be displayed on the webUI with the text
+      | The password is too short. At least 10 characters are required. |
+    Examples:
+      | password  |
+      | A         |
+      | 123456789 |

--- a/tests/acceptance/features/webUIPasswordChangeUsersPage/passwordChangeNumbers.feature
+++ b/tests/acceptance/features/webUIPasswordChangeUsersPage/passwordChangeNumbers.feature
@@ -1,0 +1,34 @@
+@webUI @insulated @disablePreviews @skipOnFIREFOX
+Feature: enforce the required number of numbers in a password on the password change from users page
+
+  As an administrator
+  I want user passwords to always contain a required number of numbers
+  So that users cannot set passwords that are too easy to guess
+
+  Background:
+    Given the administrator has enabled the numbers password policy
+    And the administrator has set the numbers required to "3"
+    And these users have been created with default attributes and skeleton files:
+      | username | password   |
+      | user1    | abcABC1234 |
+    And the user has browsed to the login page
+    And user admin has logged in using the webUI
+    And the user has browsed to the users page
+
+  Scenario Outline: Admin changes user's password to a string with enough numbers
+    When the administrator changes the password of user "user1" to "<password>" using the webUI
+    And the user re-logs in with username "user1" and password "<password>" using the webUI
+    Then the user should be redirected to a webUI page with the title "Files - ownCloud"
+    Examples:
+      | password        |
+      | 333Numbers      |
+      | moreNumbers1234 |
+
+  Scenario Outline: Admin tries to change user's password to a string that has too few numbers
+    When the administrator changes the password of user "user1" to "<password>" using the webUI
+    Then notifications should be displayed on the webUI with the text
+      | The password contains too few numbers. At least 3 numbers are required. |
+    Examples:
+      | password      |
+      | NoNumbers     |
+      | Only22Numbers |

--- a/tests/acceptance/features/webUIPasswordChangeUsersPage/passwordChangeUppercaseLetters.feature
+++ b/tests/acceptance/features/webUIPasswordChangeUsersPage/passwordChangeUppercaseLetters.feature
@@ -1,0 +1,34 @@
+@webUI @insulated @disablePreviews @skipOnFIREFOX
+Feature: enforce the required number of uppercase letters in a password on the password change from users page
+
+  As an administrator
+  I want user passwords to always contain a required number of uppercase letters
+  So that users cannot set passwords that are too easy to guess
+
+  Background:
+    Given the administrator has enabled the uppercase letters password policy
+    And the administrator has set the uppercase letters required to "3"
+    And these users have been created with default attributes and skeleton files:
+      | username | password   |
+      | user1    | abcABC1234 |
+    And the user has browsed to the login page
+    And user admin has logged in using the webUI
+    And the user has browsed to the users page
+
+  Scenario Outline: Admin changes user's password to a string with enough uppercase letters
+    When the administrator changes the password of user "user1" to "<password>" using the webUI
+    And the user re-logs in with username "user1" and password "<password>" using the webUI
+    Then the user should be redirected to a webUI page with the title "Files - ownCloud"
+    Examples:
+      | password                  |
+      | 3UpperCaseLetters         |
+      | MoreThan3UpperCaseLetters |
+
+  Scenario Outline: Admin tries to change user's password to a string that has too few uppercase letters
+    When the administrator changes the password of user "user1" to "<password>" using the webUI
+    Then notifications should be displayed on the webUI with the text
+      | The password contains too few uppercase letters. At least 3 uppercase letters are required. |
+    Examples:
+      | password       |
+      | 0uppercase     |
+      | Only2Uppercase |

--- a/tests/acceptance/features/webUIPasswordChangeUsersPageSpecial/passwordChangeLastPasswords.feature
+++ b/tests/acceptance/features/webUIPasswordChangeUsersPageSpecial/passwordChangeLastPasswords.feature
@@ -1,0 +1,38 @@
+@webUI @insulated @disablePreviews @skipOnFIREFOX
+Feature: enforce the number of last passwords that must not be used when resetting the password on the password change from users page
+
+  As an administrator
+  I want to prevent users from re-using recent passwords
+  So that recent passwords (that may have been compromised) cannot be used to access data
+
+  Background:
+    Given the administrator has enabled the last passwords user password policy
+    And the administrator has set the number of last passwords that should not be used to "3"
+    And these users have been created with default attributes and skeleton files:
+      | username | password |
+      | user1    | Number1  |
+    And the administrator has reset the password of user "user1" to "Number2"
+    And the administrator has reset the password of user "user1" to "Number3"
+    And the administrator has reset the password of user "user1" to "Number4"
+    And the user has browsed to the login page
+    And user admin has logged in using the webUI
+    And the user has browsed to the users page
+
+  Scenario Outline: Admin changes user's password to a string that is not one of their last 3 passwords
+    When the administrator changes the password of user "user1" to "<password>" using the webUI
+    And the user re-logs in with username "user1" and password "<password>" using the webUI
+    Then the user should be redirected to a webUI page with the title "Files - ownCloud"
+    Examples:
+      | password     |
+      | Number1      |
+      | AnotherValue |
+
+  Scenario Outline: Admin tries to change user's password to one of their last 3 passwords
+    When the administrator changes the password of user "user1" to "<password>" using the webUI
+    Then notifications should be displayed on the webUI with the text
+      | <error-message> |
+    Examples:
+      | password | error-message                                                  |
+      | Number2  | The password must be different than your previous 3 passwords. |
+      | Number3  | The password must be different than your previous 3 passwords. |
+      | Number4  | The password must be different than your previous 3 passwords. |

--- a/tests/acceptance/features/webUIPasswordChangeUsersPageSpecial/passwordChangeRequirementCombinations.feature
+++ b/tests/acceptance/features/webUIPasswordChangeUsersPageSpecial/passwordChangeRequirementCombinations.feature
@@ -1,0 +1,73 @@
+@webUI @insulated @disablePreviews @skipOnFIREFOX
+Feature: enforce combinations of password policies on the password change from users page
+
+  As an administrator
+  I want user passwords to always have some combination of minimum length, lowercase, uppercase, numbers and special characters
+  So that users cannot set passwords that are too easy to guess
+
+  Background:
+    Given the administrator has enabled the minimum characters password policy
+    And the administrator has set the minimum characters required to "15"
+    And the administrator has enabled the lowercase letters password policy
+    And the administrator has set the lowercase letters required to "4"
+    And the administrator has enabled the uppercase letters password policy
+    And the administrator has set the uppercase letters required to "3"
+    And the administrator has enabled the numbers password policy
+    And the administrator has set the numbers required to "2"
+    And the administrator has enabled the special characters password policy
+    And the administrator has set the special characters required to "3"
+    And these users have been created with default attributes and skeleton files:
+      | username | password        |
+      | user1    | aA1!bB2#cC&deee |
+    And the user has browsed to the login page
+    And user admin has logged in using the webUI
+    And the user has browsed to the users page
+
+  Scenario Outline: Admin changes user's password to a valid string
+    When the administrator changes the password of user "user1" to "<password>" using the webUI
+    And the user re-logs in with username "user1" and password "<password>" using the webUI
+    Then the user should be redirected to a webUI page with the title "Files - ownCloud"
+    Examples:
+      | password                  |
+      | 15***UPPloweZZZ           |
+      | More%Than$15!Characters-0 |
+
+  Scenario Outline: Admin tries to change user's password to an invalid string
+    When the administrator changes the password of user "user1" to "<password>" using the webUI
+    Then notifications should be displayed on the webUI with the text
+      | <message> |
+    Examples:
+      | password                       | message                                                                                       |
+        # where just one of the requirements is not met
+      | aA1!bB2#cC&d                   | The password is too short. At least 15 characters are required.                               |
+      | aA1!bB2#cNOT&ENOUGH#LOWERCASE  | The password contains too few lowercase letters. At least 4 lowercase letters are required.   |
+      | aA1!bB2#cnot&enough#uppercase  | The password contains too few uppercase letters. At least 3 uppercase letters are required.   |
+      | Not&Enough#Numbers=1           | The password contains too few numbers. At least 2 numbers are required.                       |
+      | Not&Enough#Special8Characters2 | The password contains too few special characters. At least 3 special characters are required. |
+        # where multiple requirements are not met, only the first error message is shown to the user
+      | aA!1                           | The password is too short. At least 15 characters are required.                               |
+      | aA!123456789012345             | The password contains too few lowercase letters. At least 4 lowercase letters are required.   |
+
+  Scenario Outline: Admin changes user's password using valid restricted special characters
+    Given the administrator has enabled the restrict to these special characters password policy
+    And the administrator has set the restricted special characters required to "$%^&*"
+    When the administrator changes the password of user "user1" to "<password>" using the webUI
+    And the user re-logs in with username "user1" and password "<password>" using the webUI
+    Then the user should be redirected to a webUI page with the title "Files - ownCloud"
+    Examples:
+      | password                  |
+      | 15%&*UPPloweZZZ           |
+      | More^Than$15&Characters*0 |
+
+  Scenario Outline: Admin tries to change user's password using invalid restricted special characters
+    Given the administrator has enabled the restrict to these special characters password policy
+    And the administrator has set the restricted special characters required to "$%^&*"
+    When the administrator changes the password of user "user1" to "<password>" using the webUI
+    Then notifications should be displayed on the webUI with the text
+      | <message> |
+    Examples:
+      | password        | message                                                                                     |
+      | 15#!!UPPloweZZZ | The password contains invalid special characters. Only $%^&* are allowed.                   |
+      | 15&%!UPPloweZZZ | The password contains invalid special characters. Only $%^&* are allowed.                   |
+        # where multiple requirements are not met, only the first error message is shown to the user
+      | 15&%!UPPlowZZZZ | The password contains too few lowercase letters. At least 4 lowercase letters are required. |

--- a/tests/acceptance/features/webUIPasswordChangeUsersPageSpecial/passwordChangeSpecialCharacters.feature
+++ b/tests/acceptance/features/webUIPasswordChangeUsersPageSpecial/passwordChangeSpecialCharacters.feature
@@ -1,0 +1,34 @@
+@webUI @insulated @disablePreviews @skipOnFIREFOX
+Feature: enforce the required number of special characters in a password on the password change from users page
+
+  As an administrator
+  I want user passwords to always contain a required number of special characters
+  So that users cannot set passwords that are too easy to guess
+
+  Background:
+    Given the administrator has enabled the special characters password policy
+    And the administrator has set the special characters required to "3"
+    And these users have been created with default attributes and skeleton files:
+      | username | password   |
+      | user1    | a!b@c#1234 |
+    And the user has browsed to the login page
+    And user admin has logged in using the webUI
+    And the user has browsed to the users page
+
+  Scenario Outline: Admin changes user's password to a string with enough special characters
+    When the administrator changes the password of user "user1" to "<password>" using the webUI
+    And the user re-logs in with username "user1" and password "<password>" using the webUI
+    Then the user should be redirected to a webUI page with the title "Files - ownCloud"
+    Examples:
+      | password              |
+      | 3#Special$Characters! |
+      | 1!2@3#4$5%6^7&8*      |
+
+  Scenario Outline: Admin tries to change user's password to a string that has too few special characters
+    When the administrator changes the password of user "user1" to "<password>" using the webUI
+    Then notifications should be displayed on the webUI with the text
+      | The password contains too few special characters. At least 3 special characters are required. |
+    Examples:
+      | password                 |
+      | NoSpecialCharacters123   |
+      | Only2$Special!Characters |

--- a/tests/acceptance/features/webUIPasswordChangeUsersPageSpecial/passwordChangeSpecialCharactersRestrictions.feature
+++ b/tests/acceptance/features/webUIPasswordChangeUsersPageSpecial/passwordChangeSpecialCharactersRestrictions.feature
@@ -1,0 +1,45 @@
+@webUI @insulated @disablePreviews @skipOnFIREFOX
+Feature: enforce the restricted special characters in a password on the password change from users page
+
+  As an administrator
+  I want user passwords to always contain some of a restricted list of special characters
+  So that users cannot set passwords that have unusual hard-to-type characters
+
+  Background:
+    Given the administrator has enabled the special characters password policy
+    And the administrator has set the special characters required to "3"
+    And the administrator has enabled the restrict to these special characters password policy
+    And the administrator has set the restricted special characters required to "$%^&*"
+    And these users have been created with default attributes and skeleton files:
+      | username | password   |
+      | user1    | a$b%c^1234 |
+    And the user has browsed to the login page
+    And user admin has logged in using the webUI
+    And the user has browsed to the users page
+
+  Scenario Outline: Admin changes user's password to a string with enough restricted special characters
+    When the administrator changes the password of user "user1" to "<password>" using the webUI
+    And the user re-logs in with username "user1" and password "<password>" using the webUI
+    Then the user should be redirected to a webUI page with the title "Files - ownCloud"
+    Examples:
+      | password              |
+      | 3$Special%Characters^ |
+      | 1*2&3^4%5$6           |
+
+  Scenario Outline: Admin tries to change user's password to a string that has too few restricted special characters
+    When the administrator changes the password of user "user1" to "<password>" using the webUI
+    Then notifications should be displayed on the webUI with the text
+      | The password contains too few special characters. At least 3 special characters ($%^&*) are required. |
+    Examples:
+      | password                 |
+      | NoSpecialCharacters123   |
+      | Only2$Special&Characters |
+
+  Scenario Outline: Admin tries to change user's password to a string that has invalid special characters
+    When the administrator changes the password of user "user1" to "<password>" using the webUI
+    Then notifications should be displayed on the webUI with the text
+      | The password contains invalid special characters. Only $%^&* are allowed. |
+    Examples:
+      | password                                 |
+      | Only#Invalid!Special@Characters          |
+      | 1*2&3^4%5$6andInvalidSpecialCharacters#! |


### PR DESCRIPTION
Related Issue https://github.com/owncloud/QA/issues/585

Add webui Tests for
- Changing password when password policy is active from the webUI
- Create new Test suites `webUIPasswordChangeUsersPage` and `webUIPasswordChangeUsersPageSpecial`
- Register new suites to run on drone
