### PR TITLE
Remove phpstan ignores fixed in phpstan 0.12.29

### DIFF
--- a/lib/Jobs/PasswordExpirationNotifierJob.php
+++ b/lib/Jobs/PasswordExpirationNotifierJob.php
@@ -167,7 +167,6 @@ class PasswordExpirationNotifierJob extends TimedJob {
 				'user' => $this->userManager->get($passInfo->getUid()),
 				'passwordExpireInSeconds' => $expirationTime
 			]);
-		/* @phpstan-ignore-next-line */
 		$this->eventDispatcher->dispatch($aboutToExpireEvent, 'user.passwordAboutToExpire');
 	}
 
@@ -213,7 +212,6 @@ class PasswordExpirationNotifierJob extends TimedJob {
 				'user' => $this->userManager->get($passInfo->getUid()),
 				'passwordExpireInSeconds' => $expirationTime
 			]);
-		/* @phpstan-ignore-next-line */
 		$this->eventDispatcher->dispatch($expiredEvent, 'user.passwordExpired');
 	}
 


### PR DESCRIPTION
Fixes issue #310 

Somewhere in https://github.com/phpstan/phpstan/releases/tag/0.12.29 this problem got fixed, and the "ignore" are no longer needed.