### PR TITLE
Adjust phpstan.neon for new bootstrapFiles setting

### DIFF
--- a/lib/Jobs/PasswordExpirationNotifierJob.php
+++ b/lib/Jobs/PasswordExpirationNotifierJob.php
@@ -167,6 +167,7 @@ class PasswordExpirationNotifierJob extends TimedJob {
 				'user' => $this->userManager->get($passInfo->getUid()),
 				'passwordExpireInSeconds' => $expirationTime
 			]);
+		/* @phpstan-ignore-next-line */
 		$this->eventDispatcher->dispatch($aboutToExpireEvent, 'user.passwordAboutToExpire');
 	}
 
@@ -212,6 +213,7 @@ class PasswordExpirationNotifierJob extends TimedJob {
 				'user' => $this->userManager->get($passInfo->getUid()),
 				'passwordExpireInSeconds' => $expirationTime
 			]);
+		/* @phpstan-ignore-next-line */
 		$this->eventDispatcher->dispatch($expiredEvent, 'user.passwordExpired');
 	}
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,6 @@
 parameters:
   inferPrivatePropertyTypeFromConstructor: true
-  bootstrap: %currentWorkingDirectory%/../../lib/base.php
-  excludes_analyse:
-    - %currentWorkingDirectory%/appinfo/Migrations/*.php
+  bootstrapFiles:
+    - %currentWorkingDirectory%/../../lib/base.php
   ignoreErrors:
 


### PR DESCRIPTION
And suppress some messages:

https://drone.owncloud.com/owncloud/password_policy/1330/2/4
```
php -d zend.enable_gc=0 vendor-bin/phpstan/vendor/bin/phpstan analyse --memory-limit=4G --configuration=./phpstan.neon --no-progress --level=5 appinfo lib
 ------ ----------------------------------------------------------------------- 
  Line   lib/Jobs/PasswordExpirationNotifierJob.php                             
 ------ ----------------------------------------------------------------------- 
  170    Parameter #2 $event of method                                          
         Symfony\Component\EventDispatcher\EventDispatcher::dispatch() expects  
         object, string given.                                                  
  215    Parameter #2 $event of method                                          
         Symfony\Component\EventDispatcher\EventDispatcher::dispatch() expects  
         object, string given.                                                  
 ------ ----------------------------------------------------------------------- 

 [ERROR] Found 2 errors
```

https://symfony.com/blog/new-in-symfony-4-3-simpler-event-dispatching

The `dispatch()` PHPdoc in Symfony 4.3 onwards still has the old backward-compatible parameters, but the new order of parameters is fine. For some reason, `phpstan` `0.12.28` has now started noticing this in this app.