### PR TITLE
[tests-only] [full-ci] Run phan with php 7.3

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -47,7 +47,14 @@ config = {
     ],
     "codestyle": True,
     "phpstan": True,
-    "phan": True,
+    "phan": {
+        "multipleVersions": {
+            "phpVersions": [
+                DEFAULT_PHP_VERSION,
+                "7.3",
+            ],
+        },
+    },
     "phpunit": {
         "allDatabases": {
             "phpVersions": [

--- a/.drone.star
+++ b/.drone.star
@@ -445,6 +445,7 @@ def phan(ctx):
 
     default = {
         "phpVersions": [DEFAULT_PHP_VERSION],
+        "extraApps": {},
     }
 
     if "defaults" in config:
@@ -483,6 +484,7 @@ def phan(ctx):
                 },
                 "steps": skipIfUnchanged(ctx, "lint") +
                          installCore(ctx, "daily-master-qa", "sqlite", False) +
+                         installExtraApps(phpVersion, params["extraApps"], False) +
                          [
                              {
                                  "name": "phan",
@@ -1214,6 +1216,7 @@ def acceptance(ctx):
                              testConfig["extraSetup"] +
                              waitForServer(testConfig["federatedServerNeeded"]) +
                              waitForEmailService(testConfig["emailNeeded"]) +
+                             waitForSamba(testConfig["extraServices"]) +
                              fixPermissions(phpVersionForDocker, testConfig["federatedServerNeeded"], params["selUserNeeded"]) +
                              waitForBrowserService(testConfig["browser"]) +
                              [
@@ -1514,6 +1517,26 @@ def waitForEmailService(emailNeeded):
 
     return []
 
+def waitForSamba(extraServices):
+    foundSamba = False
+
+    for extraService in extraServices:
+        # each service entry should be a key-value dictionary that has at least a "name" key
+        # if there is a "samba" service specified, then we need to wait for it to start.
+        if (extraService["name"] == "samba"):
+            foundSamba = True
+
+    if (foundSamba):
+        return [{
+            "name": "wait-for-samba",
+            "image": OC_CI_WAIT_FOR,
+            "commands": [
+                "wait-for -it samba:139,samba:445 -t 300",
+            ],
+        }]
+
+    return []
+
 def ldapService(ldapNeeded):
     if ldapNeeded:
         return [{
@@ -1740,18 +1763,19 @@ def installTestrunner(ctx, phpVersion, useBundledApp):
         ] if not useBundledApp else []),
     }]
 
-def installExtraApps(phpVersion, extraApps):
+def installExtraApps(phpVersion, extraApps, enableExtraApps = True):
     commandArray = []
     for app, command in extraApps.items():
-        commandArray.append("git clone https://github.com/owncloud/%s.git %s/apps/%s" % (app, dir["testrunner"], app))
-        commandArray.append("cp -r %s/apps/%s %s/apps/" % (dir["testrunner"], app, dir["server"]))
+        commandArray.append("ls %s/apps/%s || git clone https://github.com/owncloud/%s.git %s/apps/%s" % (dir["testrunner"], app, app, dir["testrunner"], app))
+        commandArray.append("ls %s/apps/%s || cp -r %s/apps/%s %s/apps/" % (dir["server"], app, dir["testrunner"], app, dir["server"]))
         if (command != ""):
             commandArray.append("cd %s/apps/%s" % (dir["server"], app))
             commandArray.append(command)
         commandArray.append("cd %s" % dir["server"])
-        commandArray.append("php occ a:l")
-        commandArray.append("php occ a:e %s" % app)
-        commandArray.append("php occ a:l")
+        if (enableExtraApps):
+            commandArray.append("php occ a:l")
+            commandArray.append("php occ a:e %s" % app)
+            commandArray.append("php occ a:l")
 
     if (commandArray == []):
         return []

--- a/vendor-bin/phan/composer.json
+++ b/vendor-bin/phan/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phan/phan": "^5.2"
+        "phan/phan": "^5.4"
     }
 }


### PR DESCRIPTION
`phan` will report errors if any of the code is not compatible with PHP 7.3.

This app still supports PHP 7.3 when used with oC10 core 10.11 and earlier.
