### PR TITLE
[tests-only] [full-ci] Adjust 'last public link shared folder' step text

### DIFF
--- a/tests/acceptance/features/apiGuests/guests.feature
+++ b/tests/acceptance/features/apiGuests/guests.feature
@@ -79,7 +79,7 @@ Feature: Guests
       | 2lOWERcASE | 1               | 403        | 200         | OK                 |
       | 2lOWERcASE | 2               | 403        | 403         | Forbidden          |
 
-  @mailhog @skipOnOcV10.2
+  @mailhog
   Scenario Outline: A guest user creates a public link share with a password that has enough lowercase letters
     Given using OCS API version "<ocs-api-version>"
     And the administrator has created guest user "guest" with email "guest@example.com"
@@ -102,30 +102,7 @@ Feature: Guests
       | moreThan3LowercaseLetters | 1               | 100        |
       | moreThan3LowercaseLetters | 2               | 200        |
 
-  @mailhog @skipOnOcV10.3
-  # This scenario repeats the one above, but without checking the new public WebDAV API.
-  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
-  Scenario Outline: A guest user creates a public link share with a password that has enough lowercase letters
-    Given using OCS API version "<ocs-api-version>"
-    And the administrator has created guest user "guest" with email "guest@example.com"
-    And user "Alice" has uploaded file with content "Alice file" to "/randomfile.txt"
-    And user "Alice" has shared file "/randomfile.txt" with user "guest@example.com"
-    And guest user "guest" has registered and set password to "enoughLowerCase"
-    When user "guest@example.com" creates a public link share using the sharing API with settings
-      | path     | randomfile.txt |
-      | password | <password>     |
-    Then the OCS status code should be "<ocs-status>"
-    And the HTTP status code should be "200"
-    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "<password>" and the content should be "Alice file"
-    And the public download of the last publicly shared file using the old public WebDAV API with password "%regular%" should fail with HTTP status code "401"
-    Examples:
-      | password                  | ocs-api-version | ocs-status |
-      | 3LCase                    | 1               | 100        |
-      | 3LCase                    | 2               | 200        |
-      | moreThan3LowercaseLetters | 1               | 100        |
-      | moreThan3LowercaseLetters | 2               | 200        |
-
-  @mailhog @skipOnOcV10.2
+  @mailhog
   Scenario Outline: A guest user creates a public link share with a password that does not have enough lowercase letters
     Given using OCS API version "<ocs-api-version>"
     And the administrator has created guest user "guest" with email "guest@example.com"
@@ -141,34 +118,6 @@ Feature: Guests
       """
       The password contains too few lowercase letters. At least 3 lowercase letters are required.
       """
-    And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
-    And the public download of the last publicly shared file using the new public WebDAV API with password "<password>" should fail with HTTP status code "401"
-    Examples:
-      | password   | ocs-api-version | ocs-status | http-status | http-reason-phrase |
-      | 0LOWERCASE | 1               | 403        | 200         | OK                 |
-      | 0LOWERCASE | 2               | 403        | 403         | Forbidden          |
-      | 2lOWERcASE | 1               | 403        | 200         | OK                 |
-      | 2lOWERcASE | 2               | 403        | 403         | Forbidden          |
-
-  @mailhog @skipOnOcV10.3
-  # This scenario repeats the one above, but without checking the new public WebDAV API.
-  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
-  Scenario Outline: A guest user creates a public link share with a password that does not have enough lowercase letters
-    Given using OCS API version "<ocs-api-version>"
-    And the administrator has created guest user "guest" with email "guest@example.com"
-    And user "Alice" has shared file "/textfile1.txt" with user "guest@example.com"
-    Given guest user "guest" has registered and set password to "enoughLowerCase"
-    When user "guest@example.com" creates a public link share using the sharing API with settings
-      | path     | textfile1.txt |
-      | password | <password>    |
-    Then the HTTP status code should be "<http-status>"
-    And the HTTP reason phrase should be "<http-reason-phrase>"
-    And the OCS status code should be "<ocs-status>"
-    And the OCS status message should be:
-      """
-      The password contains too few lowercase letters. At least 3 lowercase letters are required.
-      """
-    And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
     Examples:
       | password   | ocs-api-version | ocs-status | http-status | http-reason-phrase |
       | 0LOWERCASE | 1               | 403        | 200         | OK                 |

--- a/tests/acceptance/features/apiUpdateShare/publicShareLinkExpirationPolicy.feature
+++ b/tests/acceptance/features/apiUpdateShare/publicShareLinkExpirationPolicy.feature
@@ -28,7 +28,7 @@ Feature: enforce public link expiration policies
       | path     | PARENT   |
     Then the HTTP status code should be "<http-status>"
     And the OCS status code should be "<ocs-status>"
-    And the public should be able to download file "parent.txt" from inside the last public shared folder using the new public WebDAV API with password "abcdefgh" and the content should be "ownCloud test text file parent" plus end-of-line
+    And the public should be able to download file "parent.txt" from inside the last public link shared folder using the new public WebDAV API with password "abcdefgh" and the content should be "ownCloud test text file parent" plus end-of-line
     Examples:
       | ocs-api-version | ocs-status | http-status |
       | 1               | 100        | 200         |
@@ -41,7 +41,7 @@ Feature: enforce public link expiration policies
       | path | PARENT |
     Then the HTTP status code should be "<http-status>"
     And the OCS status code should be "<ocs-status>"
-    And the public should be able to download file "parent.txt" from inside the last public shared folder using the new public WebDAV API with password "abcdefgh" and the content should be "ownCloud test text file parent" plus end-of-line
+    And the public should be able to download file "parent.txt" from inside the last public link shared folder using the new public WebDAV API with password "abcdefgh" and the content should be "ownCloud test text file parent" plus end-of-line
     Examples:
       | ocs-api-version | ocs-status | http-status |
       | 1               | 100        | 200         |
@@ -85,7 +85,7 @@ Feature: enforce public link expiration policies
       | password   | abcdefgh |
     Then the HTTP status code should be "<http-status>"
     And the OCS status code should be "<ocs-status>"
-    And the public should be able to download file "parent.txt" from inside the last public shared folder using the new public WebDAV API with password "abcdefgh" and the content should be "ownCloud test text file parent" plus end-of-line
+    And the public should be able to download file "parent.txt" from inside the last public link shared folder using the new public WebDAV API with password "abcdefgh" and the content should be "ownCloud test text file parent" plus end-of-line
     Examples:
       | ocs-api-version | ocs-status | http-status |
       | 1               | 100        | 200         |
@@ -99,7 +99,7 @@ Feature: enforce public link expiration policies
       | expireDate | +10 days |
     Then the HTTP status code should be "<http-status>"
     And the OCS status code should be "<ocs-status>"
-    And the public should be able to download file "parent.txt" from inside the last public shared folder using the new public WebDAV API with password "abcdefgh" and the content should be "ownCloud test text file parent" plus end-of-line
+    And the public should be able to download file "parent.txt" from inside the last public link shared folder using the new public WebDAV API with password "abcdefgh" and the content should be "ownCloud test text file parent" plus end-of-line
     Examples:
       | ocs-api-version | ocs-status | http-status |
       | 1               | 100        | 200         |
@@ -129,7 +129,7 @@ Feature: enforce public link expiration policies
       | expireDate | +10 days |
     Then the HTTP status code should be "<http-status>"
     And the OCS status code should be "<ocs-status>"
-    And the public should be able to download file "parent.txt" from inside the last public shared folder using the new public WebDAV API with password "abcdefgh" and the content should be "ownCloud test text file parent" plus end-of-line
+    And the public should be able to download file "parent.txt" from inside the last public link shared folder using the new public WebDAV API with password "abcdefgh" and the content should be "ownCloud test text file parent" plus end-of-line
     Examples:
       | ocs-api-version | ocs-status | http-status |
       | 1               | 100        | 200         |
