### PR TITLE
Always return an int from Symfony Command execute method

### DIFF
--- a/lib/Command/ExpirePassword.php
+++ b/lib/Command/ExpirePassword.php
@@ -127,7 +127,7 @@ class ExpirePassword extends Command {
 	 * @return int
 	 * @throws \OCP\PreConditionNotMetException
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$groups = $input->getOption('group');
 		$allUsers = $input->getOption('all');
 		$uids = $input->getOption('uid');


### PR DESCRIPTION
Symfony 5 will require this, so be prepared.
For Symfony 4 it is optional.

Preparation for https://github.com/owncloud/core/issues/39630