### PR TITLE
fix: drop usage of ${}

### DIFF
--- a/lib/Jobs/PasswordExpirationNotifierJob.php
+++ b/lib/Jobs/PasswordExpirationNotifierJob.php
@@ -116,10 +116,10 @@ class PasswordExpirationNotifierJob extends TimedJob {
 			}
 
 			if ($elapsedTime >= $expirationTime) {
-				$this->logger->debug("password timestamp for {$passInfo->getUid()}: {$passInfo->getChangeTime()}; elapsed time: {$elapsedTime} -> EXPIRED${adminPart}", ['app' => 'password_policy']);
+				$this->logger->debug("password timestamp for {$passInfo->getUid()}: {$passInfo->getChangeTime()}; elapsed time: {$elapsedTime} -> EXPIRED{$adminPart}", ['app' => 'password_policy']);
 				$this->sendPassExpiredNotification($passInfo, $expirationTime);
 			} elseif ($elapsedTime >= $notifyAfter) {
-				$this->logger->debug("password timestamp for {$passInfo->getUid()}: {$passInfo->getChangeTime()}; elapsed time: {$elapsedTime} -> NOTIFY${adminPart}", ['app' => 'password_policy']);
+				$this->logger->debug("password timestamp for {$passInfo->getUid()}: {$passInfo->getChangeTime()}; elapsed time: {$elapsedTime} -> NOTIFY{$adminPart}", ['app' => 'password_policy']);
 				$this->sendAboutToExpireNotification($passInfo, $expirationTime);
 			}
 		}


### PR DESCRIPTION
## Description
In preparation of php8.2 support - see https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated

Similar to core https://github.com/owncloud/core/pull/40995