@@ -145,7 +145,7 @@ Feature: enforce public link expiration policies
       | password   | abcdefgh |
     Then the HTTP status code should be "<http-status>"
     And the OCS status code should be "<ocs-status>"
-    And the public should be able to download file "parent.txt" from inside the last public shared folder using the new public WebDAV API with password "abcdefgh" and the content should be "ownCloud test text file parent" plus end-of-line
+    And the public should be able to download file "parent.txt" from inside the last public link shared folder using the new public WebDAV API with password "abcdefgh" and the content should be "ownCloud test text file parent" plus end-of-line
     Examples:
       | ocs-api-version | ocs-status | http-status |
       | 1               | 100        | 200         |
@@ -190,7 +190,7 @@ Feature: enforce public link expiration policies
       | expireDate | +20 days |
     Then the HTTP status code should be "<http-status>"
     And the OCS status code should be "<ocs-status>"
-    And the public should be able to download file "parent.txt" from inside the last public shared folder using the new public WebDAV API with password "abcdefgh" and the content should be "ownCloud test text file parent" plus end-of-line
+    And the public should be able to download file "parent.txt" from inside the last public link shared folder using the new public WebDAV API with password "abcdefgh" and the content should be "ownCloud test text file parent" plus end-of-line
     Examples:
       | ocs-api-version | ocs-status | http-status |
       | 1               | 100        | 200         |
@@ -205,7 +205,7 @@ Feature: enforce public link expiration policies
       | password   | abcdefgh |
     Then the HTTP status code should be "<http-status>"
     And the OCS status code should be "<ocs-status>"
-    And the public should be able to download file "parent.txt" from inside the last public shared folder using the new public WebDAV API with password "abcdefgh" and the content should be "ownCloud test text file parent" plus end-of-line
+    And the public should be able to download file "parent.txt" from inside the last public link shared folder using the new public WebDAV API with password "abcdefgh" and the content should be "ownCloud test text file parent" plus end-of-line
     Examples:
       | ocs-api-version | ocs-status | http-status |
       | 1               | 100        | 200         |
@@ -219,7 +219,7 @@ Feature: enforce public link expiration policies
       | expireDate | +6 days  |
       | password   | abcdefgh |
     And the administrator has set the value for the maximum days until link expires if password is set to "3"
-    When user "Alice" updates the last share using the sharing API with
+    When user "Alice" updates the last public link share using the sharing API with
       | expireDate | +5 days |
     Then the HTTP status code should be "<http-status>"
     And the OCS status code should be "<ocs-status>"
@@ -236,7 +236,7 @@ Feature: enforce public link expiration policies
       | path       | PARENT  |
       | expireDate | +6 days |
     And the administrator has set the value for the maximum days until link expires if password is not set to "3"
-    When user "Alice" updates the last share using the sharing API with
+    When user "Alice" updates the last public link share using the sharing API with
       | expireDate | +5 days |
     Then the HTTP status code should be "<http-status>"
     And the OCS status code should be "<ocs-status>"

--- a/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateLowercaseLetters.feature
+++ b/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateLowercaseLetters.feature
@@ -1,8 +1,8 @@
 @api
-Feature: enforce the required number of lowercase letters on public share links
+Feature: enforce the required number of lowercase letters on public link shares
 
   As an administrator
-  I want public share link passwords to always contain a required number of lowercase letters
+  I want public link share passwords to always contain a required number of lowercase letters
   So that users cannot set passwords that are too easy to guess
 
   Background:
@@ -16,9 +16,9 @@ Feature: enforce the required number of lowercase letters on public share links
       | path     | randomfile.txt |
       | password | ABCabc1234     |
 
-  @skipOnOcV10.2
-  Scenario Outline: user updates the public share link password to a string with enough lowercase letters
-    When user "Alice" updates the last share using the sharing API with
+
+  Scenario Outline: user updates the public link share password to a string with enough lowercase letters
+    When user "Alice" updates the last public link share using the sharing API with
       | password | <password> |
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
@@ -31,24 +31,9 @@ Feature: enforce the required number of lowercase letters on public share links
       | 3LCase                    |
       | moreThan3LowercaseLetters |
 
-  @skipOnOcV10.3
-  # This scenario repeats the one above, but without checking the new public WebDAV API.
-  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
-  Scenario Outline: user updates the public share link password to a string with enough lowercase letters
-    When user "Alice" updates the last share using the sharing API with
-      | password | <password> |
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "<password>" and the content should be "Alice file"
-    And the public download of the last publicly shared file using the old public WebDAV API with password "ABCabc1234" should fail with HTTP status code "401"
-    Examples:
-      | password                  |
-      | 3LCase                    |
-      | moreThan3LowercaseLetters |
 
-  @skipOnOcV10.2
-  Scenario Outline: user tries to update the public share link password to a string with not enough lowercase letters
-    When user "Alice" tries to update the last share using the sharing API with
+  Scenario Outline: user tries to update the public link share password to a string with not enough lowercase letters
+    When user "Alice" tries to update the last public link share using the sharing API with
       | password | <password> |
     Then the OCS status message should be "The password contains too few lowercase letters. At least 3 lowercase letters are required."
     And the OCS status code should be "400"
@@ -56,21 +41,6 @@ Feature: enforce the required number of lowercase letters on public share links
     And the public should be able to download the last publicly shared file using the new public WebDAV API with password "ABCabc1234" and the content should be "Alice file"
     And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
     And the public download of the last publicly shared file using the new public WebDAV API with password "<password>" should fail with HTTP status code "401"
-    Examples:
-      | password   |
-      | 0LOWERCASE |
-      | 2lOWERcASE |
-
-  @skipOnOcV10.3
-  # This scenario repeats the one above, but without checking the new public WebDAV API.
-  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
-  Scenario Outline: user tries to update the public share link password to a string with not enough lowercase letters
-    When user "Alice" tries to update the last share using the sharing API with
-      | password | <password> |
-    Then the OCS status message should be "The password contains too few lowercase letters. At least 3 lowercase letters are required."
-    And the OCS status code should be "400"
-    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "ABCabc1234" and the content should be "Alice file"
-    And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
     Examples:
       | password   |
       | 0LOWERCASE |

--- a/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateMinimumLength.feature
+++ b/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateMinimumLength.feature
@@ -1,8 +1,8 @@
 @api
-Feature: enforce the minimum length of a password on public share links
+Feature: enforce the minimum length of a password on public link shares
 
   As an administrator
-  I want public share link passwords to always be a certain minimum length
+  I want public link share passwords to always be a certain minimum length
   So that users cannot set passwords that are too short (easy to crack)
 
   Background:
@@ -16,9 +16,9 @@ Feature: enforce the minimum length of a password on public share links
       | path     | randomfile.txt |
       | password | ABCabc1234     |
 
-  @skipOnOcV10.2
-  Scenario Outline: user updates the public share link password a long-enough string
-    When user "Alice" updates the last share using the sharing API with
+
+  Scenario Outline: user updates the public link share password a long-enough string
+    When user "Alice" updates the last public link share using the sharing API with
       | password | <password> |
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
@@ -31,24 +31,9 @@ Feature: enforce the minimum length of a password on public share links
       | 10tenchars           |
       | morethan10characters |
 
-  @skipOnOcV10.3
-  # This scenario repeats the one above, but without checking the new public WebDAV API.
-  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
-  Scenario Outline: user updates the public share link password a long-enough string
-    When user "Alice" updates the last share using the sharing API with
-      | password | <password> |
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "<password>" and the content should be "Alice file"
-    And the public download of the last publicly shared file using the old public WebDAV API with password "ABCabc1234" should fail with HTTP status code "401"
-    Examples:
-      | password             |
-      | 10tenchars           |
-      | morethan10characters |
 
-  @skipOnOcV10.2
-  Scenario Outline: user tries to update the public share link password to a string that is too short
-    When user "Alice" tries to update the last share using the sharing API with
+  Scenario Outline: user tries to update the public link share password to a string that is too short
+    When user "Alice" tries to update the last public link share using the sharing API with
       | password | <password> |
     Then the OCS status message should be "The password is too short. At least 10 characters are required."
     And the OCS status code should be "400"
