### PR TITLE
check first time password change necessary in postLogin

### DIFF
--- a/lib/HooksHandler.php
+++ b/lib/HooksHandler.php
@@ -313,6 +313,10 @@ class HooksHandler {
 				$this->forcePasswordChange();
 			}
 		}
+		/* if this flag still exists, force to password change */
+		if ($this->config->getUserValue($user->getUID(), 'password_policy', 'firstLoginPasswordChange')) {
+			$this->forcePasswordChange();
+		}
 	}
 
 	public function checkForcePasswordChangeOnFirstLogin(GenericEvent $event) {

--- a/tests/unit/HooksHandlerTest.php
+++ b/tests/unit/HooksHandlerTest.php
@@ -370,6 +370,7 @@ class HooksHandlerTest extends TestCase {
 		return [
 			[false, 1530180780],
 			[true, 1530180781],
+			[false, 1530180780, '1']
 		];
 	}
 
@@ -377,21 +378,26 @@ class HooksHandlerTest extends TestCase {
 	 * @dataProvider checkAdminRequestedPasswordChangeProvider
 	 * @param $expired
 	 * @param $time
+	 * @param $firstLoginPasswordChange
 	 */
-	public function testCheckAdminRequestedPasswordChange($expired, $time) {
+	public function testCheckAdminRequestedPasswordChange($expired, $time, $firstLoginPasswordChange = '') {
 		/** @var IUser | \PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('testuid');
-		$this->config->expects($this->once())
+		$this->config->expects($this->at(0))
 			->method('getUserValue')
 			->with('testuid', 'password_policy', 'forcePasswordChange', '')
 			->willReturn('2018-06-28T10:13:00Z'); // = 1530180780
+		$this->config->expects($this->at(1))
+			->method('getUserValue')
+			->with('testuid', 'password_policy', 'firstLoginPasswordChange')
+			->willReturn($firstLoginPasswordChange); // = 1530180780
 
 		$this->timeFactory->expects($this->once())
 			->method('getTime')
 			->willReturn($time);
 
-		if ($expired) {
+		if ($expired || $firstLoginPasswordChange) {
 			$this->session
 				->expects($this->once())
 				->method('set')


### PR DESCRIPTION
Fixes https://github.com/owncloud/enterprise/issues/3745

We only check the change password in first login enforcement with `\OCP\IUser::firstLogin` event. However, when a user logged in but not changed the password, we count this as a valid login in the Account table, afterward `\OCP\IUser::firstLogin` is not emitting anymore in subsequent logins. Because of that, the user can log in without changing its password on his next attempt.

Luckily we add a `firstLoginPasswordChange` user value on the `\OCP\IUser::firstLogin` callback and removing this value when password changed in web UI. I add a check for this value in `postLogin` event. In this way, bypassing the password reset on the first login prevented.