### PR TITLE
[tests-only] [full-ci] Change mailhog tag to email

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,6 +1,6 @@
 BANST_AWS_CLI = "banst/awscli"
 DRONE_CLI = "drone/cli:alpine"
-MAILHOG_MAILHOG = "mailhog/mailhog"
+INBUCKET_INBUCKET = "inbucket/inbucket"
 MINIO_MC = "minio/mc:RELEASE.2020-12-18T10-53-53Z"
 OC_CI_ALPINE = "owncloudci/alpine:latest"
 OC_CI_BAZEL_BUILDIFIER = "owncloudci/bazel-buildifier"
@@ -1171,7 +1171,7 @@ def acceptance(ctx):
                         makeParameter = "test-acceptance-cli"
 
                 if testConfig["emailNeeded"]:
-                    environment["MAILHOG_HOST"] = "email"
+                    environment["EMAIL_HOST"] = "email"
 
                 if testConfig["ldapNeeded"]:
                     environment["TEST_WITH_LDAP"] = True
@@ -1490,7 +1490,7 @@ def emailService(emailNeeded):
     if emailNeeded:
         return [{
             "name": "email",
-            "image": MAILHOG_MAILHOG,
+            "image": INBUCKET_INBUCKET,
         }]
 
     return []
@@ -1501,7 +1501,7 @@ def waitForEmailService(emailNeeded):
             "name": "wait-for-email",
             "image": OC_CI_WAIT_FOR,
             "commands": [
-                "wait-for -it email:8025 -t 600",
+                "wait-for -it email:9000 -t 600",
             ],
         }]
 

--- a/tests/acceptance/features/apiGuests/guests.feature
+++ b/tests/acceptance/features/apiGuests/guests.feature
@@ -6,7 +6,7 @@ Feature: Guests
     And the administrator has enabled the lowercase letters password policy
     And the administrator has set the lowercase letters required to "3"
 
-  @mailhog
+  @email
   Scenario Outline: A guest user sets own password to a string that has enough lowercase letters
     Given using OCS API version "<ocs-api-version>"
     And the administrator has created guest user "guest" with email "guest@example.com"
@@ -23,7 +23,7 @@ Feature: Guests
       | moreThan3LowercaseLetters | 1               |
       | moreThan3LowercaseLetters | 2               |
 
-  @mailhog
+  @email
   Scenario Outline: A guest user sets own password to a string that does not have enough lowercase letters
     Given using OCS API version "<ocs-api-version>"
     And the administrator has created guest user "guest" with email "guest@example.com"
@@ -39,7 +39,7 @@ Feature: Guests
       | 2lOWERcASE | 1               |
       | 2lOWERcASE | 2               |
 
-  @mailhog
+  @email
   Scenario Outline: A guest user changes own password to a string that has enough lowercase letters
     Given using OCS API version "<ocs-api-version>"
     And the administrator has created guest user "guest" with email "guest@example.com"
@@ -56,7 +56,7 @@ Feature: Guests
       | moreThan3LowercaseLetters | 1               |
       | moreThan3LowercaseLetters | 2               |
 
-  @mailhog
+  @email
   Scenario Outline: A guest user changes own password to a string that does not have enough lowercase letters
     Given using OCS API version "<ocs-api-version>"
     And the administrator has created guest user "guest" with email "guest@example.com"
@@ -79,7 +79,7 @@ Feature: Guests
       | 2lOWERcASE | 1               | 403        | 200         | OK                 |
       | 2lOWERcASE | 2               | 403        | 403         | Forbidden          |
 
-  @mailhog
+  @email
   Scenario Outline: A guest user creates a public link share with a password that has enough lowercase letters
     Given using OCS API version "<ocs-api-version>"
     And the administrator has created guest user "guest" with email "guest@example.com"
@@ -102,7 +102,7 @@ Feature: Guests
       | moreThan3LowercaseLetters | 1               | 100        |
       | moreThan3LowercaseLetters | 2               | 200        |
 
