### PR TITLE
Added tests for guest password expire

### DIFF
--- a/tests/acceptance/features/bootstrap/PasswordPolicyContext.php
+++ b/tests/acceptance/features/bootstrap/PasswordPolicyContext.php
@@ -900,33 +900,6 @@ class PasswordPolicyContext implements Context {
 	}
 
 	/**
-	 * @Then /^the email address "([^"]*)" should not have received any emails$/
-	 *
-	 * @param string $emailAddress
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function shouldNotReceiveAnyEmails(string $emailAddress):void {
-		$emails = [];
-		foreach (\TestHelpers\EmailHelper::getEmails(\TestHelpers\EmailHelper::getLocalMailhogUrl(), $this->featureContext->getStepLineRef())->items as $item) {
-			$emailSentTo
-				= $item->To[0]->Mailbox . "@" . $item->To[0]->Domain;
-			if ($emailSentTo === $emailAddress) {
-				\array_push($emails, $item);
-			}
-		}
-		Assert::assertEquals(
-			0,
-			\count($emails),
-			__METHOD__
-			. " Expected no of email is '0' but got '"
-			. \count($emails)
-			. "'"
-		);
-	}
-
-	/**
 	 *
 	 * @param string $setting
 	 *

--- a/tests/acceptance/features/bootstrap/PasswordPolicyContext.php
+++ b/tests/acceptance/features/bootstrap/PasswordPolicyContext.php
@@ -900,6 +900,33 @@ class PasswordPolicyContext implements Context {
 	}
 
 	/**
+	 * @Then /^the email address "([^"]*)" should not have received any emails$/
+	 *
+	 * @param string $emailAddress
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function shouldNotReceiveAnyEmails(string $emailAddress):void {
+		$emails = [];
+		foreach (\TestHelpers\EmailHelper::getEmails(\TestHelpers\EmailHelper::getLocalMailhogUrl(), $this->featureContext->getStepLineRef())->items as $item) {
+			$emailSentTo
+				= $item->To[0]->Mailbox . "@" . $item->To[0]->Domain;
+			if ($emailSentTo === $emailAddress) {
+				\array_push($emails, $item);
+			}
+		}
+		Assert::assertEquals(
+			0,
+			\count($emails),
+			__METHOD__
+			. " Expected no of email is '0' but got '"
+			. \count($emails)
+			. "'"
+		);
+	}
+
+	/**
 	 *
 	 * @param string $setting
 	 *

--- a/tests/acceptance/features/webUIGuests/guestPasswordExpire.feature
+++ b/tests/acceptance/features/webUIGuests/guestPasswordExpire.feature
@@ -11,10 +11,7 @@ Feature: expire guest user's password using the occ command
     When the administrator expires the password of user "guest@example.com" using the occ command
     Then the command should have been successful
     # Guest user does not get any emails when the command is invoked
-    And the email address "guest@example.com" should not have received any emails
+    And the email address "guest@example.com" should not have received an email
     # The above step can be removed and the below can be implemented when the guest user gets a password reset email
     # When the user follows the password reset link received by "guest@example" using the webUI
     # Then the user can set new password that meets the password policy using webUI
-
-
-

--- a/tests/acceptance/features/webUIGuests/guestPasswordExpire.feature
+++ b/tests/acceptance/features/webUIGuests/guestPasswordExpire.feature
@@ -1,0 +1,20 @@
+@webUI @insulated @disablePreviews @mailhog
+Feature: expire guest user's password using the occ command
+
+  As an administrator
+  I want to expire guest user's password
+  So that guest users change their password
+
+  Scenario: admin expires password of a guest user
+    Given the administrator has created guest user "guest" with email "guest@example.com"
+    And the administrator has enabled the days until user password expires user password policy
+    When the administrator expires the password of user "guest@example.com" using the occ command
+    Then the command should have been successful
+    # Guest user does not get any emails when the command is invoked
+    And the email address "guest@example.com" should not have received any emails
+    # The above step can be removed and the below can be implemented when the guest user gets a password reset email
+    # When the user follows the password reset link received by "guest@example" using the webUI
+    # Then the user can set new password that meets the password policy using webUI
+
+
+


### PR DESCRIPTION
## Description
This PR adds acceptance tests (Scenarios) for an expired guest password. And test added is based on the step `When the administrator expires the password of user "Alice" using the occ command` the guest user shoud have got an email to reset his password but does not get. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- This PR is related to https://github.com/owncloud/password_policy/issues/360

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally 
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
