### PR TITLE
[tests-only] [full-ci] Test with 'days before password expires' set to larger values

### DIFF
--- a/tests/acceptance/features/webUIPasswordPolicySettings/setPolicySettings.feature
+++ b/tests/acceptance/features/webUIPasswordPolicySettings/setPolicySettings.feature
@@ -98,24 +98,24 @@ Feature: set password policy settings
 
   Scenario: set "days until user password expires"
     When the administrator enables the days until user password expires user password policy using the webUI
-    And the administrator sets the number of days until user password expires to "42" using the webUI
+    And the administrator sets the number of days until user password expires to "365" using the webUI
     And the administrator saves the password policy settings using the webUI
     And the administrator reloads the admin security settings page
     Then the days until user password expires user password policy checkbox should be checked on the webUI
-    And the number of days until user password expires should be set to "42" on the webUI
-    And the number of days until user password expires should be set to "42"
+    And the number of days until user password expires should be set to "365" on the webUI
+    And the number of days until user password expires should be set to "365"
     And the days until user password expires user password policy should be enabled
 
 
   Scenario: set "notification days before password expires"
     When the administrator enables the notification days before password expires user password policy using the webUI
-    And the administrator sets the notification days before password expires to "14" using the webUI
+    And the administrator sets the notification days before password expires to "300" using the webUI
     And the administrator saves the password policy settings using the webUI
     And the administrator reloads the admin security settings page
     Then the notification days before password expires user password policy checkbox should be checked on the webUI
-    And the notification days before password expires should be set to "14" on the webUI
-    # This settting is stored in seconds. 14 days = 14*24*60*60 = 1209600 seconds
-    And the notification seconds before password expires should be set to "1209600"
+    And the notification days before password expires should be set to "300" on the webUI
+    # This setting is stored in seconds. 300 days = 300*24*60*60 = 25920000 seconds
+    And the notification seconds before password expires should be set to "25920000"
     And the notification days before password expires user password policy should be enabled
 
 


### PR DESCRIPTION
Demonstrates issue https://github.com/owncloud/enterprise/issues/5985
```
Running webUIPasswordPolicySettings tests tagged ~@skipWhenTestingRemoteSystems&&~@skipOnFedOcV10&&~@skipOnFedOcV10.13&&~@skipOnFedOcV10.13.0&&~@skipOnOcV10&&~@skipOnOcV10.13&&~@skipOnOcV10.13.0&&@webUI&&~@skip on browser 'chrome' 
@webUI @insulated @disablePreviews
Feature: set password policy settings
  
  As an administrator
  I want to be able to set password requirements (minimum length, lowercase/uppercase/numeric/special characters)
  So that user and public link passwords have a minimum level of complexity

  Background:                                                               # /home/phil/git/owncloud/core/apps-external/password_policy/tests/acceptance/features/webUIPasswordPolicySettings/setPolicySettings.feature:8
    Given the administrator has browsed to the admin security settings page # WebUIPasswordPolicyContext::theAdminBrowsesToTheAdminSecuritySettingsPage()

  Scenario: set "days until user password expires"                                                           # /home/phil/git/owncloud/core/apps-external/password_policy/tests/acceptance/features/webUIPasswordPolicySettings/setPolicySettings.feature:99
    When the administrator enables the days until user password expires user password policy using the webUI # WebUIPasswordPolicyContext::theAdminTogglesDaysUntilUserPasswordExpiresPasswordPolicyUsingTheWebui()
    And the administrator sets the number of days until user password expires to "365" using the webUI       # WebUIPasswordPolicyContext::theAdminSetsDaysUntilUserPasswordExpiresUsingTheWebui()
    And the administrator saves the password policy settings using the webUI                                 # WebUIPasswordPolicyContext::theAdminSavesThePasswordPolicySettingsUsingTheWebui()
    And the administrator reloads the admin security settings page                                           # WebUIPasswordPolicyContext::theAdminReloadsTheAdminSecuritySettingsPage()
    Then the days until user password expires user password policy checkbox should be checked on the webUI   # WebUIPasswordPolicyContext::theDaysUntilUserPasswordExpiresCheckboxShouldBeOnTheWebui()
    And the number of days until user password expires should be set to "365" on the webUI                   # WebUIPasswordPolicyContext::theDaysUntilUserPasswordExpiresShouldBeSetToOnTheWebui()
      Failed asserting that two strings are equal.
      --- Expected
      +++ Actual
      @@ @@
      -'365'
      +'255'
```

```
Running webUIPasswordPolicySettings tests tagged ~@skipWhenTestingRemoteSystems&&~@skipOnFedOcV10&&~@skipOnFedOcV10.13&&~@skipOnFedOcV10.13.0&&~@skipOnOcV10&&~@skipOnOcV10.13&&~@skipOnOcV10.13.0&&@webUI&&~@skip on browser 'chrome' 
@webUI @insulated @disablePreviews
Feature: set password policy settings
  
  As an administrator
  I want to be able to set password requirements (minimum length, lowercase/uppercase/numeric/special characters)
  So that user and public link passwords have a minimum level of complexity

  Background:                                                               # /home/phil/git/owncloud/core/apps-external/password_policy/tests/acceptance/features/webUIPasswordPolicySettings/setPolicySettings.feature:8
    Given the administrator has browsed to the admin security settings page # WebUIPasswordPolicyContext::theAdminBrowsesToTheAdminSecuritySettingsPage()

  Scenario: set "notification days before password expires"                                                           # /home/phil/git/owncloud/core/apps-external/password_policy/tests/acceptance/features/webUIPasswordPolicySettings/setPolicySettings.feature:110
    When the administrator enables the notification days before password expires user password policy using the webUI # WebUIPasswordPolicyContext::theAdminTogglesNotificationDaysBeforeUserPasswordExpiresPasswordPolicyUsingTheWebui()
    And the administrator sets the notification days before password expires to "300" using the webUI                 # WebUIPasswordPolicyContext::theAdminSetsNotificationDaysBeforeUserPasswordExpiresUsingTheWebui()
    And the administrator saves the password policy settings using the webUI                                          # WebUIPasswordPolicyContext::theAdminSavesThePasswordPolicySettingsUsingTheWebui()
    And the administrator reloads the admin security settings page                                                    # WebUIPasswordPolicyContext::theAdminReloadsTheAdminSecuritySettingsPage()
    Then the notification days before password expires user password policy checkbox should be checked on the webUI   # WebUIPasswordPolicyContext::theNotificationDaysBeforeUserPasswordExpiresCheckboxShouldBeOnTheWebui()
    And the notification days before password expires should be set to "300" on the webUI                             # WebUIPasswordPolicyContext::theNotificationDaysBeforeUserPasswordExpiresShouldBeSetToOnTheWebui()
      Failed asserting that two strings are equal.
      --- Expected
      +++ Actual
      @@ @@
      -'300'
      +'255'
```

The values of these settings have been limited to 255, unfortunately.