-  @mailhog
+  @email
   Scenario Outline: A guest user creates a public link share with a password that does not have enough lowercase letters
     Given using OCS API version "<ocs-api-version>"
     And the administrator has created guest user "guest" with email "guest@example.com"

--- a/tests/acceptance/features/webUIGuests/guest.feature
+++ b/tests/acceptance/features/webUIGuests/guest.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @mailhog
+@webUI @insulated @disablePreviews @email
 Feature:
 
   Background:

--- a/tests/acceptance/features/webUIGuests/guestPasswordExpire.feature
+++ b/tests/acceptance/features/webUIGuests/guestPasswordExpire.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @mailhog
+@webUI @insulated @disablePreviews @email
 Feature: expire guest user's password using the occ command
 
   As an administrator

--- a/tests/acceptance/features/webUIGuests/guestSetsPasswordLowercaseLetters.feature
+++ b/tests/acceptance/features/webUIGuests/guestSetsPasswordLowercaseLetters.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @mailhog
+@webUI @insulated @disablePreviews @email
 Feature: enforce the required number of lowercase letters in a password when a guest user sets its own password
 
   Background:

--- a/tests/acceptance/features/webUIGuests/guestSetsPasswordMinimumLength.feature
+++ b/tests/acceptance/features/webUIGuests/guestSetsPasswordMinimumLength.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @mailhog
+@webUI @insulated @disablePreviews @email
 Feature: enforce the minimum length of a password when a guest user sets its own password
 
   Background:

--- a/tests/acceptance/features/webUIGuests/guestSetsPasswordNumbers.feature
+++ b/tests/acceptance/features/webUIGuests/guestSetsPasswordNumbers.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @mailhog
+@webUI @insulated @disablePreviews @email
 Feature: enforce the required number of numbers in a password when a guest user sets its own password
 
   Background:

--- a/tests/acceptance/features/webUIGuests/guestSetsPasswordRequirementCombinations.feature
+++ b/tests/acceptance/features/webUIGuests/guestSetsPasswordRequirementCombinations.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @mailhog
+@webUI @insulated @disablePreviews @email
 Feature: enforce combinations of password policies when a guest user sets its own password
 
   Background:

--- a/tests/acceptance/features/webUIGuests/guestSetsPasswordSpecialCharacters.feature
+++ b/tests/acceptance/features/webUIGuests/guestSetsPasswordSpecialCharacters.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @mailhog
+@webUI @insulated @disablePreviews @email
 Feature: enforce the required number of special characters in a password when a guest user sets its own password
 
   Background:

--- a/tests/acceptance/features/webUIGuests/guestSetsPasswordSpecialCharactersRestrictions.feature
+++ b/tests/acceptance/features/webUIGuests/guestSetsPasswordSpecialCharactersRestrictions.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @mailhog
+@webUI @insulated @disablePreviews @email
 Feature: enforce the restricted special characters in a password when a guest user sets its own password
 
   Background:

--- a/tests/acceptance/features/webUIGuests/guestSetsPasswordUppercaseLetters.feature
+++ b/tests/acceptance/features/webUIGuests/guestSetsPasswordUppercaseLetters.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @mailhog
+@webUI @insulated @disablePreviews @email
 Feature: enforce the required number of uppercase letters in a password when a guest user sets its own password
 
   Background:

