### PR TITLE
[Tests-Only] Add acceptance tests for password policy expiration date

### DIFF
--- a/tests/acceptance/features/webUIPublicShareLink/publicShareLinkExpirationPolicy.feature
+++ b/tests/acceptance/features/webUIPublicShareLink/publicShareLinkExpirationPolicy.feature
@@ -124,7 +124,7 @@ Feature: enforce public link expiration policies
     When the user changes the expiration of the public link "Public link" of folder "simple-folder" to "+5 days"
     Then the user should see an error message on the public link share dialog saying "The expiration date cannot exceed 3 days."
 
-  Scenario: user decreases the default maximum days until link expires if password is set and then edits expiration date of the already created public link
+  Scenario: user decreases the default maximum days until link expires if password is not set and then edits expiration date of the already created public link
     Given the administrator has enabled the days until link expires if password is not set public link password policy
     And the user has created a new public link for folder "simple-folder" using the webUI with
       | expiration | +6 days  |

--- a/tests/acceptance/features/webUIPublicShareLink/publicShareLinkExpirationPolicy.feature
+++ b/tests/acceptance/features/webUIPublicShareLink/publicShareLinkExpirationPolicy.feature
@@ -113,3 +113,22 @@ Feature: enforce public link expiration policies
       | password   | abcdefgh |
     And the public accesses the last created public link with password "abcdefgh" using the webUI
     Then file "lorem.txt" should be listed on the webUI
+
+  Scenario: user decreases the default maximum days until link expires if password is set and then edits expiration date of the already created public link
+    Given the administrator has enabled the days until link expires if password is set public link password policy
+    And the user has created a new public link for folder "simple-folder" using the webUI with
+      | expiration | +6 days  |
+      | password   | abcdefgh |
+    And the administrator has set the value for the maximum days until link expires if password is set to "3"
+    And the user has reloaded the current page of the webUI
+    When the user changes the expiration of the public link "Public link" of folder "simple-folder" to "+5 days"
+    Then the user should see an error message on the public link share dialog saying "The expiration date cannot exceed 3 days."
+
+  Scenario: user decreases the default maximum days until link expires if password is set and then edits expiration date of the already created public link
+    Given the administrator has enabled the days until link expires if password is not set public link password policy
+    And the user has created a new public link for folder "simple-folder" using the webUI with
+      | expiration | +6 days  |
+    And the administrator has set the value for the maximum days until link expires if password is not set to "3"
+    And the user has reloaded the current page of the webUI
+    When the user changes the expiration of the public link "Public link" of folder "simple-folder" to "+5 days"
+    Then the user should see an error message on the public link share dialog saying "The expiration date cannot exceed 3 days."


### PR DESCRIPTION
This PR adds acceptance tests for editing the expiration date for the previously created public link share when the maximum expiration date is enforced.

## Related Issue
- https://github.com/owncloud/password_policy/issues/126