### PR TITLE
[Tests-Only] enforce strict type checking in acceptace tests code

### DIFF
--- a/tests/acceptance/features/bootstrap/PasswordPolicyContext.php
+++ b/tests/acceptance/features/bootstrap/PasswordPolicyContext.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * ownCloud
  *
@@ -1113,7 +1113,7 @@ class PasswordPolicyContext implements Context {
 		);
 		Assert::assertStringContainsString(
 			'The user must reset their password.',
-			$this->featureContext->getResponse()->getBody(),
+			$this->featureContext->getResponse()->getBody()->getContents(),
 			__METHOD__
 			. ' expected to contain "The user must reset their password." but does not"'
 		);

--- a/tests/acceptance/features/bootstrap/WebUIPasswordPolicyContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPasswordPolicyContext.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * ownCloud
  *

--- a/tests/acceptance/features/bootstrap/WebUIPasswordUpdateContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPasswordUpdateContext.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * ownCloud
  *

--- a/tests/acceptance/features/bootstrap/bootstrap.php
+++ b/tests/acceptance/features/bootstrap/bootstrap.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * ownCloud
  *

--- a/tests/acceptance/features/lib/PasswordPolicySettingsPage.php
+++ b/tests/acceptance/features/lib/PasswordPolicySettingsPage.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * ownCloud

--- a/tests/acceptance/features/lib/UpdatePasswordPage.php
+++ b/tests/acceptance/features/lib/UpdatePasswordPage.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * ownCloud


### PR DESCRIPTION
Related https://github.com/owncloud/QA/issues/694
- add strict type checking on acceptace test code

**note** this PR was generated by a automated script