### PR TITLE
Use relative url instead of absoulute url

### DIFF
--- a/lib/Jobs/PasswordExpirationNotifierJob.php
+++ b/lib/Jobs/PasswordExpirationNotifierJob.php
@@ -216,7 +216,7 @@ class PasswordExpirationNotifierJob extends TimedJob {
 	}
 
 	private function getNotificationLink() {
-		return $this->urlGenerator->linkToRouteAbsolute(
+		return $this->urlGenerator->linkToRoute(
 			'settings.SettingsPage.getPersonal',
 			['sectionid' => 'general']
 		);


### PR DESCRIPTION
Related to https://github.com/owncloud/enterprise/issues/4250 as notifications URLs shouldn't be absolute to prevent problems with CORS.