### PR TITLE
[tests-only][full-ci]Tidy up the phpunit xml file for `password_policy` app

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,6 +8,11 @@
         timeoutForLargeTests="900"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <testsuites>
+    <testsuite name="unit">
+      <directory suffix="Test.php">./tests/unit</directory>
+    </testsuite>
+  </testsuites>
   <coverage>
     <include>
       <directory suffix=".php">.</directory>
@@ -20,13 +25,4 @@
       <clover outputFile="./tests/output/clover.xml"/>
     </report>
   </coverage>
-  <testsuites>
-    <testsuite name="unit">
-      <directory suffix="Test.php">./tests/unit</directory>
-    </testsuite>
-  </testsuites>
-  <!-- filters for code coverage -->
-  <logging>
-    <!-- and this is where your report will be written -->
-  </logging>
 </phpunit>


### PR DESCRIPTION
This PR moves unit tests into tests/unit folder. And also tidy up the `phpunit.xml` to make standard format for all oc-apps as much as possible.

- Part of https://github.com/owncloud/impersonate/issues/198