@@ -56,21 +41,6 @@ Feature: enforce the minimum length of a password on public share links
     And the public should be able to download the last publicly shared file using the new public WebDAV API with password "ABCabc1234" and the content should be "Alice file"
     And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
     And the public download of the last publicly shared file using the new public WebDAV API with password "<password>" should fail with HTTP status code "401"
-    Examples:
-      | password  |
-      | A         |
-      | 123456789 |
-
-  @skipOnOcV10.3
-  # This scenario repeats the one above, but without checking the new public WebDAV API.
-  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
-  Scenario Outline: user tries to update the public share link password to a string that is too short
-    When user "Alice" tries to update the last share using the sharing API with
-      | password | <password> |
-    Then the OCS status message should be "The password is too short. At least 10 characters are required."
-    And the OCS status code should be "400"
-    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "ABCabc1234" and the content should be "Alice file"
-    And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
     Examples:
       | password  |
       | A         |

--- a/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateNumbers.feature
+++ b/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateNumbers.feature
@@ -1,8 +1,8 @@
 @api
-Feature: enforce the required number of numbers in a password on public share links
+Feature: enforce the required number of numbers in a password on public link shares
 
   As an administrator
-  I want public share link passwords to always contain a required number of numbers
+  I want public link share passwords to always contain a required number of numbers
   So that users cannot set passwords that are too easy to guess
 
   Background:
@@ -16,9 +16,9 @@ Feature: enforce the required number of numbers in a password on public share li
       | path     | randomfile.txt |
       | password | ABCabc1234     |
 
-  @skipOnOcV10.2
-  Scenario Outline: user updates the public share link password to a string with enough numbers
-    When user "Alice" updates the last share using the sharing API with
+
+  Scenario Outline: user updates the public link share password to a string with enough numbers
+    When user "Alice" updates the last public link share using the sharing API with
       | password | <password> |
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
@@ -31,24 +31,9 @@ Feature: enforce the required number of numbers in a password on public share li
       | 333Numbers      |
       | moreNumbers1234 |
 
-  @skipOnOcV10.3
-  # This scenario repeats the one above, but without checking the new public WebDAV API.
-  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
-  Scenario Outline: user updates the public share link password to a string with enough numbers
-    When user "Alice" updates the last share using the sharing API with
-      | password | <password> |
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "<password>" and the content should be "Alice file"
-    And the public download of the last publicly shared file using the old public WebDAV API with password "ABCabc1234" should fail with HTTP status code "401"
-    Examples:
-      | password        |
-      | 333Numbers      |
-      | moreNumbers1234 |
 
-  @skipOnOcV10.2
-  Scenario Outline: user tries to update the public share link password to a string that has too few numbers
-    When user "Alice" tries to update the last share using the sharing API with
+  Scenario Outline: user tries to update the public link share password to a string that has too few numbers
+    When user "Alice" tries to update the last public link share using the sharing API with
       | password | <password> |
     Then the OCS status message should be "The password contains too few numbers. At least 3 numbers are required."
     And the OCS status code should be "400"
@@ -56,21 +41,6 @@ Feature: enforce the required number of numbers in a password on public share li
     And the public should be able to download the last publicly shared file using the new public WebDAV API with password "ABCabc1234" and the content should be "Alice file"
     And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
     And the public download of the last publicly shared file using the new public WebDAV API with password "<password>" should fail with HTTP status code "401"
-    Examples:
-      | password      |
-      | NoNumbers     |
-      | Only22Numbers |
-
-  @skipOnOcV10.3
-  # This scenario repeats the one above, but without checking the new public WebDAV API.
-  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
-  Scenario Outline: user tries to update the public share link password to a string that has too few numbers
-    When user "Alice" tries to update the last share using the sharing API with
-      | password | <password> |
-    Then the OCS status message should be "The password contains too few numbers. At least 3 numbers are required."
-    And the OCS status code should be "400"
-    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "ABCabc1234" and the content should be "Alice file"
-    And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
     Examples:
       | password      |
       | NoNumbers     |

--- a/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateRequirementCombinations.feature
+++ b/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateRequirementCombinations.feature
@@ -1,8 +1,8 @@
 @api
-Feature: enforce combinations of password policies on public share links
+Feature: enforce combinations of password policies on public link shares
 
   As an administrator
-  I want public share link passwords to always have some combination of minimum length, lowercase, uppercase, numbers and special characters
+  I want public link share passwords to always have some combination of minimum length, lowercase, uppercase, numbers and special characters
   So that users cannot set passwords that are too easy to guess
 
   Background:
@@ -24,9 +24,9 @@ Feature: enforce combinations of password policies on public share links
       | path     | randomfile.txt  |
       | password | zA1@bB2#cC&deee |
 
-  @skipOnOcV10.2
-  Scenario Outline: user updates the public share link password to a valid string
-    When user "Alice" updates the last share using the sharing API with
+
+  Scenario Outline: user updates the public link share password to a valid string
+    When user "Alice" updates the last public link share using the sharing API with
       | password | <password> |
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
@@ -39,24 +39,9 @@ Feature: enforce combinations of password policies on public share links
       | 15***UPPloweZZZ           |
       | More%Than$15!Characters-0 |
 
-  @skipOnOcV10.3
-  # This scenario repeats the one above, but without checking the new public WebDAV API.
-  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
-  Scenario Outline: user updates the public share link password to a valid string
-    When user "Alice" updates the last share using the sharing API with
-      | password | <password> |
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "<password>" and the content should be "Alice file"
-    And the public download of the last publicly shared file using the old public WebDAV API with password "zA1@bB2#cC&deee" should fail with HTTP status code "401"
-    Examples:
-      | password                  |
-      | 15***UPPloweZZZ           |
-      | More%Than$15!Characters-0 |
 
-  @skipOnOcV10.2
-  Scenario Outline: user tries to update the public share link password to an invalid string
-    When user "Alice" tries to update the last share using the sharing API with
+  Scenario Outline: user tries to update the public link share password to an invalid string
+    When user "Alice" tries to update the last public link share using the sharing API with
       | password | <password> |
     Then the OCS status message should be "<message>"
     And the OCS status code should be "400"
@@ -76,33 +61,11 @@ Feature: enforce combinations of password policies on public share links
       | aA!1                           | The password is too short. At least 15 characters are required.                               |
       | aA!123456789012345             | The password contains too few lowercase letters. At least 4 lowercase letters are required.   |
 
-  @skipOnOcV10.3
-  # This scenario repeats the one above, but without checking the new public WebDAV API.
-  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
-  Scenario Outline: user tries to update the public share link password to an invalid string
-    When user "Alice" tries to update the last share using the sharing API with
-      | password | <password> |
-    Then the OCS status message should be "<message>"
-    And the OCS status code should be "400"
-    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "zA1@bB2#cC&deee" and the content should be "Alice file"
-    And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
-    Examples:
-      | password                       | message                                                                                       |
-      # where just one of the requirements is not met
-      | aA1!bB2#cC&d                   | The password is too short. At least 15 characters are required.                               |
-      | aA1!bB2#cNOT&ENOUGH#LOWERCASE  | The password contains too few lowercase letters. At least 4 lowercase letters are required.   |
-      | aA1!bB2#cnot&enough#uppercase  | The password contains too few uppercase letters. At least 3 uppercase letters are required.   |
-      | Not&Enough#Numbers=1           | The password contains too few numbers. At least 2 numbers are required.                       |
-      | Not&Enough#Special8Characters2 | The password contains too few special characters. At least 3 special characters are required. |
-      # where multiple requirements are not met, only the first error message is shown to the user
-      | aA!1                           | The password is too short. At least 15 characters are required.                               |
-      | aA!123456789012345             | The password contains too few lowercase letters. At least 4 lowercase letters are required.   |
 
