### PR TITLE
Fix: Api requests even work if user needs to reset the password 

### DIFF
--- a/appinfo/Migrations/Version20211102124544.php
+++ b/appinfo/Migrations/Version20211102124544.php
@@ -24,10 +24,10 @@ use OCP\Migration\IOutput;
 
 class Version20211102124544 implements ISimpleMigration {
 
-    /**
-     * @param IOutput $out
-     */
-    public function run(IOutput $out) {
-        \OC::$server->getConfig()->setAppValue('password_policy', 'types', 'authentication');
-    }
+	/**
+	 * @param IOutput $out
+	 */
+	public function run(IOutput $out) {
+		\OC::$server->getConfig()->setAppValue('password_policy', 'types', 'authentication');
+	}
 }

--- a/appinfo/Migrations/Version20211102124544.php
+++ b/appinfo/Migrations/Version20211102124544.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @copyright Copyright (c) 2021, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\password_policy\Migrations;
+
+use OCP\Migration\ISimpleMigration;
+use OCP\Migration\IOutput;
+
+class Version20211102124544 implements ISimpleMigration {
+
+    /**
+     * @param IOutput $out
+     */
+    public function run(IOutput $out) {
+        \OC::$server->getConfig()->setAppValue('password_policy', 'types', 'authentication');
+    }
+}

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -33,6 +33,9 @@ Administrators find the configuration options in the 'Security' section of the o
 	<background-jobs>
 		<job>OCA\PasswordPolicy\Jobs\PasswordExpirationNotifierJob</job>
 	</background-jobs>
+	<types>
+		<authentication/>
+	</types>
 
 	<screenshot>https://raw.githubusercontent.com/owncloud/screenshots/master/password_policy/owncloud-app-password_policy.jpg</screenshot>
 	<screenshot>https://raw.githubusercontent.com/owncloud/screenshots/master/password_policy/owncloud-app-password_policy2.jpg</screenshot>

--- a/tests/acceptance/features/bootstrap/PasswordPolicyContext.php
+++ b/tests/acceptance/features/bootstrap/PasswordPolicyContext.php
@@ -1086,4 +1086,36 @@ class PasswordPolicyContext implements Context {
 			$this->featureContext->getStepLineRef()
 		);
 	}
+
+	/**
+	 * @Then /^user "([^"]*)" downloading the file "([^"]*)" and using the password "([^"]*)" should receive hint to change their password$/
+	 *
+	 * @param string $user
+	 * @param string $fileName
+	 * @param string $password
+	 *
+	 * @return void
+	 */
+	public function userReceivesChangePasswordHintOnFileDownload(
+		string $user,
+		string $fileName,
+		string $password
+	):void {
+		$user = $this->featureContext->getActualUsername($user);
+		$password = $this->featureContext->getActualPassword($password);
+		$this->featureContext->downloadFileAsUserUsingPassword($user, $fileName, $password);
+		Assert::assertSame(
+			503,
+			$this->featureContext->getResponse()->getStatusCode(),
+			__METHOD__
+			. ' 503 error expected but got status code "'
+			. $this->featureContext->getResponse()->getStatusCode() . '"'
+		);
+		Assert::assertStringContainsString(
+			'The user must reset their password.',
+			$this->featureContext->getResponse()->getBody(),
+			__METHOD__
+			. ' expected to contain "The user must reset their password." but does not"'
+		);
+	}
 }

--- a/tests/acceptance/features/cliPasswordExpire/occExpireUserPassword.feature
+++ b/tests/acceptance/features/cliPasswordExpire/occExpireUserPassword.feature
@@ -8,10 +8,12 @@ Feature: expire user's password using the occ command
   Background:
     Given user "Alice" has been created with default attributes and small skeleton files
 
+
   Scenario: admin tries to expire user password without setting expiration rule
     When the administrator expires the password of user "Alice" using the occ command
     Then the command should have failed with exit code 1
     And the command output should contain the text 'Cannot use this command because no expiration rule was configured'
+
 
   Scenario: admin expires user password after setting expiration rule
     Given the administrator has enabled the days until user password expires user password policy
@@ -19,20 +21,19 @@ Feature: expire user's password using the occ command
     Then the command should have been successful
     And the command output should contain the text 'The password for Alice is set to expire'
 
-  @issue-313
+
   Scenario: admin expires password of a user and then the user downloads a file
     Given the administrator has enabled the days until user password expires user password policy
     When the administrator expires the password of user "Alice" using the occ command
-    Then the downloaded content when downloading file "/textfile0.txt" for user "Alice" with range "bytes=0-1" should be "ow"
-#    Then user "Alice" using password "%regular%" should not be able to download file "textfile0.txt"
+    Then user "Alice" downloading the file "textfile0.txt" and using the password "%regular%" should receive hint to change their password
 
-  @issue-313
+
   Scenario: admin expires password of a user and then the user deletes a file
     Given the administrator has enabled the days until user password expires user password policy
     And the administrator has expired the password of user "Alice"
     When user "Alice" deletes file "/textfile0.txt" using the WebDAV API
-    Then as "Alice" file "/textfile0.txt" should not exist
-#    Then as "Alice" file "/textfile0.txt" should exist
+    Then the HTTP status code should be "503"
+
 
   Scenario: admin expires password of a user and then the user tries to share a file
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -41,4 +42,3 @@ Feature: expire user's password using the occ command
     When user "Alice" shares file "/textfile0.txt" with user "Brian" using the sharing API
     Then the HTTP status code should be "204"
     But as "Brian" file "/textfile0.txt" should not exist
-


### PR DESCRIPTION
The type determines the app loading order. We need `authentication` here to make sure the app gets loaded before the DAV implementation. This way, users with expired passwords can't make DAV requests with their accounts until they've updated their passwords.

fixes https://github.com/owncloud/password_policy/issues/313