--- a/tests/acceptance/features/webUIPasswordAddUser/addUserLowercaseLetters.feature
+++ b/tests/acceptance/features/webUIPasswordAddUser/addUserLowercaseLetters.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @mailhog
+@webUI @insulated @disablePreviews @email
 Feature: enforce the required number of lowercase letters in a password on user creation
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordAddUser/addUserMinimumLength.feature
+++ b/tests/acceptance/features/webUIPasswordAddUser/addUserMinimumLength.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @mailhog
+@webUI @insulated @disablePreviews @email
 Feature: enforce the minimum length of a password on user creation
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordAddUser/addUserNumbers.feature
+++ b/tests/acceptance/features/webUIPasswordAddUser/addUserNumbers.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @mailhog
+@webUI @insulated @disablePreviews @email
 Feature: enforce the required number of numbers in a password on user creation
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordAddUser/addUserUppercaseLetters.feature
+++ b/tests/acceptance/features/webUIPasswordAddUser/addUserUppercaseLetters.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @mailhog
+@webUI @insulated @disablePreviews @email
 Feature: enforce the required number of uppercase letters in a password on user creation
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordAddUserSpecial/addUserRequirementCombinations.feature
+++ b/tests/acceptance/features/webUIPasswordAddUserSpecial/addUserRequirementCombinations.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @mailhog
+@webUI @insulated @disablePreviews @email
 Feature: enforce combinations of password policies on user creation
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordAddUserSpecial/addUserSpecialCharacters.feature
+++ b/tests/acceptance/features/webUIPasswordAddUserSpecial/addUserSpecialCharacters.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @mailhog
+@webUI @insulated @disablePreviews @email
 Feature: enforce the required number of special characters in a password on user creation
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordAddUserSpecial/addUserSpecialCharactersRestrictions.feature
+++ b/tests/acceptance/features/webUIPasswordAddUserSpecial/addUserSpecialCharactersRestrictions.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @mailhog
+@webUI @insulated @disablePreviews @email
 Feature: enforce the restricted special characters in a password on user creation
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordReset/passwordResetLastPasswords.feature
+++ b/tests/acceptance/features/webUIPasswordReset/passwordResetLastPasswords.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @mailhog
+@webUI @insulated @disablePreviews @email
 Feature: enforce the number of last passwords that must not be used when resetting the password on the password reset UI page
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordReset/passwordResetLowercaseLetters.feature
+++ b/tests/acceptance/features/webUIPasswordReset/passwordResetLowercaseLetters.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @mailhog
+@webUI @insulated @disablePreviews @email
 Feature: enforce the required number of lowercase letters in a password on the password reset UI page
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordReset/passwordResetMinimumLength.feature
+++ b/tests/acceptance/features/webUIPasswordReset/passwordResetMinimumLength.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @mailhog
+@webUI @insulated @disablePreviews @email
 Feature: enforce the minimum length of a password on the password reset UI page
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordReset/passwordResetNumbers.feature
+++ b/tests/acceptance/features/webUIPasswordReset/passwordResetNumbers.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @mailhog
+@webUI @insulated @disablePreviews @email
 Feature: enforce the required number of numbers in a password on the password reset UI page
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordReset/passwordResetRequirementCombinations.feature
+++ b/tests/acceptance/features/webUIPasswordReset/passwordResetRequirementCombinations.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @mailhog
+@webUI @insulated @disablePreviews @email
 Feature: enforce combinations of password policies on the password reset UI page
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordReset/passwordResetSpecialCharacters.feature
+++ b/tests/acceptance/features/webUIPasswordReset/passwordResetSpecialCharacters.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @mailhog
+@webUI @insulated @disablePreviews @email
 Feature: enforce the required number of special characters in a password on the password reset UI page
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordReset/passwordResetSpecialCharactersRestriction.feature
+++ b/tests/acceptance/features/webUIPasswordReset/passwordResetSpecialCharactersRestriction.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @mailhog
+@webUI @insulated @disablePreviews @email
 Feature: enforce the restricted special characters in a password on the password reset UI page
 
   As an administrator

--- a/tests/acceptance/features/webUIPasswordReset/passwordResetUppercaseLetters.feature
+++ b/tests/acceptance/features/webUIPasswordReset/passwordResetUppercaseLetters.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @mailhog
+@webUI @insulated @disablePreviews @email
 Feature: enforce the required number of uppercase letters in a password on the password reset UI page
 
   As an administrator


### PR DESCRIPTION
https://github.com/owncloud/core/pull/40442 changed the email server used in tests from mailhog to inbucket. It also changed the tag used in feature files from `@mailhog` to `@email`

So make the same change here.

Issue https://github.com/owncloud/QA/issues/771