-  @skipOnOcV10.2
-  Scenario Outline: user updates the public share link password to valid restricted special characters
+  Scenario Outline: user updates the public link share password to valid restricted special characters
     Given the administrator has enabled the restrict to these special characters password policy
     And the administrator has set the restricted special characters required to "$%^&*"
-    When user "Alice" updates the last share using the sharing API with
+    When user "Alice" updates the last public link share using the sharing API with
       | password | <password> |
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
@@ -115,28 +78,11 @@ Feature: enforce combinations of password policies on public share links
       | 15%&*UPPloweZZZ           |
       | More^Than$15&Characters*0 |
 
-  @skipOnOcV10.3
-  # This scenario repeats the one above, but without checking the new public WebDAV API.
-  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
-  Scenario Outline: user updates the public share link password to valid restricted special characters
-    Given the administrator has enabled the restrict to these special characters password policy
-    And the administrator has set the restricted special characters required to "$%^&*"
-    When user "Alice" updates the last share using the sharing API with
-      | password | <password> |
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "<password>" and the content should be "Alice file"
-    And the public download of the last publicly shared file using the old public WebDAV API with password "zA1@bB2#cC&deee" should fail with HTTP status code "401"
-    Examples:
-      | password                  |
-      | 15%&*UPPloweZZZ           |
-      | More^Than$15&Characters*0 |
 
-  @skipOnOcV10.2
-  Scenario Outline: user tries to update the public share link password to invalid restricted special characters
+  Scenario Outline: user tries to update the public link share password to invalid restricted special characters
     Given the administrator has enabled the restrict to these special characters password policy
     And the administrator has set the restricted special characters required to "$%^&*"
-    When user "Alice" tries to update the last share using the sharing API with
+    When user "Alice" tries to update the last public link share using the sharing API with
       | password | <password> |
     Then the OCS status message should be "<message>"
     And the OCS status code should be "400"
@@ -144,25 +90,6 @@ Feature: enforce combinations of password policies on public share links
     And the public should be able to download the last publicly shared file using the new public WebDAV API with password "zA1@bB2#cC&deee" and the content should be "Alice file"
     And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
     And the public download of the last publicly shared file using the new public WebDAV API with password "<password>" should fail with HTTP status code "401"
-    Examples:
-      | password        | message                                                                                     |
-      | 15#!!UPPloweZZZ | The password contains invalid special characters. Only $%^&* are allowed.                   |
-      | 15&%!UPPloweZZZ | The password contains invalid special characters. Only $%^&* are allowed.                   |
-      # where multiple requirements are not met, only the first error message is shown to the user
-      | 15&%!UPPlowZZZZ | The password contains too few lowercase letters. At least 4 lowercase letters are required. |
-
-  @skipOnOcV10.3
-  # This scenario repeats the one above, but without checking the new public WebDAV API.
-  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
-  Scenario Outline: user tries to update the public share link password to invalid restricted special characters
-    Given the administrator has enabled the restrict to these special characters password policy
-    And the administrator has set the restricted special characters required to "$%^&*"
-    When user "Alice" tries to update the last share using the sharing API with
-      | password | <password> |
-    Then the OCS status message should be "<message>"
-    And the OCS status code should be "400"
-    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "zA1@bB2#cC&deee" and the content should be "Alice file"
-    And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
     Examples:
       | password        | message                                                                                     |
       | 15#!!UPPloweZZZ | The password contains invalid special characters. Only $%^&* are allowed.                   |

--- a/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateSpecialCharacters.feature
+++ b/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateSpecialCharacters.feature
@@ -1,8 +1,8 @@
 @api
-Feature: enforce the required number of special characters in a password on public share links
+Feature: enforce the required number of special characters in a password on public link shares
 
   As an administrator
-  I want public share link passwords to always contain a required number of special characters
+  I want public link share passwords to always contain a required number of special characters
   So that users cannot set passwords that are too easy to guess
 
   Background:
@@ -16,9 +16,9 @@ Feature: enforce the required number of special characters in a password on publ
       | path     | randomfile.txt |
       | password | g@b#c!1234     |
 
-  @skipOnOcV10.2
-  Scenario Outline: user updates the public share link password to a string with enough special characters
-    When user "Alice" updates the last share using the sharing API with
+
+  Scenario Outline: user updates the public link share password to a string with enough special characters
+    When user "Alice" updates the last public link share using the sharing API with
       | password | <password> |
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
@@ -31,24 +31,9 @@ Feature: enforce the required number of special characters in a password on publ
       | 3#Special$Characters! |
       | 1!2@3#4$5%6^7&8*      |
 
-  @skipOnOcV10.3
-  # This scenario repeats the one above, but without checking the new public WebDAV API.
-  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
-  Scenario Outline: user updates the public share link password to a string with enough special characters
-    When user "Alice" updates the last share using the sharing API with
-      | password | <password> |
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "<password>" and the content should be "Alice file"
-    And the public download of the last publicly shared file using the old public WebDAV API with password "g@b#c!1234" should fail with HTTP status code "401"
-    Examples:
-      | password              |
-      | 3#Special$Characters! |
-      | 1!2@3#4$5%6^7&8*      |
 
-  @skipOnOcV10.2
-  Scenario Outline: user tries to update the public share link password to a string that has too few special characters
-    When user "Alice" tries to update the last share using the sharing API with
+  Scenario Outline: user tries to update the public link share password to a string that has too few special characters
+    When user "Alice" tries to update the last public link share using the sharing API with
       | password | <password> |
     Then the OCS status message should be "The password contains too few special characters. At least 3 special characters are required."
     And the OCS status code should be "400"
@@ -56,21 +41,6 @@ Feature: enforce the required number of special characters in a password on publ
     And the public should be able to download the last publicly shared file using the new public WebDAV API with password "g@b#c!1234" and the content should be "Alice file"
     And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
     And the public download of the last publicly shared file using the new public WebDAV API with password "<password>" should fail with HTTP status code "401"
-    Examples:
-      | password                 |
-      | NoSpecialCharacters123   |
-      | Only2$Special!Characters |
-
-  @skipOnOcV10.3
-  # This scenario repeats the one above, but without checking the new public WebDAV API.
-  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
-  Scenario Outline: user tries to update the public share link password to a string that has too few special characters
-    When user "Alice" tries to update the last share using the sharing API with
-      | password | <password> |
-    Then the OCS status message should be "The password contains too few special characters. At least 3 special characters are required."
-    And the OCS status code should be "400"
-    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "g@b#c!1234" and the content should be "Alice file"
-    And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
     Examples:
       | password                 |
       | NoSpecialCharacters123   |

--- a/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateSpecialCharactersRestrictions.feature
+++ b/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateSpecialCharactersRestrictions.feature
@@ -1,8 +1,8 @@
 @api
-Feature: enforce the restricted special characters in a password on public share links
+Feature: enforce the restricted special characters in a password on public link shares
 
   As an administrator
-  I want public share link passwords to always contain some of a restricted list of special characters
+  I want public link share passwords to always contain some of a restricted list of special characters
   So that users cannot set passwords that have unusual hard-to-type characters
 
   Background:
@@ -18,9 +18,9 @@ Feature: enforce the restricted special characters in a password on public share
       | path     | randomfile.txt |
       | password | a324$b%c^1234  |
 
-  @skipOnOcV10.2
-  Scenario Outline: user updates the public share link password to a string with enough restricted special characters
-    When user "Alice" updates the last share using the sharing API with
+
+  Scenario Outline: user updates the public link share password to a string with enough restricted special characters
+    When user "Alice" updates the last public link share using the sharing API with
       | password | <password> |
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
@@ -33,24 +33,9 @@ Feature: enforce the restricted special characters in a password on public share
       | 3$Special%Characters^ |
       | 1*2&3^4%5$6           |
 
