### PR TITLE
chore: bump version to 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Unreleased] - 
 
 
+## [2.3.1] - 2026-07-22
+
+### Changed
+- Maintenance release re-signed with the ownCloud G2 code-signing certificate for the ownCloud 11.0.0 release.
+
+## [2.3.0] - 2026-06-29
+
+### Changed
+- ownCloud 11 compatible release (oc 11.0.0-rc1).
 
 ## [2.2.0] - 2023-07-27
 
@@ -129,7 +138,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Translate save button - #102
 - Change headline and subheadlines - #92
 
-[Unreleased]: https://github.com/owncloud/password_policy/compare/v2.2.0...master
+[Unreleased]: https://github.com/owncloud/password_policy/compare/v2.3.1..master
+[2.3.1]: https://github.com/owncloud/password_policy/compare/v2.3.0..v2.3.1
+[2.3.0]: https://github.com/owncloud/password_policy/compare/v2.2.0..v2.3.0
 [2.2.0]: https://github.com/owncloud/password_policy/compare/v2.1.4...v2.2.0
 [2.1.4]: https://github.com/owncloud/password_policy/compare/v2.1.3...v2.1.4
 [2.1.3]: https://github.com/owncloud/password_policy/compare/v2.1.2...v2.1.3

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,7 +12,7 @@ The definition of certain password rules support administrators in the task of e
 Password history and expiration policies are supplements that allow IT to establish a level of password security that can comply with corporate guidelines of all sorts. The provided tools enable administrators to granularly choose their desired security level. At this point it is important to keep in mind that high levels of security might sacrifice usability and come at the expense of user experience. For this reason it is highly recommended to check [best practices](https://pages.nist.gov/800-63-3/sp800-63b.html) and decide carefully on the hurdles that are put upon users in order to maintain and optimize user adoption and satisfaction.
 
 Administrators find the configuration options in the 'Security' section of the ownCloud administration settings panel. The respective policies are designed for local user accounts created by administrators or via the [Guests](https://marketplace.owncloud.com/apps/guests) extension, not for user accounts imported from LDAP or other user backends as these provide their own mechanisms. For more information and recommendations when deploying policies in an existing ownCloud, please consult the [ownCloud Documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/security/password_policy.html).</description>
-	<version>2.3.0</version>
+	<version>2.3.1</version>
 	<documentation>
 		<admin>https://doc.owncloud.com/server/latest/admin_manual/configuration/server/security/password_policy.html</admin>
 	</documentation>


### PR DESCRIPTION
Patch-level version bump (2.3.0 -> 2.3.1) for the oc11 (11.0.0) complete release. Part of the G2 code-signing re-release.