### PR TITLE
[tests-only] Save exitcode of last occ command

### DIFF
--- a/tests/acceptance/features/bootstrap/PasswordPolicyContext.php
+++ b/tests/acceptance/features/bootstrap/PasswordPolicyContext.php
@@ -964,8 +964,10 @@ class PasswordPolicyContext implements Context {
 	 */
 	public function expireUserPassword(string $username): void {
 		$username = $this->featureContext->getActualUsername($username);
-		$this->featureContext->runOcc(
-			["user:expire-password -u $username"]
+		$this->featureContext->setOccLastCode(
+			$this->featureContext->runOcc(
+				["user:expire-password -u $username"]
+			)
 		);
 	}
 	/**


### PR DESCRIPTION
## Description
The PR https://github.com/owncloud/core/pull/40359 has implemented different method to save the exitcode of the last occ command and the local tests were failing because the exitcode was not saved.
In this PR, I have implemented the updated way to save the occ exitCode.


## Related Issue
Fixes https://github.com/owncloud/password_policy/issues/379