-  @skipOnOcV10.3
-  # This scenario repeats the one above, but without checking the new public WebDAV API.
-  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
-  Scenario Outline: user updates the public share link password to a string with enough restricted special characters
-    When user "Alice" updates the last share using the sharing API with
-      | password | <password> |
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "<password>" and the content should be "Alice file"
-    And the public download of the last publicly shared file using the old public WebDAV API with password "a324$b%c^1234" should fail with HTTP status code "401"
-    Examples:
-      | password              |
-      | 3$Special%Characters^ |
-      | 1*2&3^4%5$6           |
 
-  @skipOnOcV10.2
-  Scenario Outline: user tries to update the public share link password to a string that has too few restricted special characters
-    When user "Alice" tries to update the last share using the sharing API with
+  Scenario Outline: user tries to update the public link share password to a string that has too few restricted special characters
+    When user "Alice" tries to update the last public link share using the sharing API with
       | password | <password> |
     Then the OCS status message should be "The password contains too few special characters. At least 3 special characters ($%^&*) are required."
     And the OCS status code should be "400"
@@ -63,24 +48,9 @@ Feature: enforce the restricted special characters in a password on public share
       | NoSpecialCharacters123   |
       | Only2$Special&Characters |
 
-  @skipOnOcV10.3
-  # This scenario repeats the one above, but without checking the new public WebDAV API.
-  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
-  Scenario Outline: user tries to update the public share link password to a string that has too few restricted special characters
-    When user "Alice" tries to update the last share using the sharing API with
-      | password | <password> |
-    Then the OCS status message should be "The password contains too few special characters. At least 3 special characters ($%^&*) are required."
-    And the OCS status code should be "400"
-    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "a324$b%c^1234" and the content should be "Alice file"
-    And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
-    Examples:
-      | password                 |
-      | NoSpecialCharacters123   |
-      | Only2$Special&Characters |
 
-  @skipOnOcV10.2
-  Scenario Outline: user tries to update the public share link password to a string that has invalid special characters
-    When user "Alice" tries to update the last share using the sharing API with
+  Scenario Outline: user tries to update the public link share password to a string that has invalid special characters
+    When user "Alice" tries to update the last public link share using the sharing API with
       | password | <password> |
     Then the OCS status message should be "The password contains invalid special characters. Only $%^&* are allowed."
     And the OCS status code should be "400"
@@ -88,21 +58,6 @@ Feature: enforce the restricted special characters in a password on public share
     And the public should be able to download the last publicly shared file using the new public WebDAV API with password "a324$b%c^1234" and the content should be "Alice file"
     And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
     And the public download of the last publicly shared file using the new public WebDAV API with password "<password>" should fail with HTTP status code "401"
-    Examples:
-      | password                                 |
-      | Only#Invalid!Special@Characters          |
-      | 1*2&3^4%5$6andInvalidSpecialCharacters#! |
-
-  @skipOnOcV10.3
-  # This scenario repeats the one above, but without checking the new public WebDAV API.
-  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
-  Scenario Outline: user tries to update the public share link password to a string that has invalid special characters
-    When user "Alice" tries to update the last share using the sharing API with
-      | password | <password> |
-    Then the OCS status message should be "The password contains invalid special characters. Only $%^&* are allowed."
-    And the OCS status code should be "400"
-    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "a324$b%c^1234" and the content should be "Alice file"
-    And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
     Examples:
       | password                                 |
       | Only#Invalid!Special@Characters          |

--- a/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateUppercaseLetters.feature
+++ b/tests/acceptance/features/apiUpdateShare/publicShareLinkUpdateUppercaseLetters.feature
@@ -1,8 +1,8 @@
 @api
-Feature: enforce the required number of uppercase letters in a password on public share links
+Feature: enforce the required number of uppercase letters in a password on public link shares
 
   As an administrator
-  I want public share link passwords to always contain a required number of uppercase letters
+  I want public link share passwords to always contain a required number of uppercase letters
   So that users cannot set passwords that are too easy to guess
 
   Background:
@@ -16,9 +16,9 @@ Feature: enforce the required number of uppercase letters in a password on publi
       | path     | randomfile.txt |
       | password | ABCabc1234     |
 
-  @skipOnOcV10.2
-  Scenario Outline: user updates the public share link password to a string with enough uppercase letters
-    When user "Alice" updates the last share using the sharing API with
+
+  Scenario Outline: user updates the public link share password to a string with enough uppercase letters
+    When user "Alice" updates the last public link share using the sharing API with
       | password | <password> |
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
@@ -31,24 +31,9 @@ Feature: enforce the required number of uppercase letters in a password on publi
       | 3UpperCaseLetters         |
       | MoreThan3UpperCaseLetters |
 
-  @skipOnOcV10.3
-  # This scenario repeats the one above, but without checking the new public WebDAV API.
-  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
-  Scenario Outline: user updates the public share link password to a string with enough uppercase letters
-    When user "Alice" updates the last share using the sharing API with
-      | password | <password> |
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "<password>" and the content should be "Alice file"
-    And the public download of the last publicly shared file using the old public WebDAV API with password "ABCabc1234" should fail with HTTP status code "401"
-    Examples:
-      | password                  |
-      | 3UpperCaseLetters         |
-      | MoreThan3UpperCaseLetters |
 
-  @skipOnOcV10.2
-  Scenario Outline: user tries to update the public share link password to a string that has too few uppercase letters
-    When user "Alice" tries to update the last share using the sharing API with
+  Scenario Outline: user tries to update the public link share password to a string that has too few uppercase letters
+    When user "Alice" tries to update the last public link share using the sharing API with
       | password | <password> |
     Then the OCS status message should be "The password contains too few uppercase letters. At least 3 uppercase letters are required."
     And the OCS status code should be "400"
@@ -56,21 +41,6 @@ Feature: enforce the required number of uppercase letters in a password on publi
     And the public should be able to download the last publicly shared file using the new public WebDAV API with password "ABCabc1234" and the content should be "Alice file"
     And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
     And the public download of the last publicly shared file using the new public WebDAV API with password "<password>" should fail with HTTP status code "401"
-    Examples:
-      | password       |
-      | 0uppercase     |
-      | Only2Uppercase |
-
-  @skipOnOcV10.3
-  # This scenario repeats the one above, but without checking the new public WebDAV API.
-  # It works against core 10.2.1. Delete the scenario when testing against 10.2.1 is no longer required.
-  Scenario Outline: user tries to update the public share link password to a string that has too few uppercase letters
-    When user "Alice" tries to update the last share using the sharing API with
-      | password | <password> |
-    Then the OCS status message should be "The password contains too few uppercase letters. At least 3 uppercase letters are required."
-    And the OCS status code should be "400"
-    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "ABCabc1234" and the content should be "Alice file"
-    And the public download of the last publicly shared file using the old public WebDAV API with password "<password>" should fail with HTTP status code "401"
     Examples:
       | password       |
       | 0uppercase     |

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserLowercaseLetters.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserLowercaseLetters.feature
@@ -22,23 +22,7 @@ Feature: enforce the required number of lowercase letters in a password when cre
       | 3LCase                    |
       | moreThan3LowercaseLetters |
 
-  @skipOnOcV10.2
-  # The command output for errors is coming on stdout from core 10.3 onwards
-  Scenario Outline: admin creates a user with a password that does not have enough lowercase letters
-    When the administrator creates this user using the occ command:
-      | username | password   |
-      | Alice    | <password> |
-    Then the command should have failed with exit code 1
-    # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
-    And the command error output should contain the text 'The password contains too few lowercase letters. At least 3 lowercase'
-    And user "Alice" should not exist
-    Examples:
-      | password   |
-      | 0LOWERCASE |
-      | 2lOWERcASE |
 
-  @skipOnOcV10.3
-  # The command output for errors comes on stderr in core 10.2
   Scenario Outline: admin creates a user with a password that does not have enough lowercase letters
     When the administrator creates this user using the occ command:
       | username | password   |

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserMinimumLength.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserMinimumLength.feature
@@ -22,22 +22,7 @@ Feature: enforce the minimum length of a password when creating a user
       | 10tenchars           |
       | morethan10characters |
 
