### PR TITLE
Adjust Symfony eventDispatcher->dispatch calls

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -1058,7 +1058,7 @@ def databaseService(db):
 	if dbName == 'oracle':
 		return [{
 			'name': dbName,
-			'image': 'deepdiver/docker-oracle-xe-11g:latest',
+			'image': 'owncloudci/oracle-xe:latest',
 			'pull': 'always',
 			'environment': {
 				'ORACLE_USER': getDbUsername(db),

--- a/.drone.yml
+++ b/.drone.yml
@@ -567,7 +567,7 @@ steps:
 services:
 - name: oracle
   pull: always
-  image: deepdiver/docker-oracle-xe-11g:latest
+  image: owncloudci/oracle-xe:latest
   environment:
     ORACLE_DB: XE
     ORACLE_DISABLE_ASYNCH_IO: true
@@ -5827,7 +5827,7 @@ steps:
 services:
 - name: oracle
   pull: always
-  image: deepdiver/docker-oracle-xe-11g:latest
+  image: owncloudci/oracle-xe:latest
   environment:
     ORACLE_DB: XE
     ORACLE_DISABLE_ASYNCH_IO: true
@@ -6071,7 +6071,7 @@ steps:
 services:
 - name: oracle
   pull: always
-  image: deepdiver/docker-oracle-xe-11g:latest
+  image: owncloudci/oracle-xe:latest
   environment:
     ORACLE_DB: XE
     ORACLE_DISABLE_ASYNCH_IO: true
@@ -6287,7 +6287,7 @@ steps:
 services:
 - name: oracle
   pull: always
-  image: deepdiver/docker-oracle-xe-11g:latest
+  image: owncloudci/oracle-xe:latest
   environment:
     ORACLE_DB: XE
     ORACLE_DISABLE_ASYNCH_IO: true
@@ -6499,7 +6499,7 @@ steps:
 services:
 - name: oracle
   pull: always
-  image: deepdiver/docker-oracle-xe-11g:latest
+  image: owncloudci/oracle-xe:latest
   environment:
     ORACLE_DB: XE
     ORACLE_DISABLE_ASYNCH_IO: true
@@ -6711,7 +6711,7 @@ steps:
 services:
 - name: oracle
   pull: always
-  image: deepdiver/docker-oracle-xe-11g:latest
+  image: owncloudci/oracle-xe:latest
   environment:
     ORACLE_DB: XE
     ORACLE_DISABLE_ASYNCH_IO: true
@@ -6923,7 +6923,7 @@ steps:
 services:
 - name: oracle
   pull: always
-  image: deepdiver/docker-oracle-xe-11g:latest
+  image: owncloudci/oracle-xe:latest
   environment:
     ORACLE_DB: XE
     ORACLE_DISABLE_ASYNCH_IO: true
@@ -7135,7 +7135,7 @@ steps:
 services:
 - name: oracle
   pull: always
-  image: deepdiver/docker-oracle-xe-11g:latest
+  image: owncloudci/oracle-xe:latest
   environment:
     ORACLE_DB: XE
     ORACLE_DISABLE_ASYNCH_IO: true
@@ -7347,7 +7347,7 @@ steps:
 services:
 - name: oracle
   pull: always
-  image: deepdiver/docker-oracle-xe-11g:latest
+  image: owncloudci/oracle-xe:latest
   environment:
     ORACLE_DB: XE
     ORACLE_DISABLE_ASYNCH_IO: true
@@ -7559,7 +7559,7 @@ steps:
 services:
 - name: oracle
   pull: always
-  image: deepdiver/docker-oracle-xe-11g:latest
+  image: owncloudci/oracle-xe:latest
   environment:
     ORACLE_DB: XE
     ORACLE_DISABLE_ASYNCH_IO: true
@@ -7771,7 +7771,7 @@ steps:
 services:
 - name: oracle
   pull: always
-  image: deepdiver/docker-oracle-xe-11g:latest
+  image: owncloudci/oracle-xe:latest
   environment:
     ORACLE_DB: XE
     ORACLE_DISABLE_ASYNCH_IO: true
@@ -7983,7 +7983,7 @@ steps:
 services:
 - name: oracle
   pull: always
-  image: deepdiver/docker-oracle-xe-11g:latest
+  image: owncloudci/oracle-xe:latest
   environment:
     ORACLE_DB: XE
     ORACLE_DISABLE_ASYNCH_IO: true
@@ -8195,7 +8195,7 @@ steps:
 services:
 - name: oracle
   pull: always
-  image: deepdiver/docker-oracle-xe-11g:latest
+  image: owncloudci/oracle-xe:latest
   environment:
     ORACLE_DB: XE
     ORACLE_DISABLE_ASYNCH_IO: true

--- a/lib/HooksHandler.php
+++ b/lib/HooksHandler.php
@@ -135,6 +135,8 @@ class HooksHandler {
 	public function generatePassword(GenericEvent $event) {
 		$this->fixDI();
 		$event['password'] = $this->engine->generatePassword();
+		/* ToDo: issue 278 - deprecated since Symfony 4.3, use "Symfony\Contracts\EventDispatcher\Event" instead */
+		/* @phan-suppress-next-line PhanDeprecatedFunction */
 		$event->stopPropagation();
 	}
 

--- a/lib/Jobs/PasswordExpirationNotifierJob.php
+++ b/lib/Jobs/PasswordExpirationNotifierJob.php
@@ -167,7 +167,7 @@ class PasswordExpirationNotifierJob extends TimedJob {
 				'user' => $this->userManager->get($passInfo->getUid()),
 				'passwordExpireInSeconds' => $expirationTime
 			]);
-		$this->eventDispatcher->dispatch('user.passwordAboutToExpire', $aboutToExpireEvent);
+		$this->eventDispatcher->dispatch($aboutToExpireEvent, 'user.passwordAboutToExpire');
 	}
 
 	/**
@@ -212,7 +212,7 @@ class PasswordExpirationNotifierJob extends TimedJob {
 				'user' => $this->userManager->get($passInfo->getUid()),
 				'passwordExpireInSeconds' => $expirationTime
 			]);
-		$this->eventDispatcher->dispatch('user.passwordExpired', $expiredEvent);
+		$this->eventDispatcher->dispatch($expiredEvent, 'user.passwordExpired');
 	}
 
 	private function getNotificationLink() {

--- a/tests/unit/Jobs/PasswordExpirationNotifierJobTest.php
+++ b/tests/unit/Jobs/PasswordExpirationNotifierJobTest.php
@@ -366,7 +366,7 @@ class PasswordExpirationNotifierJobTest extends TestCase {
 				'passwordExpireInSeconds' => 180]);
 		$this->eventDispatcher->expects($this->once())
 			->method('dispatch')
-			->with('user.passwordAboutToExpire', $aboutToExpireEvent);
+			->with($aboutToExpireEvent, 'user.passwordAboutToExpire');
 
 		$this->invokePrivate($this->job, 'run', [[]]);
 	}
@@ -411,7 +411,7 @@ class PasswordExpirationNotifierJobTest extends TestCase {
 				'passwordExpireInSeconds' => 180]);
 		$this->eventDispatcher->expects($this->once())
 			->method('dispatch')
-			->with('user.passwordExpired', $aboutToExpireEvent);
+			->with($aboutToExpireEvent, 'user.passwordExpired');
 
 		$this->invokePrivate($this->job, 'run', [[]]);
 	}


### PR DESCRIPTION
Similar to https://github.com/owncloud/core/pull/36897

We updated from Symfony 3.4 to 4.4 in PR #36881 
Symfony 4.3 (and thus 4.4) adjusted the `EventDispatcher` `dispatch` method to take parameters in the opposite order.
https://symfony.com/blog/new-in-symfony-4-3-simpler-event-dispatching
https://github.com/symfony/symfony/pull/28920
https://github.com/symfony/symfony/pull/33115

The change was made in a BC way - if the parameters are provided the old way around, then the `dispatch` method flips them. So existing code is OK. But in Symfony5 the "old way" is likely to have been removed.

`phan` code analysis reports that the parameters are around the "wrong way" (the old way). e.g.
```
lib/Jobs/PasswordExpirationNotifierJob.php:170 PhanTypeMismatchArgument Argument 1 (event) is 'user.passwordAboutToExpire' but \Symfony\Component\EventDispatcher\EventDispatcher::dispatch() takes object defined at ../../lib/composer/symfony/event-dispatcher/EventDispatcher.php:51
lib/Jobs/PasswordExpirationNotifierJob.php:215 PhanTypeMismatchArgument Argument 1 (event) is 'user.passwordExpired' but \Symfony\Component\EventDispatcher\EventDispatcher::dispatch() takes object defined at ../../lib/composer/symfony/event-dispatcher/EventDispatcher.php:51
```

Fix this to match the currently expected order of arguments