### PR TITLE
docs(ospo): community health rollout v2 — README, agents.md, health files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+# Code of Conduct
+
+This project follows the ownCloud Code of Conduct.
+
+Please read the full Code of Conduct at:
+**<https://owncloud.com/contribute/code-of-conduct/>**
+
+By participating in this project, you agree to abide by its terms.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+Thank you for your interest in contributing to this project!
+
+Please read the full contributing guidelines at:
+**<https://owncloud.com/contribute/>**
+
+For development setup, coding standards, and pull request process,
+see the README in this repository.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,128 @@
 # Password Policy
 
-[![Build Status](https://drone.owncloud.com/api/badges/owncloud/password_policy/status.svg?branch=master)](https://drone.owncloud.com/owncloud/password_policy)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=owncloud_password_policy&metric=alert_status)](https://sonarcloud.io/dashboard?id=owncloud_password_policy)
-[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=owncloud_password_policy&metric=security_rating)](https://sonarcloud.io/dashboard?id=owncloud_password_policy)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=owncloud_password_policy&metric=coverage)](https://sonarcloud.io/dashboard?id=owncloud_password_policy)
+<!-- OSPO-managed README | Generated: 2026-04-16 | v2 -->
 
-The Password Policy extension enables ownCloud administrators to define password requirements like minimum characters, numbers, capital letters and more for all kinds of password endpoints like user account and public link sharing passwords. To add another layer of security, the administrator can enforce maximum expiration dates for public link shares depending on whether a password has been set or not. As a further measure the extension saves a history of hashed user passwords to prevent users from choosing a former password again, enforcing password security even more. Users can also be required to change their password upon first login. To impose regular password changes administrators can set up password expiration policies. For this users can be notified via email, web interface and the ownCloud Clients when their password is about to expire and when it has expired.
+[![License](https://img.shields.io/badge/License-GPL--2.0-blue.svg)](LICENSE) [![ownCloud OSPO](https://img.shields.io/badge/OSPO-ownCloud-blue)](https://kiteworks.com/opensource) [![Docker Hub](https://img.shields.io/docker/pulls/owncloud)](https://hub.docker.com/r/owncloud/server)
 
-The definition of certain password rules support administrators in the task of ensuring a minimum level of password security throughout the enterprise. It minimizes the risk of weak user passwords and therefore adds an additional security aspect to ownCloud. The expiration date policies for public link shares allow users to depart from general public link expiration policies. Users can, for instance, be allowed to create longer-lasting public link shares when they choose to set a password. This way IT can provide more flexibility in external sharing while staying in full control.
-Password history and expiration policies are supplements that allow IT to establish a level of password security that can comply with corporate guidelines of all sorts. The provided tools enable administrators to granularly choose their desired security level. At this point it is important to keep in mind that high levels of security might sacrifice usability and come at the expense of user experience. For this reason it is highly recommended to check [best practices](https://pages.nist.gov/800-63-3/sp800-63b.html) and decide carefully on the hurdles that are put upon users in order to maintain and optimize user adoption and satisfaction.
+An ownCloud Server app that enables administrators to define and enforce comprehensive password policies for user accounts and public link shares. It supports configurable rules for minimum length, character requirements (uppercase, numbers, special characters), password history tracking, password expiration with notifications, and adjustable public link expiration based on password presence.
 
-Administrators find the configuration options in the 'Security' section of the ownCloud administration settings panel. The respective policies are designed for local user accounts created by administrators or via the [Guests](https://marketplace.owncloud.com/apps/guests) extension, not for user accounts imported from LDAP or other user backends as these provide their own mechanisms. For more information and recommendations when deploying policies in an existing ownCloud, please consult the [ownCloud Documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/security/password_policy.html).
+## Getting Started
+
+Follow the steps below to install and configure the Password Policy app.
+
+### Prerequisites
+
+- ownCloud Server 10.x
+- PHP 7.4+
+
+### Installation
+
+```bash
+occ app:enable password_policy
+```
+
+Configuration is done through the ownCloud admin panel under Settings > Security.
+
+### Build
+
+```bash
+make dist
+```
+
+### Run Tests
+
+```bash
+make test-php-unit
+make test-php-style
+```
+
+## Documentation
+
+- [Password Policy Documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/security/password_policy.html)
+- [NIST Password Best Practices](https://pages.nist.gov/800-63-3/sp800-63b.html)
+
+## Part of ownCloud Server (Classic)
+
+This app is a plugin for [ownCloud Server 10](https://github.com/owncloud/core). Password policies are configured in the Security section of the administration settings panel.
+
+This component is included in the [ownCloud Server Docker image](https://hub.docker.com/r/owncloud/server).
+
+Designed for local user accounts created by administrators or the [Guests](https://marketplace.owncloud.com/apps/guests) extension (not LDAP-backed accounts).
+
+## Community & Support
+
+**[Star](https://github.com/owncloud/password_policy)** this repo and **Watch** for release notifications!
+
+- [ownCloud Website](https://owncloud.com)
+- [Community Discussions](https://github.com/orgs/owncloud/discussions)
+- [Matrix Chat](https://app.element.io/#/room/#owncloud:matrix.org)
+- [Documentation](https://doc.owncloud.com)
+- [Enterprise Support](https://owncloud.com/contact-us/)
+- [OSPO Home](https://kiteworks.com/opensource)
+
+## Contributing
+
+We welcome contributions! Please read the [Contributing Guidelines](CONTRIBUTING.md)
+and our [Code of Conduct](CODE_OF_CONDUCT.md) before getting started.
+
+### Workflow
+
+- **Rebase Early, Rebase Often!** We use a rebase workflow. Always rebase on the target branch before submitting a PR.
+- **Dependabot**: Automated dependency updates are managed via Dependabot. Review and merge dependency PRs promptly.
+- **Signed Commits**: All commits **must** be PGP/GPG signed. See [GitHub's signing guide](https://docs.github.com/en/authentication/managing-commit-signature-verification).
+- **DCO Sign-off**: Every commit must carry a `Signed-off-by` line:
+  ```
+  git commit -s -S -m "your commit message"
+  ```
+- **GitHub Actions Policy**: Workflows may only use actions that are (a) owned by `owncloud`, (b) created by GitHub (`actions/*`), or (c) verified in the GitHub Marketplace.
+
+## Translations
+
+Help translate this project on Transifex:
+**<https://explore.transifex.com/owncloud-org/owncloud/>**
+
+Please submit translations via Transifex -- do not open pull requests for translation changes.
+
+## Security
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Report vulnerabilities at **<https://security.owncloud.com>** -- see [SECURITY.md](SECURITY.md).
+
+Bug bounty: [YesWeHack ownCloud Program](https://yeswehack.com/programs/owncloud-bug-bounty-program)
+
+## License
+
+This project is licensed under the [GPL-2.0](LICENSE).
+
+## About the ownCloud OSPO
+
+The [Kiteworks Open Source Program Office](https://kiteworks.com/opensource), operating under
+the [ownCloud](https://owncloud.com) brand, launched on May 5, 2026, to steward the open source
+ecosystem around ownCloud's products. The OSPO ensures transparent governance, license compliance,
+community health, and sustainable collaboration between the open source community and
+[Kiteworks](https://www.kiteworks.com), which acquired ownCloud in 2023.
+
+- **OSPO Home**: <https://kiteworks.com/opensource>
+- **GitHub**: <https://github.com/owncloud>
+- **ownCloud**: <https://owncloud.com>
+
+For questions about the OSPO or licensing, contact ospo@kiteworks.com.
+
+### License Migration to Apache 2.0
+
+The OSPO is driving a strategic relicensing of ownCloud repositories toward the
+[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0), following
+the [Apache Software Foundation's third-party license policy](https://www.apache.org/legal/resolved.html).
+
+Individual repositories will migrate as their audit is completed. The LICENSE file
+in each repo reflects its **current** license status (not the target).
+
+**Current license: GPL-2.0** (Category X per Apache policy -- cannot be included in Apache-2.0 works).
+
+Migration prerequisites for this repository:
+
+- **CLA/DCO coverage**: All past contributors must have signed agreements permitting relicensing
+- **Copyleft dependency audit**: All GPL dependencies must be replaced or isolated
+- **KDE heritage review**: Any code with KDE-era copyrights requires legal analysis
+- **Complete relicensing**: GPL-2.0 is a strong copyleft license; migration requires full relicensing of all files

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+Please report security issues responsibly via:
+**<https://security.owncloud.com>**
+
+You can also report vulnerabilities through our YesWeHack bug bounty program:
+**<https://yeswehack.com/programs/owncloud-bug-bounty-program>**

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,10 @@
+# Support
+
+For support with this project, please use the following channels:
+
+- **Enterprise Support**: <https://owncloud.com/contact-us/>
+- **Community discussions**: https://github.com/orgs/owncloud/discussions
+- **Matrix Chat**: <https://app.element.io/#/room/#owncloud:matrix.org>
+- **Documentation**: <https://doc.owncloud.com>
+
+Please do not use GitHub issues for general support questions.

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,63 @@
+# agents.md -- Password Policy
+
+## Repository Overview
+
+ownCloud Server app for defining and enforcing password policies for user accounts and public link shares. Licensed under GPL-2.0.
+
+## Architecture & Key Paths
+
+- `lib/` -- PHP application logic
+- `js/` -- Frontend JavaScript
+- `css/` -- Stylesheets
+- `templates/` -- Server-side templates
+- `appinfo/` -- ownCloud app metadata
+- `l10n/` -- Translation files
+- `tests/` -- Unit and acceptance tests
+- `Makefile` -- Build and test automation
+- `composer.json` -- PHP dependencies
+
+## Development Conventions
+
+- PHP code follows ownCloud coding standards (phpcs)
+- Static analysis with PHPStan and Phan
+
+## Build & Test Commands
+
+```bash
+make dist                     # Build distribution package
+make test-php-unit            # Run PHP unit tests
+make test-php-style           # Check PHP code style
+make test-php-phpstan         # Run PHPStan
+make test-php-phan            # Run Phan
+make test-acceptance-api      # Run API acceptance tests
+make clean                    # Clean build artifacts
+```
+
+## Important Constraints
+
+- Licensed under GPL-2.0 (copyleft). Apache 2.0 migration planned.
+- Password policies apply to local accounts only, not LDAP-backed accounts.
+- All contributions require a DCO sign-off.
+
+
+## OSPO Policy Constraints
+
+### GitHub Actions
+- **Only** use actions owned by `owncloud`, created by GitHub (`actions/*`), verified on the GitHub Marketplace, or verified by the ownCloud Maintainers.
+- Pin all actions to their full commit SHA (not tags): `uses: actions/checkout@<SHA> # vX.Y.Z`
+- Never introduce actions from unverified third parties.
+
+### Dependency Management
+- Dependabot is configured for automated dependency updates.
+- Review and merge Dependabot PRs as part of regular maintenance.
+- Do not introduce new dependencies without discussion in an issue first.
+
+### Git Workflow
+- **Rebase policy**: Always rebase; never create merge commits. Use `git pull --rebase` and `git rebase` before pushing.
+- **Signed commits**: All commits **must** be PGP/GPG signed (`git commit -S -s`).
+- **DCO sign-off**: Every commit needs a `Signed-off-by` line (`git commit -s`).
+- **Conventional Commits & Squash Merge**: Use the [Conventional Commits](https://www.conventionalcommits.org/) format where the repository enforces it. Many repos use squash merge, where the PR title becomes the commit message on the default branch — apply Conventional Commits format to PR titles as well. A reusable GitHub Actions workflow enforces this.
+
+## Context for AI Agents
+
+Configuration is via the Security section of ownCloud admin settings. The app tracks password history via hashed values, enforces expiration policies, and supports notification via email and web. Policies are defined in the lib/ classes.


### PR DESCRIPTION
## Summary

This PR is part of the **Kiteworks OSPO community health rollout** ([kiteworks.com/opensource](https://kiteworks.com/opensource)), applied to all ~110 public ownCloud repositories starting May 5, 2026.

- **README.md**: Rewritten with v2 OSPO template
  * License-specific OSPO section with Apache 2.0 migration guidance
  * Mandatory Community & Support section: GitHub Discussions, Matrix, docs, enterprise support, OSPO home
  * Contributing workflow: Rebase Early/Often, Dependabot, PGP/GPG-signed commits, DCO sign-off, GitHub Actions policy
  * Security section pointing to security.owncloud.com + YesWeHack bug bounty
  * Translations link to Transifex ([owncloud project](https://explore.transifex.com/owncloud-org/owncloud/))
- **agents.md** *(new)*: AI agent context file with architecture, build commands, OSPO policy constraints
- **CODE_OF_CONDUCT.md** *(new)*: Redirect to <https://owncloud.com/contribute/code-of-conduct/>
- **CONTRIBUTING.md** *(new)*: Redirect to <https://owncloud.com/contribute/>
- **SECURITY.md** *(new)*: Redirect to <https://security.owncloud.com> + YesWeHack
- **SUPPORT.md** *(new)*: Redirect to <https://owncloud.com/contact-us/> and support channels

## Test plan

- [ ] README renders correctly on GitHub (badges, sections, links)
- [ ] All health file links resolve (CODE_OF_CONDUCT, CONTRIBUTING, SECURITY, SUPPORT)
- [ ] agents.md loads correctly in Claude Code and GitHub Copilot
- [ ] License referenced in README matches actual LICENSE file in repo

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) as part of the ownCloud OSPO rollout.
Kiteworks OSPO: <https://kiteworks.com/opensource>