-  @skipOnOcV10.2
-  # The command output for errors is coming on stdout from core 10.3 onwards
-  Scenario Outline: admin creates a user with a password that is not long enough
-    When the administrator creates this user using the occ command:
-      | username | password   |
-      | Alice    | <password> |
-    Then the command should have failed with exit code 1
-    And the command error output should contain the text 'The password is too short. At least 10 characters are required.'
-    And user "Alice" should not exist
-    Examples:
-      | password  |
-      | A         |
-      | 123456789 |
 
-  @skipOnOcV10.3
-  # The command output for errors comes on stderr in core 10.2
   Scenario Outline: admin creates a user with a password that is not long enough
     When the administrator creates this user using the occ command:
       | username | password   |

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserNumbers.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserNumbers.feature
@@ -22,22 +22,7 @@ Feature: enforce the required number of numbers in a password when creating a us
       | 333Numbers      |
       | moreNumbers1234 |
 
-  @skipOnOcV10.2
-  # The command output for errors is coming on stdout from core 10.3 onwards
-  Scenario Outline: admin creates a user with a password that does not have enough numbers
-    When the administrator creates this user using the occ command:
-      | username | password   |
-      | Alice    | <password> |
-    Then the command should have failed with exit code 1
-    And the command error output should contain the text 'The password contains too few numbers. At least 3 numbers are required.'
-    And user "Alice" should not exist
-    Examples:
-      | password      |
-      | NoNumbers     |
-      | Only22Numbers |
 
-  @skipOnOcV10.3
-  # The command output for errors comes on stderr in core 10.2
   Scenario Outline: admin creates a user with a password that does not have enough numbers
     When the administrator creates this user using the occ command:
       | username | password   |

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserRequirementCombinations.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserRequirementCombinations.feature
@@ -30,8 +30,7 @@ Feature: enforce combinations of password policies when creating a user
       | 15***UPPloweZZZ           |
       | More%Than$15!Characters-0 |
 
-  @skipOnOcV10.2
-  # The command output for errors is coming on stdout from core 10.3 onwards
+
   Scenario Outline: admin creates a user with a password that does not meet the password policy
     When the administrator creates this user using the occ command:
       | username | password   |
@@ -51,26 +50,6 @@ Feature: enforce combinations of password policies when creating a user
       | aA!1                           | The password is too short. At least 15 characters are required.           |
       | aA!123456789012345             | The password contains too few lowercase letters. At least 4 lowercase     |
 
-  @skipOnOcV10.3
-  # The command output for errors comes on stderr in core 10.2
-  Scenario Outline: admin creates a user with a password that does not meet the password policy
-    When the administrator creates this user using the occ command:
-      | username | password   |
-      | Alice    | <password> |
-    Then the command should have failed with exit code 1
-    And the command error output should contain the text '<message>'
-    And user "Alice" should not exist
-    Examples:
-      | password                       | message                                                                   |
-        # where just one of the requirements is not met
-      | aA1!bB2#cC&d                   | The password is too short. At least 15 characters are required.           |
-      | aA1!bB2#cNOT&ENOUGH#LOWERCASE  | The password contains too few lowercase letters. At least 4 lowercase     |
-      | aA1!bB2#cnot&enough#uppercase  | The password contains too few uppercase letters. At least 3 uppercase     |
-      | Not&Enough#Numbers=1           | The password contains too few numbers. At least 2 numbers are required.   |
-      | Not&Enough#Special8Characters2 | The password contains too few special characters. At least 3 special char |
-        # where multiple requirements are not met, only the first error message is shown to the user
-      | aA!1                           | The password is too short. At least 15 characters are required.           |
-      | aA!123456789012345             | The password contains too few lowercase letters. At least 4 lowercase     |
 
   Scenario Outline: admin creates a user with a password that has valid restricted special characters
     Given the administrator has enabled the restrict to these special characters password policy
@@ -86,26 +65,7 @@ Feature: enforce combinations of password policies when creating a user
       | 15%&*UPPloweZZZ           |
       | More^Than$15&Characters*0 |
 
-  @skipOnOcV10.2
-  # The command output for errors is coming on stdout from core 10.3 onwards
-  Scenario Outline: admin creates a user with a password that has invalid restricted special characters
-    Given the administrator has enabled the restrict to these special characters password policy
-    And the administrator has set the restricted special characters required to "$%^&*"
-    When the administrator creates this user using the occ command:
-      | username | password   |
-      | Alice    | <password> |
-    Then the command should have failed with exit code 1
-    And the command error output should contain the text '<message>'
-    And user "Alice" should not exist
-    Examples:
-      | password        | message                                                                   |
-      | 15#!!UPPloweZZZ | The password contains invalid special characters. Only $%^&* are allowed. |
-      | 15&%!UPPloweZZZ | The password contains invalid special characters. Only $%^&* are allowed. |
-        # where multiple requirements are not met, only the first error message is shown to the user
-      | 15&%!UPPlowZZZZ | The password contains too few lowercase letters. At least 4 lowercase     |
 
-  @skipOnOcV10.3
-  # The command output for errors comes on stderr in core 10.2
   Scenario Outline: admin creates a user with a password that has invalid restricted special characters
     Given the administrator has enabled the restrict to these special characters password policy
     And the administrator has set the restricted special characters required to "$%^&*"

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserSpecialCharacters.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserSpecialCharacters.feature
@@ -22,23 +22,7 @@ Feature: enforce the required number of special characters in a password when cr
       | 3#Special$Characters! |
       | 1!2@3#4$5%6^7&8*      |
 
-  @skipOnOcV10.2
-  # The command output for errors is coming on stdout from core 10.3 onwards
-  Scenario Outline: admin creates a user with a password that does not have enough special characters
-    When the administrator creates this user using the occ command:
-      | username | password   |
-      | Alice    | <password> |
-    Then the command should have failed with exit code 1
-    # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
-    And the command error output should contain the text 'The password contains too few special characters. At least 3 special char'
-    And user "Alice" should not exist
-    Examples:
-      | password                 |
-      | NoSpecialCharacters123   |
-      | Only2$Special!Characters |
 
-  @skipOnOcV10.3
-  # The command output for errors comes on stderr in core 10.2
   Scenario Outline: admin creates a user with a password that does not have enough special characters
     When the administrator creates this user using the occ command:
       | username | password   |

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserSpecialCharactersRestrictions.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserSpecialCharactersRestrictions.feature
@@ -24,8 +24,7 @@ Feature: enforce the restricted special characters in a password when creating a
       | 3$Special%Characters^ |
       | 1*2&3^4%5$6           |
 
-  @skipOnOcV10.2
-  # The command output for errors is coming on stdout from core 10.3 onwards
+
   Scenario Outline: admin creates a user with a password that does not have enough restricted special characters
     When the administrator creates this user using the occ command:
       | username | password   |
@@ -39,38 +38,7 @@ Feature: enforce the restricted special characters in a password when creating a
       | NoSpecialCharacters123   |
       | Only2$Special&Characters |
 
-  @skipOnOcV10.3
-  # The command output for errors comes on stderr in core 10.2
-  Scenario Outline: admin creates a user with a password that does not have enough restricted special characters
-    When the administrator creates this user using the occ command:
-      | username | password   |
-      | Alice    | <password> |
-    Then the command should have failed with exit code 1
-    # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
-    And the command error output should contain the text 'The password contains too few special characters. At least 3 special char'
-    And user "Alice" should not exist
-    Examples:
-      | password                 |
-      | NoSpecialCharacters123   |
-      | Only2$Special&Characters |
 
-  @skipOnOcV10.2
-  # The command output for errors is coming on stdout from core 10.3 onwards
-  Scenario Outline: admin creates a user with a password that has invalid special characters
-    When the administrator creates this user using the occ command:
-      | username | password   |
-      | Alice    | <password> |
-    Then the command should have failed with exit code 1
-    # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
-    And the command error output should contain the text 'The password contains invalid special characters. Only $%^&* are allowed.'
-    And user "Alice" should not exist
-    Examples:
-      | password                                 |
-      | Only#Invalid!Special@Characters          |
-      | 1*2&3^4%5$6andInvalidSpecialCharacters#! |
-
-  @skipOnOcV10.3
-  # The command output for errors comes on stderr in core 10.2
   Scenario Outline: admin creates a user with a password that has invalid special characters
     When the administrator creates this user using the occ command:
       | username | password   |

--- a/tests/acceptance/features/cliPasswordAddUser/occAddUserUppercaseLetters.feature
+++ b/tests/acceptance/features/cliPasswordAddUser/occAddUserUppercaseLetters.feature
@@ -22,23 +22,7 @@ Feature: enforce the required number of uppercase letters in a password when cre
       | 3UpperCaseLetters         |
       | MoreThan3UpperCaseLetters |
 
-  @skipOnOcV10.2
-  # The command output for errors is coming on stdout from core 10.3 onwards
-  Scenario Outline: admin creates a user with a password that does not have enough uppercase letters
-    When the administrator creates this user using the occ command:
-      | username | password   |
-      | Alice    | <password> |
-    Then the command should have failed with exit code 1
-    # Long text output comes on multiple lines. Here we just check for enough that will fit on one of the lines.
-    And the command error output should contain the text 'The password contains too few uppercase letters. At least 3 uppercase'
-    And user "Alice" should not exist
-    Examples:
-      | password       |
-      | 0uppercase     |
-      | Only2Uppercase |
 
-  @skipOnOcV10.3
-  # The command output for errors comes on stderr in core 10.2
   Scenario Outline: admin creates a user with a password that does not have enough uppercase letters
     When the administrator creates this user using the occ command:
       | username | password   |

--- a/tests/acceptance/features/webUIPublicShareLink/publicShareLinkExpirationPolicyEdgeCases.feature
+++ b/tests/acceptance/features/webUIPublicShareLink/publicShareLinkExpirationPolicyEdgeCases.feature
@@ -13,7 +13,7 @@ Feature: enforce public link expiration policies on public links only
     And user "Alice" has created folder "folder-to-share"
     And user "Alice" has logged in using the webUI
 
-  @issue-287 @skipOnOcV10.3 @skipOnOcV10.4.0
+
   Scenario: user tries to create a user share when "days maximum until link expires if password is not set" is enabled
     Given the administrator has enabled the days until link expires if password is not set public link password policy
     When the user shares folder "folder-to-share" with user "Brian" using the webUI
@@ -24,7 +24,7 @@ Feature: enforce public link expiration policies on public links only
     When the user shares folder "folder-to-share" with user "Brian" using the webUI
     And as "Brian" folder "folder-to-share" should exist
 
-  @issue-287 @skipOnOcV10.3 @skipOnOcV10.4.0
+
   Scenario: user tries to create a group share when "days maximum until link expires if password is not set" is enabled
     Given group "new-group" has been created
     And user "Brian" has been added to group "new-group"

--- a/tests/acceptance/features/webUIPublicShareLink/publicShareLinkLowercaseLetters.feature
+++ b/tests/acceptance/features/webUIPublicShareLink/publicShareLinkLowercaseLetters.feature
@@ -1,8 +1,8 @@
 @webUI @insulated @disablePreviews
-Feature: enforce the required number of lowercase letters in a password on the public share link page
+Feature: enforce the required number of lowercase letters in a password on the public link share page
 
   As an administrator
-  I want public share link passwords to always contain a required number of lowercase letters
+  I want public link share passwords to always contain a required number of lowercase letters
   So that users cannot set passwords that are too easy to guess
 
   Background:
@@ -14,7 +14,7 @@ Feature: enforce the required number of lowercase letters in a password on the p
     And the user has browsed to the login page
     And the user has logged in with username "Alice" and password "abcABC1234" using the webUI
 
-  Scenario Outline: user creates a public share link with enough lowercase letters
+  Scenario Outline: user creates a public link share with enough lowercase letters
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | password | <password> |
     And the public accesses the last created public link with password "<password>" using the webUI
@@ -24,7 +24,7 @@ Feature: enforce the required number of lowercase letters in a password on the p
       | 3LCase                    |
       | moreThan3LowercaseLetters |
 
-  Scenario Outline: user tries to create a public share link with too few lowercase letters
+  Scenario Outline: user tries to create a public link share with too few lowercase letters
     When the user tries to create a new public link for folder "simple-folder" using the webUI with
       | password | <password> |
     Then the user should see an error message on the public link share dialog saying "The password contains too few lowercase letters. At least 3 lowercase letters are required."

--- a/tests/acceptance/features/webUIPublicShareLink/publicShareLinkMinimumLength.feature
+++ b/tests/acceptance/features/webUIPublicShareLink/publicShareLinkMinimumLength.feature
@@ -1,8 +1,8 @@
 @webUI @insulated @disablePreviews
-Feature: enforce the minimum length of a password on the public share link page
+Feature: enforce the minimum length of a password on the public link share page
 
   As an administrator
-  I want public share link passwords to always be a certain minimum length
+  I want public link share passwords to always be a certain minimum length
   So that users cannot set passwords that are too short (easy to crack)
 
   Background:
@@ -14,7 +14,7 @@ Feature: enforce the minimum length of a password on the public share link page
     And the user has browsed to the login page
     And the user has logged in with username "Alice" and password "1234567890" using the webUI
 
-  Scenario Outline: user creates a public share link with enough letters
+  Scenario Outline: user creates a public link share with enough letters
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | password | <password> |
     And the public accesses the last created public link with password "<password>" using the webUI
@@ -24,7 +24,7 @@ Feature: enforce the minimum length of a password on the public share link page
       | 10tenchars                |
       | moreThan3LowercaseLetters |
 
-  Scenario Outline: user tries to create a public share link with too few letters
+  Scenario Outline: user tries to create a public link share with too few letters
     When the user tries to create a new public link for folder "simple-folder" using the webUI with
       | password | <password> |
     Then the user should see an error message on the public link share dialog saying "The password is too short. At least 10 characters are required."

--- a/tests/acceptance/features/webUIPublicShareLink/publicShareLinkNumbers.feature
+++ b/tests/acceptance/features/webUIPublicShareLink/publicShareLinkNumbers.feature
@@ -1,8 +1,8 @@
 @webUI @insulated @disablePreviews
-Feature: enforce the required number of numbers in a password on the public share link page
+Feature: enforce the required number of numbers in a password on the public link share page
 
   As an administrator
-  I want public share link passwords to always contain a required number of numbers
+  I want public link share passwords to always contain a required number of numbers
   So that users cannot set passwords that are too easy to guess
 
   Background:
@@ -14,7 +14,7 @@ Feature: enforce the required number of numbers in a password on the public shar
     And the user has browsed to the login page
     And the user has logged in with username "Alice" and password "abcABC1234" using the webUI
 
-  Scenario Outline: user creates a public share link with enough numbers
+  Scenario Outline: user creates a public link share with enough numbers
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | password | <password> |
     And the public accesses the last created public link with password "<password>" using the webUI
@@ -24,7 +24,7 @@ Feature: enforce the required number of numbers in a password on the public shar
       | 333Numbers      |
       | moreNumbers1234 |
 
-  Scenario Outline: user tries to create a public share link that has too few numbers
+  Scenario Outline: user tries to create a public link share that has too few numbers
     When the user tries to create a new public link for folder "simple-folder" using the webUI with
       | password | <password> |
     Then the user should see an error message on the public link share dialog saying "The password contains too few numbers. At least 3 numbers are required."

--- a/tests/acceptance/features/webUIPublicShareLink/publicShareLinkRequirementCombinations.feature
+++ b/tests/acceptance/features/webUIPublicShareLink/publicShareLinkRequirementCombinations.feature
@@ -1,8 +1,8 @@
 @webUI @insulated @disablePreviews
-Feature: enforce combinations of password policies on the public share link page
+Feature: enforce combinations of password policies on the public link share page
 
   As an administrator
-  I want public share link passwords to always have some combination of minimum length, lowercase, uppercase, numbers and special characters
+  I want public link share passwords to always have some combination of minimum length, lowercase, uppercase, numbers and special characters
   So that users cannot set passwords that are too easy to guess
 
   Background:
@@ -22,7 +22,7 @@ Feature: enforce combinations of password policies on the public share link page
     And the user has browsed to the login page
     And the user has logged in with username "Alice" and password "aA1!bB2#cC&deee" using the webUI
 
-  Scenario Outline: user creates a public share link with valid password
+  Scenario Outline: user creates a public link share with valid password
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | password | <password> |
     And the public accesses the last created public link with password "<password>" using the webUI
@@ -32,7 +32,7 @@ Feature: enforce combinations of password policies on the public share link page
       | 15***UPPloweZZZ           |
       | More%Than$15!Characters-0 |
 
-  Scenario Outline: user tries to create a public share link with invalid password
+  Scenario Outline: user tries to create a public link share with invalid password
     When the user tries to create a new public link for folder "simple-folder" using the webUI with
       | password | <password> |
     Then the user should see an error message on the public link share dialog saying "<message>"
@@ -49,7 +49,7 @@ Feature: enforce combinations of password policies on the public share link page
       | aA!1                           | The password is too short. At least 15 characters are required.                               |
       | aA!123456789012345             | The password contains too few lowercase letters. At least 4 lowercase letters are required.   |
 
-  Scenario Outline: user creates a public share link using valid restricted special characters
+  Scenario Outline: user creates a public link share using valid restricted special characters
     Given the administrator has enabled the restrict to these special characters password policy
     And the administrator has set the restricted special characters required to "$%^&*"
     When the user creates a new public link for folder "simple-folder" using the webUI with
@@ -61,7 +61,7 @@ Feature: enforce combinations of password policies on the public share link page
       | 15%&*UPPloweZZZ           |
       | More^Than$15&Characters*0 |
 
-  Scenario Outline: user tries to create a public share link using invalid restricted special characters
+  Scenario Outline: user tries to create a public link share using invalid restricted special characters
     Given the administrator has enabled the restrict to these special characters password policy
     And the administrator has set the restricted special characters required to "$%^&*"
     When the user tries to create a new public link for folder "simple-folder" using the webUI with

--- a/tests/acceptance/features/webUIPublicShareLink/publicShareLinkSpecialCharacters.feature
+++ b/tests/acceptance/features/webUIPublicShareLink/publicShareLinkSpecialCharacters.feature
@@ -1,8 +1,8 @@
 @webUI @insulated @disablePreviews
-Feature: enforce the required number of special characters on the public share link page
+Feature: enforce the required number of special characters on the public link share page
 
   As an administrator
-  I want public share link passwords to always contain a required number of special characters
+  I want public link share passwords to always contain a required number of special characters
   So that users cannot set passwords that are too easy to guess
 
   Background:
@@ -14,7 +14,7 @@ Feature: enforce the required number of special characters on the public share l
     And the user has browsed to the login page
     And the user has logged in with username "Alice" and password "a!b@c#1234" using the webUI
 
-  Scenario Outline: user creates a public share link with enough special characters
+  Scenario Outline: user creates a public link share with enough special characters
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | password | <password> |
     And the public accesses the last created public link with password "<password>" using the webUI
@@ -24,7 +24,7 @@ Feature: enforce the required number of special characters on the public share l
       | 3#Special$Characters! |
       | 1!2@3#4$5%6^7&8*      |
 
-  Scenario Outline: user tries to create a public share link with too few special characters
+  Scenario Outline: user tries to create a public link share with too few special characters
     When the user tries to create a new public link for folder "simple-folder" using the webUI with
       | password | <password> |
     Then the user should see an error message on the public link share dialog saying "The password contains too few special characters. At least 3 special characters are required."

--- a/tests/acceptance/features/webUIPublicShareLink/publicShareLinkSpecialCharactersRestrictions.feature
+++ b/tests/acceptance/features/webUIPublicShareLink/publicShareLinkSpecialCharactersRestrictions.feature
@@ -1,8 +1,8 @@
 @webUI @insulated @disablePreviews
-Feature: enforce the restricted special characters in a password on the public share link page
+Feature: enforce the restricted special characters in a password on the public link share page
 
   As an administrator
-  I want public share link passwords to always contain some of a restricted list of special characters
+  I want public link share passwords to always contain some of a restricted list of special characters
   So that users cannot set passwords that have unusual hard-to-type characters
 
   Background:
@@ -16,7 +16,7 @@ Feature: enforce the restricted special characters in a password on the public s
     And the user has browsed to the login page
     And the user has logged in with username "Alice" and password "a$b%c^1234" using the webUI
 
-  Scenario Outline: user creates a public share link with enough restricted special characters
+  Scenario Outline: user creates a public link share with enough restricted special characters
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | password | <password> |
     And the public accesses the last created public link with password "<password>" using the webUI
@@ -36,7 +36,7 @@ Feature: enforce the restricted special characters in a password on the public s
       | NoSpecialCharacters123   |
       | Only2$Special&Characters |
 
-  Scenario Outline: user tries to create a public share link with invalid special characters
+  Scenario Outline: user tries to create a public link share with invalid special characters
     When the user tries to create a new public link for folder "simple-folder" using the webUI with
       | password | <password> |
     Then the user should see an error message on the public link share dialog saying "The password contains invalid special characters. Only $%^&* are allowed."

--- a/tests/acceptance/features/webUIPublicShareLink/publicShareLinkUppercaseLetters.feature
+++ b/tests/acceptance/features/webUIPublicShareLink/publicShareLinkUppercaseLetters.feature
@@ -1,8 +1,8 @@
 @webUI @insulated @disablePreviews
-Feature: enforce the required number of uppercase letters in a password on the public share link page
+Feature: enforce the required number of uppercase letters in a password on the public link share page
 
   As an administrator
-  I want public share link passwords to always contain a required number of uppercase letters
+  I want public link share passwords to always contain a required number of uppercase letters
   So that users cannot set passwords that are too easy to guess
 
   Background:
@@ -14,7 +14,7 @@ Feature: enforce the required number of uppercase letters in a password on the p
     And the user has browsed to the login page
     And the user has logged in with username "Alice" and password "abc123" using the webUI
 
-  Scenario Outline: user creates a public share link with enough uppercase letters
+  Scenario Outline: user creates a public link share with enough uppercase letters
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | password | <password> |
     And the public accesses the last created public link with password "<password>" using the webUI
@@ -24,7 +24,7 @@ Feature: enforce the required number of uppercase letters in a password on the p
       | 3UpperCaseLetters         |
       | MoreThan3UpperCaseLetters |
 
-  Scenario Outline: user tries to create a public share link with too few uppercase letters
+  Scenario Outline: user tries to create a public link share with too few uppercase letters
     When the user tries to create a new public link for folder "simple-folder" using the webUI with
       | password | <password> |
     Then the user should see an error message on the public link share dialog saying "The password contains too few uppercase letters. At least 3 uppercase letters are required."


### PR DESCRIPTION
Fixes Issue #375 

Adjusted the step text for public links to match recent core changes

Removed steps that supposedly tried to access a non-existent public link.
Those steps did not do what they looked like doing anyway. They had been accessing a previous ordinary share in the scenario. The scenarios were checking cases where the share receiver tries to create a public link and provides a password that does not meet the password policy. In those cases there is no public link to attempt to access.

Removed old test scenarios that were for core 10.2. Those have not been needed for a long time.

Removed old 'skip' tags that are no longer useful.